### PR TITLE
Impedance and Admittance implementation  (with tests)

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1900,7 +1900,7 @@ def s2z(s,z0=50):
     '''
     if npy.isscalar(z0):
         z0 = npy.array(s.shape[0]*[s.shape[1] * [z0]])
-    z = npy.zeros(s.shape)
+    z = npy.zeros(s.shape, dtype='complex')
     I = npy.mat(npy.identity(s.shape[1]))
     try:
         for fidx in xrange(s.shape[0]):
@@ -1959,7 +1959,7 @@ def s2y(s,z0=50):
 
     if npy.isscalar(z0):
         z0 = npy.array(s.shape[0]*[s.shape[1] * [z0]])
-    y = npy.zeros(s.shape)
+    y = npy.zeros(s.shape, dtype='complex')
     I = npy.mat(npy.identity(s.shape[1]))
     try:
         for fidx in xrange(s.shape[0]):
@@ -2055,7 +2055,7 @@ def z2s(z, z0=50):
     '''
     if npy.isscalar(z0):
         z0 = npy.array(z.shape[0]*[z.shape[1] * [z0]])
-    s = npy.zeros(z.shape)
+    s = npy.zeros(z.shape, dtype='complex')
     I = npy.mat(npy.identity(z.shape[1]))
     for fidx in xrange(z.shape[0]):
         sqrty0 = npy.mat(npy.sqrt(npy.diagflat(1.0/z0[fidx])))
@@ -2202,7 +2202,7 @@ def y2s(y, z0=50):
     '''
     if npy.isscalar(z0):
         z0 = npy.array(y.shape[0]*[y.shape[1] * [z0]])
-    s = npy.zeros(y.shape)
+    s = npy.zeros(y.shape, dtype='complex')
     I = npy.mat(npy.identity(s.shape[1]))
     for fidx in xrange(s.shape[0]):
         sqrtz0 = npy.mat(npy.sqrt(npy.diagflat(z0[fidx])))

--- a/skrf/testCases/testNetwork.py
+++ b/skrf/testCases/testNetwork.py
@@ -60,10 +60,10 @@ class NetworkTestCase(unittest.TestCase):
     def test_yz(self):
         tinyfloat = 1e-12
         ntwk = rf.Network()
-        ntwk.z0 = npy.array([28,75])
+        ntwk.z0 = npy.array([28,75+3j])
         ntwk.f = npy.array([1000, 2000])
-        ntwk.s = rf.z2s(npy.array([[[1,5,11],[40,5,3],[16,8,9]],
-                                   [[1,20,3],[14,10,16],[27,18,19]]]))
+        ntwk.s = rf.z2s(npy.array([[[1+1j,5,11],[40,5,3],[16,8,9+8j]],
+                                   [[1,20,3],[14,10,16],[27,18,-19-2j]]]))
         self.assertTrue((abs(rf.y2z(ntwk.y)-ntwk.z) < tinyfloat).all())
         self.assertTrue((abs(rf.y2s(ntwk.y, ntwk.z0)-ntwk.s) < tinyfloat).all())
         self.assertTrue((abs(rf.z2y(ntwk.z)-ntwk.y) < tinyfloat).all())


### PR DESCRIPTION
As far as I could tell, the impedance and admittance parameter support was more of
a place holder.  I've implemented s2y, y2s, s2z, z2s, y2z, and z2y using the matrix
algebra support in numpy.

Note that s2y, y2s, s2z, and z2s require an additional z0 parameter (scalar or 2d
array).

Thanks for all of the work you've put into this very nice module.   -- Trey
