### PR TITLE
Remove n_reflects argument from M-TRL

### DIFF
--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -615,7 +615,6 @@ class NISTMultilineTRLTest(EightTermTest):
             Grefls = [-1, 1],
             l = [0, 100e-6, 200e-6, 500e-6],
             er_est = 1,
-            n_reflects = 2,
             switch_terms = (self.gamma_f, self.gamma_r),
             gamma_root_choice = 'imag' #Losslessness of the line causes problems
                                        #without this option


### PR DESCRIPTION
Number of reflects is determined by the length of Grefls list.

Added error checking to make sure that number of measurements
equals number of line lengths plus number of reflects.