### PR TITLE
license confusion in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ LONG_DESCRIPTION = """
 """
 setup(name='scikit-rf',
 	version=VERSION,
-	license='gpl',
+	license='new BSD',
 	description='Object Oriented Microwave Engineering',
 	long_description=LONG_DESCRIPTION,
 	author='Alex Arsenovic',


### PR DESCRIPTION
`LICENSE.txt` contains a BSD license, but `setup.py` still lists GPL.
