### PR TITLE
Testcase to excercise get_sparameter_data.

### DIFF
--- a/skrf/io/tests/test_touchstone.py
+++ b/skrf/io/tests/test_touchstone.py
@@ -54,6 +54,28 @@ class TouchstoneTestCase(unittest.TestCase):
         self.assertTrue((s == s_true).all())
         self.assertTrue((z0 == z0_true))
 
+    def test_get_sparameter_data(self):
+        '''
+        This tests the get_sparameter_data function.
+
+        '''
+        with open(os.path.join(self.test_dir, 'simple_touchstone.s2p')) as fid:
+            touch = Touchstone(fid)
+
+        spardict = touch.get_sparameter_data(format="ri")
+        self.assertTrue("frequency" in spardict)
+        self.assertTrue("S11R" in spardict)
+        self.assertTrue("S11I" in spardict)
+        self.assertTrue("S12R" in spardict)
+        self.assertTrue("S12I" in spardict)
+        self.assertTrue("S21R" in spardict)
+        self.assertTrue("S21I" in spardict)
+        self.assertTrue("S22R" in spardict)
+        self.assertTrue("S22I" in spardict)
+        self.assertTrue("S11DB" not in spardict)
+        self.assertTrue("S11M" not in spardict)
+
+
 suite = unittest.TestLoader().loadTestsFromTestCase(TouchstoneTestCase)
 unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -255,8 +255,8 @@ class Touchstone:
         if format == 'orig':
             format = self.format
         ext1, ext2 = {'ri':('R','I'),'ma':('M','A'), 'db':('DB','A')}.get(format)
-        for r1 in xrange(self.rank):
-            for r2 in xrange(self.rank):
+        for r1 in range(self.rank):
+            for r2 in range(self.rank):
                 names.append("S%i%i%s"%(r1+1,r2+1,ext1))
                 names.append("S%i%i%s"%(r1+1,r2+1,ext2))
         return names


### PR DESCRIPTION
get_sparameter_names use the xrange function which is not available
in python3. Switching to range function.