### PR TITLE
Add test for conversion between parameters

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4058,7 +4058,7 @@ def z2a(z):
         ]).transpose()
     return abcd
 
-def s2a(s,z0):
+def s2a(s,z0=50):
     '''
     Converts scattering parameters to abcd  parameters [#]_ .
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -150,7 +150,17 @@ class NetworkTestCase(unittest.TestCase):
         y = short.y
         a = react.y
 
+    def test_conversions(self):
+        #Converting to other format and back to S-parameters should return the original network
+        tinyfloat = 1e-12
+        for test_z0 in (50, 10, 90+10j, 4-100j):
+            for test_ntwk in (self.ntwk1, self.ntwk2, self.ntwk3):
+                ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0)
 
+                self.assertTrue((abs(rf.a2s(rf.s2a(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
+                self.assertTrue((abs(rf.z2s(rf.s2z(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
+                self.assertTrue((abs(rf.y2s(rf.s2y(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
+                self.assertTrue((abs(rf.t2s(rf.s2t(ntwk.s))-ntwk.s) < tinyfloat).all())
 
     def test_yz(self):
         tinyfloat = 1e-12


### PR DESCRIPTION
Here's one test case that checks that converting from S-parameters to ABCD/Z/Y/T and back to S-parameters returns the original network. It uses the test networks that are defined in test_network file and tests are done with different z0s. I meant to still add one test case that checks that a simple network is converted correctly, but I don't think I have time for it right now.

There's also another small commit that adds a missing default 50 ohm z0 to s2a function.