### PR TITLE
Time domain fixes

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2194,7 +2194,8 @@ class Network(object):
         .. [1] Agilent Time Domain Analysis Using a Network Analyzer Application Note 1287-12
 
         '''
-        window = signal.get_window(window, len(self))
+
+        window = signal.get_window(window, 2*len(self))[len(self):]
 
         window = window.reshape(-1, 1, 1) * npy.ones((len(self),
                                                       self.nports,

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -173,6 +173,11 @@ from .time import time_gate
 
 from .constants import ZERO
 
+def s_to_time(s, pad=0):
+    """Transforms S-parameters to time-domain"""
+    if len(s.shape) != 1 and s.shape[1:] != (1,1):
+        raise ValueError('Only one-ports are supported')
+    return npy.fft.fftshift(npy.fft.irfft(s, axis=0, n=s.shape[0]+pad), axes=0)
 
 class Network(object):
     """
@@ -279,9 +284,9 @@ class Network(object):
                                  npy.abs(x),
         # 'gd' : lambda x: -1 * npy.gradient(mf.unwrap_rad(npy.angle(x)))[0], # removed because it depends on `f` as well as `s`
         'vswr': lambda x: (1 + abs(x)) / (1 - abs(x)),
-        'time': lambda x: fft.fftshift(fft.ifft(x, axis=0), axes=0),
-        'time_db': lambda x: mf.complex_2_db(fft.fftshift(fft.ifft(x, axis=0), axes=0)),
-        'time_mag': lambda x: mf.complex_2_magnitude(fft.fftshift(fft.ifft(x, axis=0), axes=0)),
+        'time': s_to_time,
+        'time_db': lambda x: mf.complex_2_db(s_to_time(x)),
+        'time_mag': lambda x: mf.complex_2_magnitude(s_to_time(x)),
     }
     # provides y-axis labels to the plotting functions
     global Y_LABEL_DICT

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2515,7 +2515,9 @@ class Network(object):
         """Calculates time-domain impulse response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
-        the frequency step must be uniform.
+        the frequency step must be uniform. Positions of the reflections are
+        accurate even if the frequency doesn't begin from 0, but shapes will
+        be distorted.
 
         Real measurements should be extrapolated to DC and interpolated to
         uniform frequency spacing.
@@ -2527,18 +2529,19 @@ class Network(object):
         window : string
                 FFT windowing function.
         pad : int
-                Number of zeros to add as padding.
+                Number of zeros to add as padding for FFT.
+                Adding more zeros improves accuracy of peaks.
 
         Returns
         ---------
         t : class:`numpy.ndarray`
             Time vector
         y : class:`numpy.ndarray`
-            Step response
+            Impulse response
 
         See Also
         -----------
-            impulse_response
+            step_response
         """
         if self.nports != 1:
             raise ValueError('Only one-ports are supported')
@@ -2566,7 +2569,8 @@ class Network(object):
         window : string
                 FFT windowing function.
         pad : int
-                Number of zeros to add as padding.
+                Number of zeros to add as padding for FFT.
+                Adding more zeros improves accuracy of peaks.
 
         Returns
         ---------

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -51,7 +51,9 @@ class NetworkTestCase(unittest.TestCase):
         self.DUT = rf.concat_ports([l2, l2, l2, l2])
         self.Meas = rf.concat_ports([l3, l3, l3, l3])
 
-
+    def test_timedomain(self):
+        t = self.ntwk1.s11.s_time
+        self.assertTrue(npy.sum(npy.abs(t.imag)) == 0)
 
     def test_constructor_empty(self):
         rf.Network()


### PR DESCRIPTION
Fix time domain transformation and windowing. Add impulse and step response functions with windowing and zero-padding arguments.

Example program:

    import skrf
    import matplotlib.pyplot as plt
    skrf.stylely()

    freq = skrf.F(0,110,400)
    coax1mm = skrf.media.Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e20)

    X = coax1mm.line(10, 'mm', z0=50, name='X', embed=True)
    Y = coax1mm.line(80, 'mm', z0=75, name='Y', embed=True)
    dut = X**Y**X

    v = coax1mm.v_p[-1].real
    print '1st reflection time:', 2*10e-3/v

    plt.figure()
    plt.title('Step')
    t, y = dut.s11.step_response(pad=2000)
    plt.plot(t, y)
    plt.xlabel('Time (ns)')

    plt.figure()
    plt.title('Impulse')
    t, y = dut.s11.impulse_response(pad=2000)
    plt.plot(t, y)
    plt.xlabel('Time (ns)')

    plt.show(block=True)

![impulse](https://user-images.githubusercontent.com/544240/29424436-6d6fa308-8388-11e7-820d-39809762d06d.png)
![step](https://user-images.githubusercontent.com/544240/29424443-72e6f926-8388-11e7-86e5-f7dcdb3f85fc.png)
Step response peak is 0.2, which is the expected reflection coefficient from 50 to 75 ohms. This can be used to measure characteristic impedance of transmission lines.