### PR TITLE
Add rational interpolation

### DIFF
--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -254,6 +254,12 @@ class NetworkTestCase(unittest.TestCase):
         b = a.interpolate(freq)
         # TODO: numerically test for correct interpolation
 
+    def test_interpolate_rational(self):
+        a = rf.N(f=[1,2],s=[1+2j, 3+4j],z0=1)
+        freq = rf.F.from_f(npy.linspace(1,2,4), unit='ghz')
+        b = a.interpolate(freq, kind='rational')
+        # TODO: numerically test for correct interpolation
+
     def test_interpolate_self_npoints(self):
         a = rf.N(f=[1,2],s=[1+2j, 3+4j],z0=1)
         a.interpolate_self_npoints(4)


### PR DESCRIPTION
Should be a better interpolation method that causes less errors with time-domain transformations.

Based on: https://www.in.tu-clausthal.de/fileadmin/homes/techreports/ifi0606floater.pdf

Example:

    import skrf
    import matplotlib.pyplot as plt
    skrf.stylely()

    freq = skrf.F(0.5,110,801)
    freq2 = skrf.F(0,110,801)
    coax1mm = skrf.media.Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e20)
    coax1mm2 = skrf.media.Coaxial(freq2, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e20)

    X = coax1mm.line(10, 'mm', z0=50, name='X', embed=True)
    Y = coax1mm.line(80, 'mm', z0=75, name='Y', embed=True)
    dut = X**Y**X

    X2 = coax1mm2.line(10, 'mm', z0=50, name='X', embed=True)
    Y2 = coax1mm2.line(80, 'mm', z0=75, name='Y', embed=True)
    dut2 = X2**Y2**X2

    dut_dc_rational = dut.extrapolate_to_dc(kind='rational', dc_sparam=[[0,1],[1,0]])
    dut_dc_linear = dut.extrapolate_to_dc(kind='linear', dc_sparam=[[0,1],[1,0]])
    dut_dc_cubic = dut.extrapolate_to_dc(kind='cubic', dc_sparam=[[0,1],[1,0]])

    plt.figure()
    plt.title('Step')
    t, y = dut2.s11.step_response(pad=2000)
    t2, y2 = dut_dc_rational.s11.step_response(pad=2000)
    t3, y3 = dut_dc_linear.s11.step_response(pad=2000)
    t4, y4 = dut_dc_cubic.s11.step_response(pad=2000)
    plt.plot(t, y, label='Real')
    plt.plot(t2, y2, label='Rational')
    plt.plot(t3, y3, label='Linear')
    plt.plot(t4, y4, label='Cubic')
    plt.legend()
    plt.xlabel('Time (ns)')

    plt.show(block=True)

![step](https://user-images.githubusercontent.com/544240/29529757-9b355ffc-86a9-11e7-8f00-f6da66fc2d29.png)
![step2](https://user-images.githubusercontent.com/544240/29529771-a9b896ac-86a9-11e7-9be5-200613460133.png)
![step3](https://user-images.githubusercontent.com/544240/29529765-a6003182-86a9-11e7-8e47-4a764cb134fa.png)

It does seem to be a little better than cubic interpolation with few examples that I tested.
