### PR TITLE
Smith Chart Options

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -141,7 +141,7 @@ from six.moves import xrange
 import os
 import warnings
 try:
-    import cPickle as pickle
+    import cPickle as pickle    
     from cPickle import UnpicklingError
 except ImportError:
     import pickle as pickle
@@ -163,7 +163,7 @@ from numpy import fft, gradient, reshape, shape,ones
 import unittest # fotr unitest.skip
 
 from . import mathFunctions as mf
-
+    
 from . frequency import Frequency
 
 from . plotting import *#smith, plot_rectangular, plot_smith, plot_complex_polar
@@ -262,7 +262,7 @@ class Network(object):
     ------------
     .. [#] http://en.wikipedia.org/wiki/Two-port_network
     '''
-
+    
 
     global PRIMARY_PROPERTIES
     PRIMARY_PROPERTIES = [ 's','z','y','a']
@@ -404,7 +404,7 @@ class Network(object):
         #self.nports = self.number_of_ports
         ##TODO: remove this as it takes up ~70% cpu time of this init
         self.__generate_plot_functions()
-
+        
 
     ## OPERATORS
     def __pow__(self,other):
@@ -541,7 +541,7 @@ class Network(object):
             result.s = npy.array(other).reshape(-1,self.nports,self.nports) - self.s
 
         return result
-
+    
     def __truediv__(self,other):
         return self.__div__(other)
 
@@ -1225,7 +1225,7 @@ class Network(object):
         # case we dont know how to re-shape the z0 to fxn. to solve this
         # i attempt to do the re-shaping when z0 is accessed, not when
         # it is set. this is what makes this function confusing.
-
+        
         try:
             if len(npy.shape(self._z0)) ==0:
                 try:
@@ -1491,15 +1491,15 @@ class Network(object):
     def group_delay(self):
         '''
         The group delay
-
-        Usually used as a measure of dispersion (or distortion).
-
-        Defined as the derivative of the unwrapped s-parameter phase
-        (in rad) with respect to the frequency.
-
+        
+        Usually used as a measure of dispersion (or distortion). 
+        
+        Defined as the derivative of the unwrapped s-parameter phase 
+        (in rad) with respect to the frequency. 
+        
         -d(self.s_rad_unwrap)/d(self.frequency.f)
-
-
+        
+        
         https://en.wikipedia.org/wiki/Group_delay_and_phase_delay
         '''
 
@@ -1507,7 +1507,7 @@ class Network(object):
         dw = gradient(self.frequency.w)
         dw = dw.reshape([-1,1,1])*ones(shape(self.s)) # make shapes work
         gd = gradient(phi.squeeze(),dw.squeeze()) # squeeze if dims are 1
-
+        
         if self.nports >1:
             gd = gd[0] # return gradient along frequency axis
         else:
@@ -1540,7 +1540,7 @@ class Network(object):
         raise(NotImplementedError)
 
 
-
+    
 
     ## specific ploting functions
     def plot(self, *args, **kw):
@@ -1548,16 +1548,16 @@ class Network(object):
         plot somthing vs frequency
         '''
         return self.frequency.plot(*args, **kw)
-
+    
     def plot_passivity(self, port = None,label_prefix=None,  *args, **kwargs):
         '''
         Plot dB(diag(passivity metric)) vs frequency
-
+        
         Notes
         -------
-        This plot does not completely capture the passivity metric, which
+        This plot does not completely capture the passivity metric, which 
         is a test for `unitary-ness` of the s-matrix. However, it may
-        be  used to display a measure of power disapated in a network.
+        be  used to display a measure of power disapated in a network. 
 
         See Also
         -----------
@@ -1643,7 +1643,7 @@ class Network(object):
                        frequency = self.frequency.copy(),
                        z0 = self.z0,
                        )
-
+        
         ntwk.name = self.name
         return ntwk
 
@@ -2362,15 +2362,15 @@ class Network(object):
         '''
         Time-gate s-parameters
 
-        The gate can be defined with start/stop times, or by the gate
-        width. If `t_stop` is None, the it will default to -`t_start`.
+        The gate can be defined with start/stop times, or by the gate 
+        width. If `t_stop` is None, the it will default to -`t_start`. 
         In this case `t_start`== gate width/2
         See Warning!
 
         Parameters
         ------------
         t_start : number
-            start of time gate, (s). Or, if t_stop==None, then it is
+            start of time gate, (s). Or, if t_stop==None, then it is 
             1/2*gate width.
         t_stop : number
             stop of time gate (s), if None  will be -t_start.
@@ -2388,11 +2388,11 @@ class Network(object):
         '''
         if t_stop is None:
             t_stop = -1*t_start
-
+        
         if t_start >t_stop:
             t_start *=-1
             t_stop *=-1
-
+        
         # find start/stop gate indecies
         t = self.frequency.t
         t_start_idx = find_nearest_index(t,t_start)
@@ -2401,22 +2401,22 @@ class Network(object):
         # create window
         window_width = abs(t_stop_idx-t_start_idx)
         window = signal.get_window(window, window_width)
-
+        
         # create the gate by padding the window with zeros
         padded_window = npy.r_[npy.zeros(t_start_idx),
                                window,
                                npy.zeros(len(t)-t_stop_idx)]
-
+        
         # reshape the gate array so it operates on all s-parameters
         padded_window = padded_window.reshape(-1,1,1) *\
                         npy.ones((len(self), self.nports, self.nports))
-
-
-
+        
+        
+        
         s_time = fft.ifftshift(fft.ifft(self.s, axis=0), axes=0)
         s_time_windowed = self.s_time*padded_window
         s_freq = fft.fft(fft.fftshift(s_time_windowed, axes=0), axis=0)
-
+        
         gated = self.copy()
         gated.s = s_freq
         return gated
@@ -2713,12 +2713,12 @@ class Network(object):
         p : int, number of differential ports
         z0_mm: f x n x n matrix of mixed mode impedances, optional
             if input is None, 100 Ohms differentail and 25 Ohms common mode reference impedance
-
+        
         .. warning::
             This is not fully tested, and should be considered as experimental
         '''
         #XXX: assumes 'proper' order (first differential ports, then single ended ports)
-        if z0_mm is None:
+        if z0_mm is None: 
             z0_mm = self.z0.copy()
             z0_mm[:,0:p] = 100 # differential mode impedance
             z0_mm[:,p:2*p] = 25 # common mode impedance
@@ -2741,7 +2741,7 @@ class Network(object):
         p : int, number of differential ports
         z0_mm: f x n x n matrix of single ended impedances, optional
             if input is None, assumes 50 Ohm reference impedance
-
+        
         .. warning::
             This is not fully tested, and should be considered as experimental
         '''
@@ -2755,35 +2755,35 @@ class Network(object):
         B = Xi_tilde_21 - npy.einsum('...ij,...jk->...ik', self.s, Xi_tilde_11)
         self.s = npy.linalg.solve(A, B)  # (35)
         self.z0 = z0_se
-
+        
     # generalized mixed mode supplement functions
     _T = npy.array([[1, 0 , -1, 0], [0, 0.5, 0, -0.5], [0.5, 0, 0.5, 0], [0, 1, 0, 1]])  # (5)
-
+    
     def _m(self, z0):
         scaling = npy.sqrt(z0.real) / (2 * npy.abs(z0))
         Z = npy.ones((z0.shape[0], 2, 2), dtype=npy.complex128)
         Z[:,0,1] = z0
         Z[:,1,1] = -z0
         return scaling[:,npy.newaxis,npy.newaxis] * Z
-
+    
     def _M(self, j, k, z0_se):  # (14)
         M = npy.zeros((self.f.shape[0],4,4), dtype=npy.complex128)
         M[:,:2,:2] = self._m(z0_se[:,j])
         M[:,2:,2:] = self._m(z0_se[:,k])
         return M
-
+    
     def _M_circle(self, l, p, z0_mm):  # (12)
         M = npy.zeros((self.f.shape[0],4,4), dtype=npy.complex128)
         M[:,:2,:2] = self._m(z0_mm[:,l])    # differential mode impedance of port pair
         M[:,2:,2:] = self._m(z0_mm[:,p+l])  # common mode impedance of port pair
         return M
-
+    
     def _X(self, j, k, l, p, z0_se, z0_mm):  # (15)
         return npy.einsum('...ij,...jk->...ik', self._M_circle(l, p, z0_mm).dot(self._T), npy.linalg.inv(self._M(j,k, z0_se)))  # matrix multiplication elementwise for each frequency
-
+    
     def _P(self, p):  # (27) (28)
         n = self.nports
-
+    
         Pda = npy.zeros((p,2*n), dtype=npy.bool)
         Pdb = npy.zeros((p,2*n), dtype=npy.bool)
         Pca = npy.zeros((p,2*n), dtype=npy.bool)
@@ -2799,24 +2799,24 @@ class Network(object):
                 Pa[l,4*p+2*(l+1)-1-1] = True
                 Pb[l,4*p+2*(l+1)-1] = True
         return npy.concatenate((Pda, Pca, Pa, Pdb, Pcb, Pb))
-
+    
     def _Q(self):  # (29) error corrected
         n = self.nports
-
+    
         Qa = npy.zeros((n,2*n), dtype=npy.bool)
         Qb = npy.zeros((n,2*n), dtype=npy.bool)
         for l in npy.arange(n):
             Qa[l,2*(l+1)-1-1] = True
             Qb[l,2*(l+1)-1] = True
         return npy.concatenate((Qa, Qb))
-
+    
     def _Xi(self, p, z0_se, z0_mm):  # (24)
         n = self.nports
         Xi = npy.ones(self.f.shape[0])[:,npy.newaxis,npy.newaxis] * npy.eye(2*n, dtype=npy.complex128)
         for l in npy.arange(p):
             Xi[:,4*l:4*l+4,4*l:4*l+4] = self._X(l*2, l*2+1, l, p, z0_se, z0_mm)
         return Xi
-
+    
     def _Xi_tilde(self, p, z0_se, z0_mm):  # (31)
         n = self.nports
         P = npy.ones(self.f.shape[0])[:,npy.newaxis,npy.newaxis] * self._P(p)
@@ -3046,17 +3046,17 @@ def innerconnect(ntwkA, k, l, num=1):
     >>> ntwkC = rf.innerconnect(ntwkA, 0,1)
 
     '''
-
+    
     if (k+num-1> ntwkA.nports-1):
         raise IndexError('Port `k` out of range')
     if (l+num-1> ntwkA.nports-1):
         raise IndexError('Port `l` out of range')
-
-
+        
+        
     # create output Network, from copy of input
     ntwkC = ntwkA.copy()
 
-
+    
     if not (ntwkA.z0[:,k] == ntwkA.z0[:,l]).all():
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
@@ -3110,19 +3110,19 @@ def cascade(ntwkA,ntwkB):
 def cascade_list(l):
     '''
     cascade a list of 2-port networks
-
+    
     all networks must have same frequency
-
+    
     Parameters
     --------------
     l : list-like
-        (ordered) list of networks
-
+        (ordered) list of networks 
+    
     Returns
     ----------
     out : 2-port Network
         the results of casacading all networks in the list `l`
-
+        
     '''
     return reduce(cascade, l)
 
@@ -3947,7 +3947,7 @@ def z2a(z):
     '''
     Converts impedance parameters to abcd  parameters [#]_ .
 
-
+   
     Parameters
     -----------
     z : :class:`numpy.ndarray` (shape fx2x2)
@@ -3995,12 +3995,12 @@ def s2a(s,z0):
     '''
     Converts scattering parameters to abcd  parameters [#]_ .
 
-
+   
     Parameters
     -----------
     s : :class:`numpy.ndarray` (shape fx2x2)
         impedance parameter matrix
-
+        
     z0: number or, :class:`numpy.ndarray` (shape fx2)
         port impedance
 
@@ -4010,7 +4010,7 @@ def s2a(s,z0):
         scattering transfer parameters (aka wave cascading matrix)
     '''
     return z2a(s2z(s,z0))
-
+    
 def y2s(y, z0=50):
     '''
     convert admittance parameters [#]_ to scattering parameters [#]_
@@ -4300,8 +4300,8 @@ def passivity(s):
     '''
     Passivity metric for a multi-port network.
 
-    A metric which is proportional to the amount of power lost in a
-    multiport network, depending on the excitation port. Specifically,
+    A metric which is proportional to the amount of power lost in a 
+    multiport network, depending on the excitation port. Specifically, 
     this returns a matrix who's diagonals are equal to the total
     power received at all ports, normalized to the power at a single
     excitement port.
@@ -4323,12 +4323,12 @@ def passivity(s):
 
     where :math:`H` is conjugate transpose of S, and :math:`\\cdot`
     is dot product.
-
+    
     Notes
     ---------
-    The total amount of power disipated in a network depends on the
-    port matches. For example, given a matched attenuator, this metric
-    will yield the attenuation value. However, if the attenuator is
+    The total amount of power disipated in a network depends on the 
+    port matches. For example, given a matched attenuator, this metric 
+    will yield the attenuation value. However, if the attenuator is 
     cascaded with a mismatch, the power disipated will not be equivalent
     to the attenuator value, nor equal for each excitation port.
 
@@ -4749,7 +4749,7 @@ def two_port_reflect(ntwk1, ntwk2=None):
     ntwk1 : one-port Network object
             network seen from port 1
     ntwk2 : one-port Network object, or None
-            network seen from port 2. if None then will use ntwk1.
+            network seen from port 2. if None then will use ntwk1. 
 
     Returns
     -------

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -141,7 +141,7 @@ from six.moves import xrange
 import os
 import warnings
 try:
-    import cPickle as pickle    
+    import cPickle as pickle
     from cPickle import UnpicklingError
 except ImportError:
     import pickle as pickle
@@ -163,7 +163,7 @@ from numpy import fft, gradient, reshape, shape,ones
 import unittest # fotr unitest.skip
 
 from . import mathFunctions as mf
-    
+
 from . frequency import Frequency
 
 from . plotting import *#smith, plot_rectangular, plot_smith, plot_complex_polar
@@ -262,7 +262,7 @@ class Network(object):
     ------------
     .. [#] http://en.wikipedia.org/wiki/Two-port_network
     '''
-    
+
 
     global PRIMARY_PROPERTIES
     PRIMARY_PROPERTIES = [ 's','z','y','a']
@@ -404,7 +404,7 @@ class Network(object):
         #self.nports = self.number_of_ports
         ##TODO: remove this as it takes up ~70% cpu time of this init
         self.__generate_plot_functions()
-        
+
 
     ## OPERATORS
     def __pow__(self,other):
@@ -541,7 +541,7 @@ class Network(object):
             result.s = npy.array(other).reshape(-1,self.nports,self.nports) - self.s
 
         return result
-    
+
     def __truediv__(self,other):
         return self.__div__(other)
 
@@ -1225,7 +1225,7 @@ class Network(object):
         # case we dont know how to re-shape the z0 to fxn. to solve this
         # i attempt to do the re-shaping when z0 is accessed, not when
         # it is set. this is what makes this function confusing.
-        
+
         try:
             if len(npy.shape(self._z0)) ==0:
                 try:
@@ -1491,15 +1491,15 @@ class Network(object):
     def group_delay(self):
         '''
         The group delay
-        
-        Usually used as a measure of dispersion (or distortion). 
-        
-        Defined as the derivative of the unwrapped s-parameter phase 
-        (in rad) with respect to the frequency. 
-        
+
+        Usually used as a measure of dispersion (or distortion).
+
+        Defined as the derivative of the unwrapped s-parameter phase
+        (in rad) with respect to the frequency.
+
         -d(self.s_rad_unwrap)/d(self.frequency.f)
-        
-        
+
+
         https://en.wikipedia.org/wiki/Group_delay_and_phase_delay
         '''
 
@@ -1507,7 +1507,7 @@ class Network(object):
         dw = gradient(self.frequency.w)
         dw = dw.reshape([-1,1,1])*ones(shape(self.s)) # make shapes work
         gd = gradient(phi.squeeze(),dw.squeeze()) # squeeze if dims are 1
-        
+
         if self.nports >1:
             gd = gd[0] # return gradient along frequency axis
         else:
@@ -1540,7 +1540,7 @@ class Network(object):
         raise(NotImplementedError)
 
 
-    
+
 
     ## specific ploting functions
     def plot(self, *args, **kw):
@@ -1548,16 +1548,16 @@ class Network(object):
         plot somthing vs frequency
         '''
         return self.frequency.plot(*args, **kw)
-    
+
     def plot_passivity(self, port = None,label_prefix=None,  *args, **kwargs):
         '''
         Plot dB(diag(passivity metric)) vs frequency
-        
+
         Notes
         -------
-        This plot does not completely capture the passivity metric, which 
+        This plot does not completely capture the passivity metric, which
         is a test for `unitary-ness` of the s-matrix. However, it may
-        be  used to display a measure of power disapated in a network. 
+        be  used to display a measure of power disapated in a network.
 
         See Also
         -----------
@@ -1643,7 +1643,7 @@ class Network(object):
                        frequency = self.frequency.copy(),
                        z0 = self.z0,
                        )
-        
+
         ntwk.name = self.name
         return ntwk
 
@@ -2362,15 +2362,15 @@ class Network(object):
         '''
         Time-gate s-parameters
 
-        The gate can be defined with start/stop times, or by the gate 
-        width. If `t_stop` is None, the it will default to -`t_start`. 
+        The gate can be defined with start/stop times, or by the gate
+        width. If `t_stop` is None, the it will default to -`t_start`.
         In this case `t_start`== gate width/2
         See Warning!
 
         Parameters
         ------------
         t_start : number
-            start of time gate, (s). Or, if t_stop==None, then it is 
+            start of time gate, (s). Or, if t_stop==None, then it is
             1/2*gate width.
         t_stop : number
             stop of time gate (s), if None  will be -t_start.
@@ -2388,11 +2388,11 @@ class Network(object):
         '''
         if t_stop is None:
             t_stop = -1*t_start
-        
+
         if t_start >t_stop:
             t_start *=-1
             t_stop *=-1
-        
+
         # find start/stop gate indecies
         t = self.frequency.t
         t_start_idx = find_nearest_index(t,t_start)
@@ -2401,29 +2401,29 @@ class Network(object):
         # create window
         window_width = abs(t_stop_idx-t_start_idx)
         window = signal.get_window(window, window_width)
-        
+
         # create the gate by padding the window with zeros
         padded_window = npy.r_[npy.zeros(t_start_idx),
                                window,
                                npy.zeros(len(t)-t_stop_idx)]
-        
+
         # reshape the gate array so it operates on all s-parameters
         padded_window = padded_window.reshape(-1,1,1) *\
                         npy.ones((len(self), self.nports, self.nports))
-        
-        
-        
+
+
+
         s_time = fft.ifftshift(fft.ifft(self.s, axis=0), axes=0)
         s_time_windowed = self.s_time*padded_window
         s_freq = fft.fft(fft.fftshift(s_time_windowed, axes=0), axis=0)
-        
+
         gated = self.copy()
         gated.s = s_freq
         return gated
 
     # plotting
     def plot_s_smith(self,m=None, n=None,r=1,ax = None, show_legend=True,\
-            chart_type='z', draw_labels=False, label_axes=False, *args,**kwargs):
+            chart_type='z', draw_labels=False, label_axes=False, draw_vswr=None, *args,**kwargs):
         '''
         plots the scattering parameter on a smith chart
 
@@ -2450,6 +2450,8 @@ class Network(object):
             Label axis with titles `Real` and `Imaginary`
         border : Boolean
             draw rectangular border around image with ticks
+        draw_vswr : list of numbers, Boolean or None
+            draw VSWR circles. If True, default values are used.
 
         \*args : arguments, optional
                 passed to the matplotlib.plot command
@@ -2510,7 +2512,7 @@ class Network(object):
 
                 # plot the desired attribute vs frequency
                 if len (ax.patches) == 0:
-                    smith(ax=ax, smithR = r, chart_type=chart_type, draw_labels=draw_labels)
+                    smith(ax=ax, smithR = r, chart_type=chart_type, draw_labels=draw_labels, draw_vswr=draw_vswr)
                 ax.plot(self.s[:,m,n].real,  self.s[:,m,n].imag, *args,**kwargs)
 
         #draw legend
@@ -2711,12 +2713,12 @@ class Network(object):
         p : int, number of differential ports
         z0_mm: f x n x n matrix of mixed mode impedances, optional
             if input is None, 100 Ohms differentail and 25 Ohms common mode reference impedance
-        
+
         .. warning::
             This is not fully tested, and should be considered as experimental
         '''
         #XXX: assumes 'proper' order (first differential ports, then single ended ports)
-        if z0_mm is None: 
+        if z0_mm is None:
             z0_mm = self.z0.copy()
             z0_mm[:,0:p] = 100 # differential mode impedance
             z0_mm[:,p:2*p] = 25 # common mode impedance
@@ -2739,7 +2741,7 @@ class Network(object):
         p : int, number of differential ports
         z0_mm: f x n x n matrix of single ended impedances, optional
             if input is None, assumes 50 Ohm reference impedance
-        
+
         .. warning::
             This is not fully tested, and should be considered as experimental
         '''
@@ -2753,35 +2755,35 @@ class Network(object):
         B = Xi_tilde_21 - npy.einsum('...ij,...jk->...ik', self.s, Xi_tilde_11)
         self.s = npy.linalg.solve(A, B)  # (35)
         self.z0 = z0_se
-        
+
     # generalized mixed mode supplement functions
     _T = npy.array([[1, 0 , -1, 0], [0, 0.5, 0, -0.5], [0.5, 0, 0.5, 0], [0, 1, 0, 1]])  # (5)
-    
+
     def _m(self, z0):
         scaling = npy.sqrt(z0.real) / (2 * npy.abs(z0))
         Z = npy.ones((z0.shape[0], 2, 2), dtype=npy.complex128)
         Z[:,0,1] = z0
         Z[:,1,1] = -z0
         return scaling[:,npy.newaxis,npy.newaxis] * Z
-    
+
     def _M(self, j, k, z0_se):  # (14)
         M = npy.zeros((self.f.shape[0],4,4), dtype=npy.complex128)
         M[:,:2,:2] = self._m(z0_se[:,j])
         M[:,2:,2:] = self._m(z0_se[:,k])
         return M
-    
+
     def _M_circle(self, l, p, z0_mm):  # (12)
         M = npy.zeros((self.f.shape[0],4,4), dtype=npy.complex128)
         M[:,:2,:2] = self._m(z0_mm[:,l])    # differential mode impedance of port pair
         M[:,2:,2:] = self._m(z0_mm[:,p+l])  # common mode impedance of port pair
         return M
-    
+
     def _X(self, j, k, l, p, z0_se, z0_mm):  # (15)
         return npy.einsum('...ij,...jk->...ik', self._M_circle(l, p, z0_mm).dot(self._T), npy.linalg.inv(self._M(j,k, z0_se)))  # matrix multiplication elementwise for each frequency
-    
+
     def _P(self, p):  # (27) (28)
         n = self.nports
-    
+
         Pda = npy.zeros((p,2*n), dtype=npy.bool)
         Pdb = npy.zeros((p,2*n), dtype=npy.bool)
         Pca = npy.zeros((p,2*n), dtype=npy.bool)
@@ -2797,24 +2799,24 @@ class Network(object):
                 Pa[l,4*p+2*(l+1)-1-1] = True
                 Pb[l,4*p+2*(l+1)-1] = True
         return npy.concatenate((Pda, Pca, Pa, Pdb, Pcb, Pb))
-    
+
     def _Q(self):  # (29) error corrected
         n = self.nports
-    
+
         Qa = npy.zeros((n,2*n), dtype=npy.bool)
         Qb = npy.zeros((n,2*n), dtype=npy.bool)
         for l in npy.arange(n):
             Qa[l,2*(l+1)-1-1] = True
             Qb[l,2*(l+1)-1] = True
         return npy.concatenate((Qa, Qb))
-    
+
     def _Xi(self, p, z0_se, z0_mm):  # (24)
         n = self.nports
         Xi = npy.ones(self.f.shape[0])[:,npy.newaxis,npy.newaxis] * npy.eye(2*n, dtype=npy.complex128)
         for l in npy.arange(p):
             Xi[:,4*l:4*l+4,4*l:4*l+4] = self._X(l*2, l*2+1, l, p, z0_se, z0_mm)
         return Xi
-    
+
     def _Xi_tilde(self, p, z0_se, z0_mm):  # (31)
         n = self.nports
         P = npy.ones(self.f.shape[0])[:,npy.newaxis,npy.newaxis] * self._P(p)
@@ -3044,17 +3046,17 @@ def innerconnect(ntwkA, k, l, num=1):
     >>> ntwkC = rf.innerconnect(ntwkA, 0,1)
 
     '''
-    
+
     if (k+num-1> ntwkA.nports-1):
         raise IndexError('Port `k` out of range')
     if (l+num-1> ntwkA.nports-1):
         raise IndexError('Port `l` out of range')
-        
-        
+
+
     # create output Network, from copy of input
     ntwkC = ntwkA.copy()
 
-    
+
     if not (ntwkA.z0[:,k] == ntwkA.z0[:,l]).all():
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
@@ -3108,19 +3110,19 @@ def cascade(ntwkA,ntwkB):
 def cascade_list(l):
     '''
     cascade a list of 2-port networks
-    
+
     all networks must have same frequency
-    
+
     Parameters
     --------------
     l : list-like
-        (ordered) list of networks 
-    
+        (ordered) list of networks
+
     Returns
     ----------
     out : 2-port Network
         the results of casacading all networks in the list `l`
-        
+
     '''
     return reduce(cascade, l)
 
@@ -3945,7 +3947,7 @@ def z2a(z):
     '''
     Converts impedance parameters to abcd  parameters [#]_ .
 
-   
+
     Parameters
     -----------
     z : :class:`numpy.ndarray` (shape fx2x2)
@@ -3993,12 +3995,12 @@ def s2a(s,z0):
     '''
     Converts scattering parameters to abcd  parameters [#]_ .
 
-   
+
     Parameters
     -----------
     s : :class:`numpy.ndarray` (shape fx2x2)
         impedance parameter matrix
-        
+
     z0: number or, :class:`numpy.ndarray` (shape fx2)
         port impedance
 
@@ -4008,7 +4010,7 @@ def s2a(s,z0):
         scattering transfer parameters (aka wave cascading matrix)
     '''
     return z2a(s2z(s,z0))
-    
+
 def y2s(y, z0=50):
     '''
     convert admittance parameters [#]_ to scattering parameters [#]_
@@ -4298,8 +4300,8 @@ def passivity(s):
     '''
     Passivity metric for a multi-port network.
 
-    A metric which is proportional to the amount of power lost in a 
-    multiport network, depending on the excitation port. Specifically, 
+    A metric which is proportional to the amount of power lost in a
+    multiport network, depending on the excitation port. Specifically,
     this returns a matrix who's diagonals are equal to the total
     power received at all ports, normalized to the power at a single
     excitement port.
@@ -4321,12 +4323,12 @@ def passivity(s):
 
     where :math:`H` is conjugate transpose of S, and :math:`\\cdot`
     is dot product.
-    
+
     Notes
     ---------
-    The total amount of power disipated in a network depends on the 
-    port matches. For example, given a matched attenuator, this metric 
-    will yield the attenuation value. However, if the attenuator is 
+    The total amount of power disipated in a network depends on the
+    port matches. For example, given a matched attenuator, this metric
+    will yield the attenuation value. However, if the attenuator is
     cascaded with a mismatch, the power disipated will not be equivalent
     to the attenuator value, nor equal for each excitation port.
 
@@ -4747,7 +4749,7 @@ def two_port_reflect(ntwk1, ntwk2=None):
     ntwk1 : one-port Network object
             network seen from port 1
     ntwk2 : one-port Network object, or None
-            network seen from port 2. if None then will use ntwk1. 
+            network seen from port 2. if None then will use ntwk1.
 
     Returns
     -------

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -53,10 +53,12 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
     -----------
     smithR : number
             radius of smith chart
-    chart_type : ['z','y']
+    chart_type : ['z','y','zy', 'yz']
             Contour type. Possible values are
              * *'z'* : lines of constant impedance
              * *'y'* : lines of constant admittance
+             * *'zy'* : lines of constant impedance stronger than admittance
+             * *'yz'* : lines of constant admittance stronger than impedance
     draw_labels : Boolean
              annotate real and imaginary parts of impedance on the
              chart (only if smithR=1)
@@ -112,34 +114,50 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
         rMax = (1.+smithR)/(1.-smithR)
         rLightList = plb.hstack([ plb.linspace(0,rMax,11)  , rLightList ])
 
-    if chart_type is 'y':
+    if chart_type.startswith('y'):
         y_flip_sign = -1
     else:
         y_flip_sign = 1
+
+    # draw impedance and
+    both_charts = chart_type in ('zy', 'yz')
+
+
     # loops through Verylight, Light and Heavy lists and draws circles using patches
     # for analysis of this see R.M. Weikles Microwave II notes (from uva)
 
+    superLightColor = dict(ec='whitesmoke', fc='none')
+    veryLightColor = dict(ec='lightgrey', fc='none')
+    lightColor = dict(ec='grey', fc='none')
+    heavyColor = dict(ec='black', fc='none')
+
+    # vswr circules verylight
     for vswr in vswrVeryLightList:
         radius = (vswr-1.0) / (vswr+1.0)
-        contour.append( Circle((0, 0), radius, ec='lightgrey',fc='none'))
+        contour.append( Circle((0, 0), radius, **veryLightColor))
 
+    # impedance/admittance circles
     for r in rLightList:
-        center = (r/(1.+r)*y_flip_sign,0 )
+        center = (r/(1.+r)*y_flip_sign, 0)
         radius = 1./(1+r)
-        contour.append( Circle( center, radius, ec='grey',fc = 'none'))
+        if both_charts:
+            contour.insert(0, Circle( (-center[0], center[1]), radius, **superLightColor))
+        contour.append( Circle( center, radius, **lightColor))
     for x in xLightList:
-        center = (1*y_flip_sign,1./x)
+        center = (1*y_flip_sign, 1./x)
         radius = 1./x
-        contour.append( Circle( center, radius, ec='grey',fc = 'none'))
+        if both_charts:
+            contour.insert(0, Circle( (-center[0], center[1]), radius, **superLightColor))
+        contour.append( Circle( center, radius, **lightColor))
 
     for r in rHeavyList:
-        center = (r/(1.+r)*y_flip_sign,0 )
+        center = (r/(1.+r)*y_flip_sign, 0)
         radius = 1./(1+r)
-        contour.append( Circle( center, radius, ec= 'black', fc = 'none'))
+        contour.append( Circle( center, radius, **heavyColor))
     for x in xHeavyList:
         center = (1*y_flip_sign,1./x)
         radius = 1./x
-        contour.append( Circle( center, radius, ec='black',fc = 'none'))
+        contour.append( Circle( center, radius, **heavyColor))
 
     # clipping circle
     clipc = Circle( [0,0], smithR, ec='k',fc='None',visible=True)

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -19,15 +19,15 @@ Plots and Charts
     plot_smith
     plot_rectangular
     plot_polar
-    plot_complex_rectangular 
+    plot_complex_rectangular
     plot_complex_polar
-    
+
 Misc Functions
 -----------------
 
 .. autosummary::
     :toctree: generated/
-    
+
     save_all_figs
     add_markers_to_lines
     legend_off
@@ -44,8 +44,8 @@ from matplotlib import rcParams
 
 
 
-def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False, 
-    ax=None, ref_imm = 1.0):
+def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
+    ax=None, ref_imm = 1.0, draw_vswr=None):
     '''
     plots the smith chart of a given radius
 
@@ -58,19 +58,21 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
              * *'z'* : lines of constant impedance
              * *'y'* : lines of constant admittance
     draw_labels : Boolean
-             annotate real and imaginary parts of impedance on the 
+             annotate real and imaginary parts of impedance on the
              chart (only if smithR=1)
     border : Boolean
-        draw a rectangular border with axis ticks, around the perimeter 
+        draw a rectangular border with axis ticks, around the perimeter
         of the figure. Not used if draw_labels = True
-    
+
     ax : matplotlib.axes object
             existing axes to draw smith chart on
-    
+
     ref_imm : number
             Reference immittance for center of Smith chart. Only changes
             labels, if printed.
 
+    draw_vswr : list of numbers, Boolean or None
+        draw VSWR circles. If True, default values are used.
 
     '''
     ##TODO: fix this function so it doesnt suck
@@ -96,6 +98,15 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
         rLightList = plb.array( [ 0.2, 0.5, 1.0, 2.0, 5.0 ] )
         xLightList = plb.array( [ 0.2, 0.5, 1.0, 2.0 , 5.0, -0.2, -0.5, -1.0, -2.0, -5.0 ] )
 
+    #
+    if isinstance(draw_vswr, (tuple,list)):
+        vswrVeryLightList = draw_vswr
+    elif draw_vswr is True:
+        # use the default I like
+        vswrVeryLightList = [1.5, 2.0, 3.0, 5.0]
+    else:
+        vswrVeryLightList = []
+
     # cheap way to make a ok-looking smith chart at larger than 1 radii
     if smithR > 1:
         rMax = (1.+smithR)/(1.-smithR)
@@ -105,8 +116,13 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
         y_flip_sign = -1
     else:
         y_flip_sign = 1
-    # loops through Light and Heavy lists and draws circles using patches
+    # loops through Verylight, Light and Heavy lists and draws circles using patches
     # for analysis of this see R.M. Weikles Microwave II notes (from uva)
+
+    for vswr in vswrVeryLightList:
+        radius = (vswr-1.0) / (vswr+1.0)
+        contour.append( Circle((0, 0), radius, ec='lightgrey',fc='none'))
+
     for r in rLightList:
         center = (r/(1.+r)*y_flip_sign,0 )
         radius = 1./(1+r)
@@ -136,15 +152,15 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
     # Set axis limits by plotting white points so zooming works properly
     ax1.plot(smithR*npy.array([-1.1, 1.1]), smithR*npy.array([-1.1, 1.1]), 'w.', markersize = 0)
     ax1.axis('image') # Combination of 'equal' and 'tight'
-    
-    
-    if not border: 
+
+
+    if not border:
         ax1.yaxis.set_ticks([])
         ax1.xaxis.set_ticks([])
         for loc, spine in ax1.spines.items():
             spine.set_color('none')
-        
-    
+
+
     if draw_labels:
         #Clear axis
         ax1.yaxis.set_ticks([])
@@ -181,7 +197,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                 S *= smithR * radialScaleFactor
                 rhox = S.real
                 rhoy = S.imag * y_flip_sign
-                
+
                 # Choose alignment anchor point based on label's value
                 if ((value == 1.0) or (value == -1.0)):
                     halignstyle = "center"
@@ -189,7 +205,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                     halignstyle = "right"
                 else:
                     halignstyle = "left"
-                
+
                 if (rhoy < 0):
                     valignstyle = "top"
                 else:
@@ -203,6 +219,15 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                          ha = "right", va = "center")
             ax1.annotate('$\infty$', xy=(radialScaleFactor, 0), xytext=(radialScaleFactor, 0),
                          ha = "left", va = "center")
+
+            # annotate vswr circles
+            for vswr in vswrVeryLightList:
+                rhoy = (vswr-1.0) / (vswr+1.0)
+
+                ax1.annotate(str(vswr), xy=(0, rhoy*smithR),
+                    xytext=(0, rhoy*smithR), ha = "center", va = "bottom",
+                    color='grey', size='smaller')
+
 
     # loop though contours and draw them on the given axes
     for currentContour in contour:
@@ -229,7 +254,7 @@ def plot_rectangular(x, y, x_label=None, y_label=None, title=None,
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
-    
+
     '''
     if ax is None:
         ax = plb.gca()
@@ -253,10 +278,10 @@ def plot_rectangular(x, y, x_label=None, y_label=None, title=None,
     if axis is not None:
         ax.autoscale(True, 'x', True)
         ax.autoscale(True, 'y', False)
-        
+
     if plb.isinteractive():
         plb.draw()
-    
+
     return my_plot
 
 def plot_polar(theta, r, x_label=None, y_label=None, title=None,
@@ -269,7 +294,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
     theta : array-like
         data to plot
     r : array-like
-        
+
     x_label : string
         x-axis label
     y_label : string
@@ -281,7 +306,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
-    
+
     See Also
     ----------
     plot_rectangular : plots rectangular data
@@ -312,7 +337,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
 
     if axis_equal:
         ax.axis('equal')
-        
+
     if plb.isinteractive():
         plb.draw()
 
@@ -345,7 +370,7 @@ def plot_complex_rectangular(z, x_label='Real', y_label='Imag',
     plot_polar : plot polar data
     plot_complex_polar : plot complex data on polar plane
     plot_smith : plot complex data on smith chart
-    
+
     '''
     x = npy.real(z)
     y = npy.imag(z)
@@ -391,7 +416,7 @@ def plot_complex_polar(z, x_label=None, y_label=None,
 
 def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
     y_label='Imaginary', title='Complex Plane', show_legend=True,
-    axis='equal', ax=None, force_chart = False, *args, **kwargs):
+    axis='equal', ax=None, force_chart = False, draw_vswr=None, *args, **kwargs):
     '''
     plot complex data on smith chart
 
@@ -416,7 +441,7 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
     axis_equal: Boolean
         sets axis to be equal increments (calls axis('equal'))
     force_chart : Boolean
-        forces the re-drawing of smith chart 
+        forces the re-drawing of smith chart
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
@@ -429,14 +454,14 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
     plot_complex_polar : plot complex data on polar plane
     plot_smith : plot complex data on smith chart
     '''
-    
+
     if ax is None:
         ax = plb.gca()
 
     # test if smith chart is already drawn
     if not force_chart:
         if len(ax.patches) == 0:
-            smith(ax=ax, smithR = smith_r, chart_type=chart_type)
+            smith(ax=ax, smithR = smith_r, chart_type=chart_type, draw_vswr=draw_vswr)
 
     plot_complex_rectangular(s, x_label=x_label, y_label=y_label,
         title=title, show_legend=show_legend, axis=axis,
@@ -447,15 +472,15 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
         plb.draw()
 
 
-def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,  
+def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
                    add_titles=True, keep_it_tight=True,  subplot_kw={}, *args, **kw):
     '''
     Plot all networks parameters individually on subplots
-    
+
     Parameters
     --------------
-    
-    
+
+
     '''
     if newfig:
         f,axs= plb.subplots(ntwk.nports,ntwk.nports,
@@ -463,7 +488,7 @@ def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
                                       size_per_port*ntwk.nports ),
                                       **subplot_kw)
     else:
-        f = plb.gcf() 
+        f = plb.gcf()
         axs = npy.array(f.get_axes())
 
     for ports,ax in zip(ntwk.port_tuples, axs.flatten()):
@@ -478,23 +503,23 @@ def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
 def shade_bands(edges, y_range=None,cmap='prism', **kwargs):
     '''
     Shades frequency bands.
-    
-    when plotting data over a set of frequency bands it is nice to 
+
+    when plotting data over a set of frequency bands it is nice to
     have each band visually separated from the other. The kwarg `alpha`
     is useful.
-    
-    Parameters 
+
+    Parameters
     --------------
     edges : array-like
         x-values separating regions of a given shade
-    y_range : tuple 
-        y-values to shade in 
+    y_range : tuple
+        y-values to shade in
     cmap : str
         see matplotlib.cm  or matplotlib.colormaps for acceptable values
     \*\* : key word arguments
         passed to `matplotlib.fill_between`
-        
-    Examples 
+
+    Examples
     -----------
     >>> rf.shade_bands([325,500,750,1100], alpha=.2)
     '''
@@ -503,8 +528,8 @@ def shade_bands(edges, y_range=None,cmap='prism', **kwargs):
     axis = plb.axis()
     for k in range(len(edges)-1):
         plb.fill_between(
-            [edges[k],edges[k+1]], 
-            y_range[0], y_range[1], 
+            [edges[k],edges[k+1]],
+            y_range[0], y_range[1],
             color = cmap(1.0*k/len(edges)),
             **kwargs)
     plb.axis(axis)
@@ -545,13 +570,13 @@ saf = save_all_figs
 
 def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10):
     '''
-    adds markers to existing lings on a plot 
-    
-    this is convinient if you have already have a plot made, but then 
-    need to add markers afterwards, so that it can be interpreted in 
-    black and white. The markevery argument makes the markers less 
-    frequent than the data, which is generally what you want. 
-    
+    adds markers to existing lings on a plot
+
+    this is convinient if you have already have a plot made, but then
+    need to add markers afterwards, so that it can be interpreted in
+    black and white. The markevery argument makes the markers less
+    frequent than the data, which is generally what you want.
+
     Parameters
     -----------
     ax : matplotlib.Axes
@@ -560,7 +585,7 @@ def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10
         see matplotlib.plot help for possible marker characters
     markevery : int
         markevery number of points with a marker.
-    
+
     '''
     if ax is None:
         ax=plb.gca()
@@ -572,14 +597,14 @@ def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10
 
 def legend_off(ax=None):
     '''
-    turn off the legend for a given axes. 
-    
+    turn off the legend for a given axes.
+
     if no axes is given then it will use current axes.
-    
+
     Parameters
     -----------
     ax : matplotlib.Axes object
-        axes to operate on 
+        axes to operate on
     '''
     if ax is None:
         plb.gca().legend_.set_visible(0)
@@ -589,41 +614,41 @@ def legend_off(ax=None):
 def scrape_legend(n=None, ax=None):
     '''
     scrapes a legend with redundant labels
-    
-    Given a legend of m entries of n groups, this will remove all but 
+
+    Given a legend of m entries of n groups, this will remove all but
     every m/nth entry. This is used when you plot many lines representing
     the same thing, and only want one label entry in the legend  for the
     whole ensemble of lines
-    
+
     '''
-    
+
     if ax is None:
         ax = plb.gca()
-    
+
     handles, labels = ax.get_legend_handles_labels()
-    
+
     if n is None:
         n =len ( set(labels))
-    
+
     if n>len(handles):
         raise ValueError('number of entries is too large')
-    
+
     k_list = [int(k) for k in npy.linspace(0,len(handles)-1,n)]
     ax.legend([handles[k] for k in k_list], [labels[k] for k in k_list])
 
 def func_on_all_figs(func, *args, **kwargs):
     '''
-    runs a function after making all open figures current. 
-    
-    useful if you need to change the properties of many open figures 
-    at once, like turn off the grid. 
-    
+    runs a function after making all open figures current.
+
+    useful if you need to change the properties of many open figures
+    at once, like turn off the grid.
+
     Parameters
     ----------
     func : function
         function to call
     \*args, \*\*kwargs : pased to func
-    
+
     Examples
     ----------
     >>> rf.func_on_all_figs(grid,alpha=.3)
@@ -639,9 +664,9 @@ foaf = func_on_all_figs
 
 def plot_vector(a, off=0+0j, *args, **kwargs):
     '''
-    plot a 2d vector 
+    plot a 2d vector
     '''
-    return quiver(off.real,off.imag,a.real,a.imag,scale_units ='xy', 
+    return quiver(off.real,off.imag,a.real,a.imag,scale_units ='xy',
            angles='xy',scale=1, *args, **kwargs)
 
 

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -19,15 +19,15 @@ Plots and Charts
     plot_smith
     plot_rectangular
     plot_polar
-    plot_complex_rectangular
+    plot_complex_rectangular 
     plot_complex_polar
-
+    
 Misc Functions
 -----------------
 
 .. autosummary::
     :toctree: generated/
-
+    
     save_all_figs
     add_markers_to_lines
     legend_off
@@ -60,15 +60,15 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
              * *'zy'* : lines of constant impedance stronger than admittance
              * *'yz'* : lines of constant admittance stronger than impedance
     draw_labels : Boolean
-             annotate real and imaginary parts of impedance on the
+             annotate real and imaginary parts of impedance on the 
              chart (only if smithR=1)
     border : Boolean
-        draw a rectangular border with axis ticks, around the perimeter
+        draw a rectangular border with axis ticks, around the perimeter 
         of the figure. Not used if draw_labels = True
-
+    
     ax : matplotlib.axes object
             existing axes to draw smith chart on
-
+    
     ref_imm : number
             Reference immittance for center of Smith chart. Only changes
             labels, if printed.
@@ -100,7 +100,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
         rLightList = plb.array( [ 0.2, 0.5, 1.0, 2.0, 5.0 ] )
         xLightList = plb.array( [ 0.2, 0.5, 1.0, 2.0 , 5.0, -0.2, -0.5, -1.0, -2.0, -5.0 ] )
 
-    #
+    # vswr lines
     if isinstance(draw_vswr, (tuple,list)):
         vswrVeryLightList = draw_vswr
     elif draw_vswr is True:
@@ -119,7 +119,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
     else:
         y_flip_sign = 1
 
-    # draw impedance and
+    # draw impedance and/or admittance
     both_charts = chart_type in ('zy', 'yz')
 
 
@@ -138,26 +138,26 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
 
     # impedance/admittance circles
     for r in rLightList:
-        center = (r/(1.+r)*y_flip_sign, 0)
+        center = (r/(1.+r)*y_flip_sign,0 )
         radius = 1./(1+r)
         if both_charts:
-            contour.insert(0, Circle( (-center[0], center[1]), radius, **superLightColor))
-        contour.append( Circle( center, radius, **lightColor))
+            contour.insert(0, Circle((-center[0], center[1]), radius, **superLightColor))
+        contour.append(Circle(center, radius, **lightColor))
     for x in xLightList:
-        center = (1*y_flip_sign, 1./x)
+        center = (1*y_flip_sign,1./x)
         radius = 1./x
         if both_charts:
             contour.insert(0, Circle( (-center[0], center[1]), radius, **superLightColor))
-        contour.append( Circle( center, radius, **lightColor))
+        contour.append(Circle(center, radius, **lightColor))
 
     for r in rHeavyList:
-        center = (r/(1.+r)*y_flip_sign, 0)
+        center = (r/(1.+r)*y_flip_sign,0 )
         radius = 1./(1+r)
-        contour.append( Circle( center, radius, **heavyColor))
+        contour.append(Circle(center, radius, **heavyColor))
     for x in xHeavyList:
         center = (1*y_flip_sign,1./x)
         radius = 1./x
-        contour.append( Circle( center, radius, **heavyColor))
+        contour.append(Circle(center, radius, **heavyColor))
 
     # clipping circle
     clipc = Circle( [0,0], smithR, ec='k',fc='None',visible=True)
@@ -170,15 +170,15 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
     # Set axis limits by plotting white points so zooming works properly
     ax1.plot(smithR*npy.array([-1.1, 1.1]), smithR*npy.array([-1.1, 1.1]), 'w.', markersize = 0)
     ax1.axis('image') # Combination of 'equal' and 'tight'
-
-
-    if not border:
+    
+    
+    if not border: 
         ax1.yaxis.set_ticks([])
         ax1.xaxis.set_ticks([])
         for loc, spine in ax1.spines.items():
             spine.set_color('none')
-
-
+        
+    
     if draw_labels:
         #Clear axis
         ax1.yaxis.set_ticks([])
@@ -215,7 +215,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                 S *= smithR * radialScaleFactor
                 rhox = S.real
                 rhoy = S.imag * y_flip_sign
-
+                
                 # Choose alignment anchor point based on label's value
                 if ((value == 1.0) or (value == -1.0)):
                     halignstyle = "center"
@@ -223,7 +223,7 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                     halignstyle = "right"
                 else:
                     halignstyle = "left"
-
+                
                 if (rhoy < 0):
                     valignstyle = "top"
                 else:
@@ -243,9 +243,8 @@ def smith(smithR=1, chart_type = 'z', draw_labels = False, border=False,
                 rhoy = (vswr-1.0) / (vswr+1.0)
 
                 ax1.annotate(str(vswr), xy=(0, rhoy*smithR),
-                    xytext=(0, rhoy*smithR), ha = "center", va = "bottom",
+                    xytext=(0, rhoy*smithR), ha="center", va="bottom",
                     color='grey', size='smaller')
-
 
     # loop though contours and draw them on the given axes
     for currentContour in contour:
@@ -272,7 +271,7 @@ def plot_rectangular(x, y, x_label=None, y_label=None, title=None,
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
-
+    
     '''
     if ax is None:
         ax = plb.gca()
@@ -296,10 +295,10 @@ def plot_rectangular(x, y, x_label=None, y_label=None, title=None,
     if axis is not None:
         ax.autoscale(True, 'x', True)
         ax.autoscale(True, 'y', False)
-
+        
     if plb.isinteractive():
         plb.draw()
-
+    
     return my_plot
 
 def plot_polar(theta, r, x_label=None, y_label=None, title=None,
@@ -312,7 +311,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
     theta : array-like
         data to plot
     r : array-like
-
+        
     x_label : string
         x-axis label
     y_label : string
@@ -324,7 +323,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
-
+    
     See Also
     ----------
     plot_rectangular : plots rectangular data
@@ -355,7 +354,7 @@ def plot_polar(theta, r, x_label=None, y_label=None, title=None,
 
     if axis_equal:
         ax.axis('equal')
-
+        
     if plb.isinteractive():
         plb.draw()
 
@@ -388,7 +387,7 @@ def plot_complex_rectangular(z, x_label='Real', y_label='Imag',
     plot_polar : plot polar data
     plot_complex_polar : plot complex data on polar plane
     plot_smith : plot complex data on smith chart
-
+    
     '''
     x = npy.real(z)
     y = npy.imag(z)
@@ -459,7 +458,7 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
     axis_equal: Boolean
         sets axis to be equal increments (calls axis('equal'))
     force_chart : Boolean
-        forces the re-drawing of smith chart
+        forces the re-drawing of smith chart 
     ax : :class:`matplotlib.axes.AxesSubplot` object
         axes to draw on
     *args,**kwargs : passed to pylab.plot
@@ -472,7 +471,7 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
     plot_complex_polar : plot complex data on polar plane
     plot_smith : plot complex data on smith chart
     '''
-
+    
     if ax is None:
         ax = plb.gca()
 
@@ -490,15 +489,15 @@ def plot_smith(s, smith_r=1, chart_type='z', x_label='Real',
         plb.draw()
 
 
-def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
+def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,  
                    add_titles=True, keep_it_tight=True,  subplot_kw={}, *args, **kw):
     '''
     Plot all networks parameters individually on subplots
-
+    
     Parameters
     --------------
-
-
+    
+    
     '''
     if newfig:
         f,axs= plb.subplots(ntwk.nports,ntwk.nports,
@@ -506,7 +505,7 @@ def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
                                       size_per_port*ntwk.nports ),
                                       **subplot_kw)
     else:
-        f = plb.gcf()
+        f = plb.gcf() 
         axs = npy.array(f.get_axes())
 
     for ports,ax in zip(ntwk.port_tuples, axs.flatten()):
@@ -521,23 +520,23 @@ def subplot_params(ntwk, param='s', proj='db', size_per_port=4, newfig=True,
 def shade_bands(edges, y_range=None,cmap='prism', **kwargs):
     '''
     Shades frequency bands.
-
-    when plotting data over a set of frequency bands it is nice to
+    
+    when plotting data over a set of frequency bands it is nice to 
     have each band visually separated from the other. The kwarg `alpha`
     is useful.
-
-    Parameters
+    
+    Parameters 
     --------------
     edges : array-like
         x-values separating regions of a given shade
-    y_range : tuple
-        y-values to shade in
+    y_range : tuple 
+        y-values to shade in 
     cmap : str
         see matplotlib.cm  or matplotlib.colormaps for acceptable values
     \*\* : key word arguments
         passed to `matplotlib.fill_between`
-
-    Examples
+        
+    Examples 
     -----------
     >>> rf.shade_bands([325,500,750,1100], alpha=.2)
     '''
@@ -546,8 +545,8 @@ def shade_bands(edges, y_range=None,cmap='prism', **kwargs):
     axis = plb.axis()
     for k in range(len(edges)-1):
         plb.fill_between(
-            [edges[k],edges[k+1]],
-            y_range[0], y_range[1],
+            [edges[k],edges[k+1]], 
+            y_range[0], y_range[1], 
             color = cmap(1.0*k/len(edges)),
             **kwargs)
     plb.axis(axis)
@@ -588,13 +587,13 @@ saf = save_all_figs
 
 def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10):
     '''
-    adds markers to existing lings on a plot
-
-    this is convinient if you have already have a plot made, but then
-    need to add markers afterwards, so that it can be interpreted in
-    black and white. The markevery argument makes the markers less
-    frequent than the data, which is generally what you want.
-
+    adds markers to existing lings on a plot 
+    
+    this is convinient if you have already have a plot made, but then 
+    need to add markers afterwards, so that it can be interpreted in 
+    black and white. The markevery argument makes the markers less 
+    frequent than the data, which is generally what you want. 
+    
     Parameters
     -----------
     ax : matplotlib.Axes
@@ -603,7 +602,7 @@ def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10
         see matplotlib.plot help for possible marker characters
     markevery : int
         markevery number of points with a marker.
-
+    
     '''
     if ax is None:
         ax=plb.gca()
@@ -615,14 +614,14 @@ def add_markers_to_lines(ax=None,marker_list=['o','D','s','+','x'], markevery=10
 
 def legend_off(ax=None):
     '''
-    turn off the legend for a given axes.
-
+    turn off the legend for a given axes. 
+    
     if no axes is given then it will use current axes.
-
+    
     Parameters
     -----------
     ax : matplotlib.Axes object
-        axes to operate on
+        axes to operate on 
     '''
     if ax is None:
         plb.gca().legend_.set_visible(0)
@@ -632,41 +631,41 @@ def legend_off(ax=None):
 def scrape_legend(n=None, ax=None):
     '''
     scrapes a legend with redundant labels
-
-    Given a legend of m entries of n groups, this will remove all but
+    
+    Given a legend of m entries of n groups, this will remove all but 
     every m/nth entry. This is used when you plot many lines representing
     the same thing, and only want one label entry in the legend  for the
     whole ensemble of lines
-
+    
     '''
-
+    
     if ax is None:
         ax = plb.gca()
-
+    
     handles, labels = ax.get_legend_handles_labels()
-
+    
     if n is None:
         n =len ( set(labels))
-
+    
     if n>len(handles):
         raise ValueError('number of entries is too large')
-
+    
     k_list = [int(k) for k in npy.linspace(0,len(handles)-1,n)]
     ax.legend([handles[k] for k in k_list], [labels[k] for k in k_list])
 
 def func_on_all_figs(func, *args, **kwargs):
     '''
-    runs a function after making all open figures current.
-
-    useful if you need to change the properties of many open figures
-    at once, like turn off the grid.
-
+    runs a function after making all open figures current. 
+    
+    useful if you need to change the properties of many open figures 
+    at once, like turn off the grid. 
+    
     Parameters
     ----------
     func : function
         function to call
     \*args, \*\*kwargs : pased to func
-
+    
     Examples
     ----------
     >>> rf.func_on_all_figs(grid,alpha=.3)
@@ -682,9 +681,9 @@ foaf = func_on_all_figs
 
 def plot_vector(a, off=0+0j, *args, **kwargs):
     '''
-    plot a 2d vector
+    plot a 2d vector 
     '''
-    return quiver(off.real,off.imag,a.real,a.imag,scale_units ='xy',
+    return quiver(off.real,off.imag,a.real,a.imag,scale_units ='xy', 
            angles='xy',scale=1, *args, **kwargs)
 
 

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -44,6 +44,10 @@ import collections, pprint
 from subprocess import Popen,PIPE
 # globals
 
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
 
 # other
 def now_string():
@@ -156,7 +160,7 @@ def get_fid(file, *args, **kwargs):
     file : str/unicode or file-object
         file to open
     \*args, \*\*kwargs : arguments and keyword arguments to `open()`
-        
+
     '''
     if isinstance(file, basestring):
         return open(file, *args, **kwargs)

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -160,7 +160,7 @@ def get_fid(file, *args, **kwargs):
     file : str/unicode or file-object
         file to open
     \*args, \*\*kwargs : arguments and keyword arguments to `open()`
-
+        
     '''
     if isinstance(file, basestring):
         return open(file, *args, **kwargs)


### PR DESCRIPTION
Some graphical options I like to see on smith chart plots.

chart_type="zy" or "yz"
----------------------- 
Like "z" or "y" but the circles of the second character is drawn as well but nearby transparent. In that way the chart looks not overstuffed.
![chart_type_zy](https://cloud.githubusercontent.com/assets/6317504/12222297/8f4b1978-b7b8-11e5-98bb-c355db21547e.png)

draw_vswr
---------
Sometimes the VSWR circles would be nice to be seen. So an additional keyword-parameter *draw_vswr* can be set. Can be True = (my) default VSWR list, your own list of VSWR values or None. If *draw_labels* is set these circles are labeled as well.
![draw_vswr](https://cloud.githubusercontent.com/assets/6317504/12222298/9228c2c6-b7b8-11e5-9905-369a74ac5a48.png)


