### PR TITLE
added impulse and step response plotting methods

### DIFF
--- a/doc/source/examples/networktheory/Rational Interpolation.ipynb
+++ b/doc/source/examples/networktheory/Rational Interpolation.ipynb
@@ -40,32 +40,53 @@
     "X2 = coax1mm2.line(10, 'mm', z0=50, name='X', embed=True)\n",
     "Y2 = coax1mm2.line(80, 'mm', z0=75, name='Y', embed=True)\n",
     "dut2 = X2**Y2**X2\n",
+    "dut2.name = 'real'\n",
     "\n",
     "dut_dc_rational = dut.extrapolate_to_dc(kind='rational', dc_sparam=[[0,1],[1,0]])\n",
+    "dut_dc_rational.name = 'rationnal'\n",
     "dut_dc_linear = dut.extrapolate_to_dc(kind='linear', dc_sparam=[[0,1],[1,0]])\n",
+    "dut_dc_linear.name = 'linear'\n",
     "dut_dc_cubic = dut.extrapolate_to_dc(kind='cubic', dc_sparam=[[0,1],[1,0]])\n",
+    "dut_dc_cubic.name = 'cubic'\n",
     "\n",
     "plt.figure()\n",
-    "plt.title('Step')\n",
-    "t, y = dut2.s11.step_response(pad=2000)\n",
-    "t2, y2 = dut_dc_rational.s11.step_response(pad=2000)\n",
-    "t3, y3 = dut_dc_linear.s11.step_response(pad=2000)\n",
-    "t4, y4 = dut_dc_cubic.s11.step_response(pad=2000)\n",
-    "plt.plot(t, y, label='Real')\n",
-    "plt.plot(t2, y2, label='Rational')\n",
-    "plt.plot(t3, y3, label='Linear')\n",
-    "plt.plot(t4, y4, label='Cubic')\n",
-    "plt.legend()\n",
-    "plt.xlabel('Time (ns)')\n",
+    "plt.title('Step Response Lowpass')\n",
+    "dut2.s11.plot_s_time_step(pad=2000, window='hamming')\n",
+    "dut_dc_rational.s11.plot_s_time_step(pad=2000, window='hamming')\n",
+    "dut_dc_linear.s11.plot_s_time_step(pad=2000, window='hamming')\n",
+    "dut_dc_cubic.s11.plot_s_time_step(pad=2000, window='hamming')\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.title('Impulse Response Lowpass')\n",
+    "dut2.s11.plot_s_time_impulse(pad=2000, window='hamming')\n",
+    "dut_dc_rational.s11.plot_s_time_impulse(pad=2000, window='hamming')\n",
+    "dut_dc_linear.s11.plot_s_time_impulse(pad=2000, window='hamming')\n",
+    "dut_dc_cubic.s11.plot_s_time_impulse(pad=2000, window='hamming')\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.title('Impulse Response Bandpass')\n",
+    "dut2.s11.plot_s_time(pad=2000, window='hamming')\n",
+    "(dut_dc_rational.s11.windowed()).plot_s_time()\n",
+    "(dut_dc_linear.s11.windowed()).plot_s_time()\n",
+    "(dut_dc_cubic.s11.windowed()).plot_s_time()\n",
     "\n",
     "plt.show(block=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -79,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -285,6 +285,8 @@ class Network(object):
         'time': s_to_time,
         'time_db': lambda x: mf.complex_2_db(s_to_time(x)),
         'time_mag': lambda x: mf.complex_2_magnitude(s_to_time(x)),
+        'time_impulse': None,
+        'time_step': None,
     }
     # provides y-axis labels to the plotting functions
     global Y_LABEL_DICT
@@ -308,6 +310,8 @@ class Network(object):
         'time': 'Time (real)',
         'time_db': 'Magnitude (dB)',
         'time_mag': 'Magnitude',
+        'time_impulse': 'Magnitude',
+        'time_step': 'Magnitude',
     }
 
     # CONSTRUCTOR

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -932,7 +932,7 @@ Examples
 
             def plot_func(self,  m=None, n=None, ax=None,
                 show_legend=True,attribute=attribute,
-                y_label=y_label,*args, **kwargs):
+                y_label=y_label, pad=0, window='hamming', *args, **kwargs):
 
                 # create index lists, if not provided by user
                 if m is None:
@@ -956,7 +956,6 @@ Examples
                 #was_interactive = plb.isinteractive
                 #if was_interactive:
                 #    plb.interactive(False)
-
                 for m in M:
                     for n in N:
                         # set the legend label for this trace to the networks
@@ -979,22 +978,46 @@ Examples
                                     (attribute[0].upper(),m+1,n+1)
                             kwargs['label'] = label_string
 
-                        # plot the desired attribute vs frequency
-                        if 'time' in attribute:
+                        # quick and dirty way to plot step and impulse response
+                        if 'time_impulse' in attribute:
                             xlabel = 'Time (ns)'
-                            x = self.frequency.t_ns
-
+                            x,y = self.impulse_response(pad=pad, window=window)
+                            plot_rectangular(
+                                        x = x,
+                                        y = y,
+                                        x_label = xlabel,
+                                        y_label = y_label,
+                                        show_legend = show_legend, ax = ax,
+                                        *args, **kwargs)
+                        elif 'time_step' in attribute:
+                            xlabel = 'Time (ns)'
+                            x,y = self.step_response(pad=pad, window=window)
+                            plot_rectangular(
+                                        x = x,
+                                        y = y,
+                                        x_label = xlabel,
+                                        y_label = y_label,
+                                        show_legend = show_legend, ax = ax,
+                                        *args, **kwargs)
+                            
                         else:
-                            xlabel = 'Frequency (%s)'%self.frequency.unit
-                            x = self.frequency.f_scaled
-
-                        plot_rectangular(
-                                x = x,
-                                y = getattr(self,attribute)[:,m,n],
-                                x_label = xlabel,
-                                y_label = y_label,
-                                show_legend = show_legend, ax = ax,
-                                *args, **kwargs)
+                            
+                            # plot the desired attribute vs frequency
+                            if 'time' in attribute:
+                                xlabel = 'Time (ns)'
+                                x = self.frequency.t_ns
+    
+                            else:
+                                xlabel = 'Frequency (%s)'%self.frequency.unit
+                                x = self.frequency.f_scaled
+    
+                            plot_rectangular(
+                                    x = x,
+                                    y = getattr(self,attribute)[:,m,n],
+                                    x_label = xlabel,
+                                    y_label = y_label,
+                                    show_legend = show_legend, ax = ax,
+                                    *args, **kwargs)
 
 
                 #if was_interactive:


### PR DESCRIPTION
First attempt to add plotting methods for impulse and step response function from @Ttl 
This solution does not satisfy me yet.

To be added directly to the Network class `COMPONENT_FUNC_DICT` dictionnary, the method has to be declared first, which sounds a bit impractical. The time axis has to be built in plotting.y for accounting to variable number of points depending on zero padding.

trough a dirty workaround, it is now possible to write:
```
plt.figure()
plt.title('Impulse Response Lowpass')
(dut2.s11.windowed()).plot_s_time(label='impulse bandpass')
dut2.s11.plot_s_time_impulse(pad=2000, window='hamming', label='impulse lowpass')
dut2.s11.plot_s_time_step(pad=2000, window='hamming', label='step lowpass')
plt.show(block=True)
```
![example_plot_step](https://user-images.githubusercontent.com/8080934/29715090-16da204e-89a6-11e7-9222-9fefca2a90e0.png)

Although it would be possible to just add and option to `Network.plot_s_time_step(z0=None)`, it would be nicer to have a more general methods in such a way e.g. `Network.plot_z_time_step()` would plot the step response with an impedance y-axis.
