### PR TITLE
fix lambda_guide attribute for rectangular waveguide

### DIFF
--- a/skrf/media/rectangularWaveguide.py
+++ b/skrf/media/rectangularWaveguide.py
@@ -303,7 +303,7 @@ class RectangularWaveguide(Media):
 
         the distance in which the phase of the field increases by 2 pi
         '''
-        return 2*pi/self.propagation_constant.imag
+        return 2*pi/self.beta
 
     @property
     def lambda_cutoff(self):


### PR DESCRIPTION
lambda_guide tries to return the guide wavelength from the imaginary
part of the propagation constant attribute, which is not defined if a
simple waveguide is initialized:

```
In [14]: wg.lambda_guide
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-14-708a158c108f> in <module>()
----> 1 wg.lambda_guide

/usr/lib/python3.6/site-packages/skrf/media/rectangularWaveguide.py in lambda_guide(self)
    304         the distance in which the phase of the field increases by 2 pi
    305         '''
--> 306         return 2*pi/self.propagation_constant.imag
    307
    308     @property

AttributeError: 'RectangularWaveguide' object has no attribute 'propagation_constant'
```

The guide wavelength is defined [0] as

    lambda_guide = 2*pi / beta

and the rectangular waveguide object has beta as an attribute.

[0] Microwave Engineering, David M. Pozar