### PR TITLE
add missing args of ax and show_legend for plotting functions

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -735,6 +735,7 @@ class Network(object):
                         # plot the desired attribute vs frequency
                         plot_complex_polar(
                             z = getattr(self,prop_name)[:,m,n],
+ 							show_legend = show_legend, ax = ax,
                             *args, **kwargs)
 
                 if was_interactive:
@@ -826,6 +827,7 @@ class Network(object):
                         # plot the desired attribute vs frequency
                         plot_complex_rectangular(
                             z = getattr(self,prop_name)[:,m,n],
+ 							show_legend = show_legend, ax = ax,
                             *args, **kwargs)
 
                 #if was_interactive:
@@ -936,6 +938,7 @@ class Network(object):
                                     y = getattr(self,attribute)[:,m,n],
                                     x_label = xlabel,
                                     y_label = y_label,
+                                    show_legend = show_legend, ax = ax,
                                     *args, **kwargs)
                             
 


### PR DESCRIPTION
Thanks for your comment. I noticed that passing ax and show_legend will not work for plot_s_XX functions, so add args to fix them. If any defect in this fix, pls tell me.
