### PR TITLE
Fix frequencies always scaled by 1e9

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -367,15 +367,14 @@ class Network(object):
                 name = os.path.splitext(os.path.basename(file))[0]
         
        
+        if self.frequency is not None and f_unit is not None:
+            self.frequency.unit = f_unit
+        
         
         # allow properties to be set through the constructor 
         for attr in PRIMARY_PROPERTIES + ['frequency','z0','f']:
             if kwargs.has_key(attr):
                 self.__setattr__(attr,kwargs[attr])
-        
-        
-        if self.frequency is not None and f_unit is not None:
-            self.frequency.unit = f_unit
         
         
         #self.nports = self.number_of_ports


### PR DESCRIPTION
Fixes a frequency scaling bug when a network is created using property setters. Network(f=[1,2,3],s=[1,2,3],z0=50,f_unit='hz') results in a Network object with a Frequency property spanning 1..3 GHz because the unit was not read in during construction until after the frequency array was already scaled by the default 'ghz' unit scaling.
