### PR TITLE
Passing the filename as a string instead of fid solves python36 bug

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -148,7 +148,6 @@ except ImportError:
     import pickle as pickle
     from pickle import UnpicklingError
 
-import warnings
 from copy import deepcopy as copy
 import re
 from numbers import Number

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -386,8 +386,7 @@ class Network(object):
                 # if unpickling doesn't work then, close fid, reopen in
                 # non-binary mode and try to read it as touchstone
                 fid.close()
-                fid = get_fid(file)
-                self.read_touchstone(fid)
+                self.read_touchstone(file)
 
             if name is None and isinstance(file,str):
                 name = os.path.splitext(os.path.basename(file))[0]


### PR DESCRIPTION
This refers to issue #103.

Passing the file name as string instead of a fid object allows to use os.path method on it. 
However I wonder why is was like that before (and why it worked)...  

Is there a py36 tests automatically run on travis?