### PR TITLE
Calibration test related fixes

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -643,8 +643,8 @@ class Calibration(object):
         d = self.coefs
 
         for k in coefs_list_8term:
-            if k not in d:
-                d = convert_12term_2_8term(d)
+            if k not in d and k in coefs_list_12term:
+                return convert_12term_2_8term(d)
 
         return d
 
@@ -691,8 +691,8 @@ class Calibration(object):
         d = self.coefs
 
         for k in coefs_list_12term:
-            if k not in d:
-                d = convert_8term_2_12term(d)
+            if k not in d and k in coefs_list_8term:
+                return convert_8term_2_12term(d)
 
         return d
 

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1100,8 +1100,9 @@ class TwelveTermToEightTermTest(unittest.TestCase, CalibrationTest):
     def test_forward_switch_term(self):
         self.assertEqual(self.coefs['forward switch term'], self.gamma_f)
     
-    def test_forward_switch_term(self):
+    def test_reverse_switch_term(self):
         self.assertEqual(self.coefs['reverse switch term'], self.gamma_r)
+
     @nottest
     def test_k(self):
         self.assertEqual(self.coefs['k'], self.X.s21/self.Y.s12 )

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -437,7 +437,7 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
         self.assertEqual(
             self.X.s21/self.Y.s12 , 
             self.cal.coefs_ntwks['k']  )   
-    @nottest
+
     def test_verify_12term(self):
         self.assertTrue(self.cal.verify_12term_ntwk.s_mag.max() < 1e-3)
             

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1147,89 +1147,6 @@ class TwelveTermToEightTermTest(unittest.TestCase, CalibrationTest):
     def test_verify_12term(self):
         self.assertTrue(self.cal.verify_12term_ntwk.s_mag.max() < 1e-3)
 
-class LMR16Test(unittest.TestCase, CalibrationTest):
-    def setUp(self):
-        self.n_ports = 2
-        self.wg = WG
-        wg = self.wg
-
-        #Port 0: VNA port 0
-        #Port 1: DUT port 0
-        #Port 2: DUT port 1
-        #Port 3: VNA port 1
-        self.Z = wg.random(n_ports = 4, name = 'Z')
-
-        r = wg.short(nports=1, name='short')
-        m = wg.match(nports=1, name='load')
-        mm = rf.two_port_reflect(m, m)
-        rm = rf.two_port_reflect(r, m)
-        mr = rf.two_port_reflect(m, r)
-        rr = rf.two_port_reflect(r, r)
-
-        thru_length = uniform(0,10)
-        thru = wg.line(thru_length,'deg',name='line')
-
-        self.thru = thru
-
-        ideals = [
-            thru,
-            mm,
-            rr,
-            rm,
-            mr
-            ]
-
-        measured = [self.measure(k) for k in ideals]
-
-        self.cal = rf.LMR16(
-            measured = measured,
-            ideals = [r],
-            ideal_is_reflect = True,
-             #Automatic sign detection doesn't work if the
-             #error terms aren't symmetric enough
-            sign = -1
-            )
-
-    def measure(self,ntwk):
-        out = rf.connect(self.Z, 1, ntwk, 0, num=2)
-        out.name = ntwk.name
-        return out
-
-    def test_solved_through(self):
-        self.assertEqual(
-            self.thru,
-            self.cal.solved_through)
-
-    def test_forward_directivity_accuracy(self):
-        self.assertEqual(
-            self.Z.s11,
-            self.cal.coefs_ntwks['forward directivity'])
-
-    def test_forward_source_match_accuracy(self):
-        self.assertEqual(
-            self.Z.s22 ,
-            self.cal.coefs_ntwks['forward source match'] )
-
-    def test_forward_reflection_tracking_accuracy(self):
-        self.assertEqual(
-            self.Z.s21 * self.Z.s12 ,
-            self.cal.coefs_ntwks['forward reflection tracking'])
-
-    def test_reverse_source_match_accuracy(self):
-        self.assertEqual(
-            self.Z.s33 ,
-            self.cal.coefs_ntwks['reverse source match']   )
-
-    def test_reverse_directivity_accuracy(self):
-        self.assertEqual(
-            self.Z.s44 ,
-            self.cal.coefs_ntwks['reverse directivity']  )
-
-    def test_reverse_reflection_tracking_accuracy(self):
-        self.assertEqual(
-            self.Z.s34 * self.Z.s43 ,
-            self.cal.coefs_ntwks['reverse reflection tracking'])
-
 class SixteenTermTest(unittest.TestCase, CalibrationTest):
     def setUp(self):
         self.n_ports = 2
@@ -1301,6 +1218,79 @@ class SixteenTermTest(unittest.TestCase, CalibrationTest):
             self.Z.s34 * self.Z.s43 ,
             self.cal.coefs_ntwks['reverse reflection tracking'])
 
+    def test_forward_isolation(self):
+        self.assertEqual(
+            self.Z.s41 ,
+            self.cal.coefs_ntwks['forward isolation'])
+
+    def test_reverse_isolation(self):
+        self.assertEqual(
+            self.Z.s14 ,
+            self.cal.coefs_ntwks['reverse isolation'])
+
+    def test_b2_a1_isolation(self):
+        self.assertEqual(
+            self.Z.s23 ,
+            self.cal.coefs_ntwks['b2 a1 isolation'])
+
+    def test_b1_a2_isolation(self):
+        self.assertEqual(
+            self.Z.s32 ,
+            self.cal.coefs_ntwks['b1 a2 isolation'])
+
+
+class LMR16Test(SixteenTermTest):
+    def setUp(self):
+        self.n_ports = 2
+        self.wg = WG
+        wg = self.wg
+
+        #Port 0: VNA port 0
+        #Port 1: DUT port 0
+        #Port 2: DUT port 1
+        #Port 3: VNA port 1
+        self.Z = wg.random(n_ports = 4, name = 'Z')
+
+        r = wg.short(nports=1, name='short')
+        m = wg.match(nports=1, name='load')
+        mm = rf.two_port_reflect(m, m)
+        rm = rf.two_port_reflect(r, m)
+        mr = rf.two_port_reflect(m, r)
+        rr = rf.two_port_reflect(r, r)
+
+        thru_length = uniform(0,10)
+        thru = wg.line(thru_length,'deg',name='line')
+
+        self.thru = thru
+
+        ideals = [
+            thru,
+            mm,
+            rr,
+            rm,
+            mr
+            ]
+
+        measured = [self.measure(k) for k in ideals]
+
+        self.cal = rf.LMR16(
+            measured = measured,
+            ideals = [r],
+            ideal_is_reflect = True,
+             #Automatic sign detection doesn't work if the
+             #error terms aren't symmetric enough
+            sign = -1
+            )
+
+    def measure(self,ntwk):
+        out = rf.connect(self.Z, 1, ntwk, 0, num=2)
+        out.name = ntwk.name
+        return out
+
+    def test_solved_through(self):
+        self.assertEqual(
+            self.thru,
+            self.cal.solved_through)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes conversion between 12 and 8 term error parameters when calling coefs_8term or coefs_12term. Previously conversion was tried multiple times in a loop, now it returns after the first conversion.

Rest of the commits fix and add some test cases but don't make functional changes.

There are still some failing disabled tests in TwelveTermTest related to conversion to 8 term error parameters. Reason they are failing is that the TwelveTermTest generates different error networks in forward and backward directions meaning that the error networks are not same in the forward and backward directions and thus conversion to 8 term error parameters is not possible.

I added some test cases to TwelveTermToEightTermTest with reciprocal error networks and 12 term to 8 term conversion seems to be working correctly.