### PR TITLE
Added the "future" package in the requirement list. 

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - matplotlib
     - mock
     - nose
+    - future
 
   run:
     - python

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -7,5 +7,6 @@ pandas>=0.11.0
 xlwt>=0.7.4
 xlrd>=0.6.1
 nose-exclude
+future
 
 


### PR DESCRIPTION
The "future" package is not installed by default in Anaconda 4.0. 
