### PR TITLE
Polishing NIST TRL / qtapps

### DIFF
--- a/qtapps/skrf_qtwidgets/calibration_widgets.py
+++ b/qtapps/skrf_qtwidgets/calibration_widgets.py
@@ -488,6 +488,7 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
         self.lineEdit_epsEstimate.value_changed.connect(self.calibration_parameters_changed)
         self.lineEdit_referencePlane.value_changed.connect(self.calibration_parameters_changed)
         self.lineEdit_thruLength.value_changed.connect(self.calibration_parameters_changed)
+        self.comboBox_rootChoice.currentIndexChanged.connect(self.calibration_parameters_changed)
         self.listWidget_reflect.state_changed.connect(self.calibration_parameters_changed)
         self.listWidget_line.state_changed.connect(self.calibration_parameters_changed)
         self.listWidget_thru.state_changed.connect(self.calibration_parameters_changed)

--- a/qtapps/skrf_qtwidgets/calibration_widgets.py
+++ b/qtapps/skrf_qtwidgets/calibration_widgets.py
@@ -484,6 +484,7 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
         self.calibration_current = False
 
         self.btn_viewCalibration.setEnabled(False)
+        self.btn_saveCalibration.setEnabled(False)
 
         self.lineEdit_epsEstimate.value_changed.connect(self.calibration_parameters_changed)
         self.lineEdit_referencePlane.value_changed.connect(self.calibration_parameters_changed)
@@ -797,9 +798,11 @@ This will save the measurements and parameters as currently entered.  Do you sti
             er_est=er_est, refl_offset=refl_offset, # p1_len_est=p1_len_est, p2_len_est=p2_len_est,
             ref_plane=ref_plane, gamma_root_choice=gamma_root_choice, switch_terms=switch_terms
         )
+        cal.run()
 
         self.calibration = cal
         self.calibration_current = True
+
         self.btn_runCalibration.setEnabled(False)
         self.btn_saveCalibration.setEnabled(True)
         self.btn_viewCalibration.setEnabled(True)

--- a/qtapps/skrf_qtwidgets/calibration_widgets.py
+++ b/qtapps/skrf_qtwidgets/calibration_widgets.py
@@ -310,15 +310,16 @@ class NISTCalViewer(QtWidgets.QDialog):
         """
         super(NISTCalViewer, self).__init__(parent)
         self.setWindowTitle("Inspect Cal")
-
-        fHz = cal.frequency.f
-        c = 299792458
-
         self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.graphicsLayout = pg.GraphicsLayoutWidget()
 
+        fHz = cal.frequency.f
+        c = 299792458
         eps_eff = (cal.gamma * c / (1j * 2 * np.pi * fHz)) ** 2  # assuming non-magnetic TEM propagation
+        Eratio_1cm = np.exp(-cal.gamma * 0.1)
+        dbcm = 20 * np.log10(np.abs(Eratio_1cm))
+
         self.eps_plot = self.graphicsLayout.addPlot()  # type: pg.PlotItem
         self.eps_plot.setLabel("left", "effective permittivity")
         self.eps_plot.setLabel("bottom", "frequency", units="Hz")
@@ -327,8 +328,6 @@ class NISTCalViewer(QtWidgets.QDialog):
         self.eps_plot.plot(fHz, eps_eff.real, pen=pg.mkPen("c"), name="real")
         self.eps_plot.plot(fHz, -eps_eff.imag, pen=pg.mkPen("y"), name="imag")
 
-        Eratio_1cm = np.exp(-cal.gamma * 0.1)
-        dbcm = 20 * np.log10(np.abs(Eratio_1cm))
         self.y_plot = self.graphicsLayout.addPlot()  # type: pg.PlotItem
         self.y_plot.setLabel("left", "line loss", units="dB/cm")
         self.y_plot.setLabel("bottom", "frequency", units="Hz")
@@ -336,7 +335,6 @@ class NISTCalViewer(QtWidgets.QDialog):
         self.y_plot.plot(fHz, dbcm)
 
         self.layout.addWidget(self.graphicsLayout)
-
         self.resize(900, 400)
 
 
@@ -483,11 +481,26 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
         self.btn_uploadCalibration.clicked.connect(self.upload_calibration)
         self._get_analyzer = None
         self._calibration = None
+        self.calibration_current = False
 
         self.btn_viewCalibration.setEnabled(False)
 
+        self.lineEdit_epsEstimate.value_changed.connect(self.calibration_parameters_changed)
+        self.lineEdit_referencePlane.value_changed.connect(self.calibration_parameters_changed)
+        self.lineEdit_thruLength.value_changed.connect(self.calibration_parameters_changed)
+        self.listWidget_reflect.state_changed.connect(self.calibration_parameters_changed)
+        self.listWidget_line.state_changed.connect(self.calibration_parameters_changed)
+        self.listWidget_thru.state_changed.connect(self.calibration_parameters_changed)
+
+    def calibration_parameters_changed(self):
+        self.calibration_current = False
+        self.btn_runCalibration.setEnabled(True)
+        if self.calibration is not None:
+            self.btn_runCalibration.setText("Re-Run Cal")
+            self.btn_viewCalibration.setText("View Cal (Old)")
+
     def view_calibration(self):
-        dialog = NISTCalViewer(self.get_calibration())
+        dialog = NISTCalViewer(self.calibration)
         dialog.exec_()
 
     def upload_calibration(self):
@@ -533,6 +546,14 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
 
     def save_calibration(self):
         """save an mTRL as a json + .s2p files in a zip archive"""
+        if not self.calibration_current:
+            msg = """Calibration parameters have changed and cal has not been re-run.
+This will save the measurements and parameters as currently entered.  Do you still want to save"""
+            reply = QtWidgets.QMessageBox.question(
+                self, 'Cal Parameters Changed', msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+            if reply == QtWidgets.QMessageBox.No:
+                return
+
         thru = self.listWidget_thru.get_named_item(self.THRU_ID).ntwk
         fswitch = self.listWidget_thru.get_named_item(self.SWITCH_TERMS_ID_FORWARD).ntwk
         rswitch = self.listWidget_thru.get_named_item(self.SWITCH_TERMS_ID_REVERSE).ntwk
@@ -708,6 +729,14 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
     def get_calibration(self):
         return self._calibration
 
+    def set_calibration(self, cal):
+        if not isinstance(cal, skrf.calibration.NISTMultilineTRL):
+            raise TypeError("Must provide a NISTMultilineTRL Calibration object")
+        else:
+            self._calibration = cal
+
+    calibration = property(get_calibration, set_calibration)
+
     def run_calibration_popup(self):
         dialog = qt.RunFunctionDialog(self.run_calibration, "Running Calibration",
                                       "Running NIST Multiline Cal\nthis window will close when finished")
@@ -768,6 +797,10 @@ class NISTTRLStandardsWidget(QtWidgets.QWidget):
             ref_plane=ref_plane, gamma_root_choice=gamma_root_choice, switch_terms=switch_terms
         )
 
-        self._calibration = cal
+        self.calibration = cal
+        self.calibration_current = True
+        self.btn_runCalibration.setEnabled(False)
+        self.btn_saveCalibration.setEnabled(True)
         self.btn_viewCalibration.setEnabled(True)
+        self.btn_viewCalibration.setText("View Cal")
         self.calibration_updated.emit(cal)

--- a/qtapps/skrf_qtwidgets/networkListWidget.py
+++ b/qtapps/skrf_qtwidgets/networkListWidget.py
@@ -318,9 +318,11 @@ class NetworkListWidget(QtWidgets.QListWidget):
     def load_network(self, ntwk, activate=True):
         item = NetworkListItem()
         item.setFlags(item.flags() | QtCore.Qt.ItemIsEditable)
-        item.setText(self.get_unique_name(ntwk.name))
+        name = self.get_unique_name(ntwk.name)
         item.ntwk = ntwk
         item.ntwk_corrected = self.correction(ntwk)
+        item.update_ntwk_names(name)
+        item.set_text()
         self.addItem(item)
         self.clearSelection()
         self.setCurrentItem(item)

--- a/qtapps/skrf_qtwidgets/networkListWidget.py
+++ b/qtapps/skrf_qtwidgets/networkListWidget.py
@@ -33,6 +33,7 @@ class NetworkListWidget(QtWidgets.QListWidget):
     save_single_requested = QtCore.Signal(object, str)
     selection_changed = QtCore.Signal(object)
     same_item_clicked = QtCore.Signal(object)
+    state_changed = QtCore.Signal()
 
     def __init__(self, name_prefix='meas', parent=None):
         super(NetworkListWidget, self).__init__(parent)
@@ -44,6 +45,8 @@ class NetworkListWidget(QtWidgets.QListWidget):
         self.save_single_requested.connect(self.save_NetworkListItem)
         self.itemDelegate().commitData.connect(self.item_text_updated)
         self.item_updated.connect(self.set_active_network)
+        self.item_updated.connect(self.state_changed.emit)
+        self.item_removed.connect(self.state_changed.emit)
 
         self._ntwk_plot = None
         self.named_items = {}
@@ -530,9 +533,14 @@ class ParameterizedNetworkListWidget(NetworkListWidget):
         """
         dialog = widgets.NetworkParameterEditor(item, self.item_parameters)
 
+        state_changed = False
+
         accepted = dialog.exec_()
         if accepted:
             for name, input in dialog.inputs.items():
+                if name == "name":
+                    continue
+
                 if isinstance(input, numeric_inputs.NumericLineEdit):
                     value = input.get_value()
                 elif isinstance(input, QtWidgets.QLineEdit):
@@ -543,12 +551,19 @@ class ParameterizedNetworkListWidget(NetworkListWidget):
                     value = input.value()
                 else:
                     raise TypeError("Unsupported Widget {:}".format(input))
-                item.parameters[name] = value
+                if item.parameters[name] != value:
+                    item.parameters[name] = value
+                    state_changed = True
 
             index = self.indexFromItem(item).row()
             name = self.get_unique_name(dialog.inputs["name"].text(), index)
-            item.update_ntwk_names(name)
+            if item.ntwk.name != name:
+                item.update_ntwk_names(name)
+                state_changed = True
             self.set_item_text(item)
+
+            if state_changed:
+                self.state_changed.emit()
 
     @property
     def item_parameters(self):

--- a/qtapps/skrf_qtwidgets/networkPlotWidget.py
+++ b/qtapps/skrf_qtwidgets/networkPlotWidget.py
@@ -232,6 +232,12 @@ class NetworkPlotWidget(QtWidgets.QWidget):
                     frequency, curve.ntwk.frequency.unit, S11.real, S11.imag, Z.real, Z.imag))
 
     def update_plot(self):
+        if self.corrected_data_enabled:
+            if self.ntwk_corrected:
+                self.checkBox_useCorrected.setEnabled(True)
+            else:
+                self.checkBox_useCorrected.setEnabled(False)
+
         if "smith" in self.comboBox_primarySelector.currentText().lower():
             self.plot_smith()
         else:


### PR DESCRIPTION
getting closer to a finished state for the NIST Multiline TRL app
added some events for numeric inputs and listwidgets that tell whether something substantially has changed so that the gui can update itself about whether calibrations need to be re-run or not

Also added recommended inspections for the calibration parameters (effective permittivity and line-loss in dB/cm).