### PR TITLE
add R&S ZVA instrument support

### DIFF
--- a/skrf/vi/scpi/parser.py
+++ b/skrf/vi/scpi/parser.py
@@ -96,10 +96,15 @@ def generate_set_string(command, command_root):
     command_string = " ".join((command_root, to_string(command["set"]))).strip()
     kwargs_string, scpi_command = parse_command_string(command_string)
 
+    if 'help' not in command:
+        command['help'] = 'no help available'
+    command['help'] = command['help'].replace('\t', '    ')
+
     function_string = \
 """def set_{:s}(self{:}):
+    \"\"\"{:s}\"\"\"
     scpi_command = {:}
-    self.write(scpi_command)""".format(command['name'], kwargs_string, scpi_command)
+    self.write(scpi_command)""".format(command['name'], kwargs_string, command['help'], scpi_command)
 
     return function_string
 
@@ -108,11 +113,16 @@ def generate_set_values_string(command, command_root):
     command_string = " ".join((command_root, to_string(command["set_values"]))).strip()
     kwargs_string, scpi_command, data_variable = parse_write_values_string(command_string)
 
+    if 'help' not in command:
+        command['help'] = 'no help available'
+    command['help'] = command['help'].replace('\t', '    ')
+
     function_string = \
 """def set_{:s}(self{:}):
+    \"\"\"{:s}\"\"\"
     scpi_command = {:}
     self.write_values(scpi_command, {:})""".format(
-            command['name'], kwargs_string, scpi_command, data_variable)
+            command['name'], kwargs_string, command['help'], scpi_command, data_variable)
 
     return function_string
 
@@ -120,6 +130,10 @@ def generate_set_values_string(command, command_root):
 def generate_query_string(command, command_root):
     command_string = "? ".join((command_root, to_string(command["query"]))).strip()
     kwargs_string, scpi_command = parse_command_string(command_string)
+
+    if 'help' not in command:
+        command['help'] = 'no help available'
+    command['help'] = command['help'].replace('\t', '    ')
 
     converter = command.get('returns', "str")
     valid_converters = ("int", "str", "float", "bool")
@@ -140,9 +154,10 @@ def generate_query_string(command, command_root):
 
     function_string = \
 """def query_{:s}(self{:}):
+    \"\"\"{:s}\"\"\"
     scpi_command = {:}
     value = self.query(scpi_command){:}
-    return value""".format(command['name'], kwargs_string, scpi_command, pre_line)
+    return value""".format(command['name'], kwargs_string, command['help'], scpi_command, pre_line)
 
     return function_string
 
@@ -151,11 +166,16 @@ def generate_query_values_string(command, command_root):
     command_string = "? ".join((command_root, to_string(command["query_values"]))).strip()
     kwargs_string, scpi_command = parse_command_string(command_string)
 
+    if 'help' not in command:
+        command['help'] = 'no help available'
+    command['help'] = command['help'].replace('\t', '    ')
+
     function_string = \
 """def query_{:s}(self{:}):
+    \"\"\"{:s}\"\"\"
     scpi_command = {:}
     return self.query_values(scpi_command)""".format(
-            command['name'], kwargs_string, scpi_command)
+            command['name'], kwargs_string, command['help'], scpi_command)
 
     return function_string
 
@@ -250,22 +270,22 @@ class_header = """class SCPI(object):
     def __init__(self, resource):
         self.resource = resource
         self.echo = False  # print scpi command string to scpi out
-    
+
     def write(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write(scpi, *args, **kwargs)
-    
+
     def query(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         return self.resource.query(scpi, *args, **kwargs)
-    
+
     def write_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write_values(scpi, *args, **kwargs)
-    
+
     def query_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)

--- a/skrf/vi/vna/__init__.py
+++ b/skrf/vi/vna/__init__.py
@@ -39,3 +39,4 @@ Available VNAs
 from .abcvna import VNA
 from .keysight_pna import PNA, PNAX
 from .keysight_fieldfox import FieldFox
+from .rs_zva import ZVA

--- a/skrf/vi/vna/parse_scpi.py
+++ b/skrf/vi/vna/parse_scpi.py
@@ -3,7 +3,7 @@ from skrf.vi.scpi.parser import parse_yaml_file
 yaml_files = [
     'keysight_pna_scpi.yaml',
     'keysight_fieldfox_scpi.yaml',
-    # 'rs_zva_scpi.yaml'
+    'rs_zva_scpi.yaml'
 ]
 
 for fname in yaml_files:

--- a/skrf/vi/vna/rs_zva.py
+++ b/skrf/vi/vna/rs_zva.py
@@ -1,0 +1,239 @@
+import warnings
+from collections import OrderedDict, Iterable
+
+import numpy as np
+import skrf
+import pyvisa
+
+from . import abcvna
+from . import rs_zva_scpi
+
+
+class ZVA(abcvna.VNA):
+    """
+    Class for modern Rohde&Schwarz ZVA Vector Network Analyzers
+    """
+
+    DEFAULT_VISA_ADDRESS = "GPIB::16::INSTR"
+    NAME = "R&S ZVA"
+    NPORTS = 4
+    NCHANNELS = 32
+    SCPI_VERSION_TESTED = 'A.09.20.08'  # taken from PNA class
+
+    def __init__(self, address=DEFAULT_VISA_ADDRESS, **kwargs):
+        """
+        initialization of ZVA Class
+
+        Parameters
+        ----------
+        address : str
+            visa resource string (full string or ip address)
+        kwargs : dict
+            interface (str), port (int), timeout (int),
+        :param address:
+        :param kwargs:
+        """
+        super(ZVA, self).__init__(address, **kwargs)
+        self.resource.timeout = kwargs.get("timeout", 2000)
+        self.scpi = rs_zva_scpi.SCPI(self.resource)
+        # self.use_binary()
+        #self.use_ascii()
+        print(self.idn)
+
+    def use_binary(self):
+        """setup the analyzer to transfer in binary which is faster, especially for large datasets"""
+        self.resource.write(':FORM:BORD SWAP')
+        self.resource.write(':FORM:DATA REAL,64')
+        self.resource.values_format.use_binary(datatype='d', is_big_endian=False, container=np.array)
+
+    def use_ascii(self):
+        self.resource.write(':FORM:DATA ASCII')
+        self.resource.values_format.use_ascii(converter='f', separator=',', container=np.array)
+
+    @property
+    def echo(self):
+        return self.scpi.echo
+
+    @echo.setter
+    def echo(self, onoff):
+        if onoff in (1, True):
+            self.scpi.echo = True
+        elif onoff in (0, False):
+            self.scpi.echo = False
+        else:
+            raise warnings.warn("echo must be a boolean")
+
+    @property
+    def active_channel(self):
+        old_timeout = self.resource.timeout
+        self.resource.timeout = 500
+        try:
+            channel = self.scpi.query_active_channel()
+        except pyvisa.VisaIOError:
+            print("No channel active, using 1")
+            channel = 1
+        finally:
+            self.resource.timeout = old_timeout
+        return channel
+
+    @active_channel.setter
+    def active_channel(self, channel):
+        """
+        Set the active channel on the analyzer
+
+        Parameters
+        ----------
+        channel : int
+
+        Notes
+        -----
+        There is no specific command to activate a channel, so we ask which channel we want and then activate the first
+        trace on that channel.  We do this because if the analyzer gets into a state where it doesn't recognize
+        any activated measurements, the get_snp_network method will fail, and possibly others as well.  That is why in
+        some methods you will see the fillowing line:
+        self.active_channel = channel = kwargs.get("channel", self.active_channel)
+        this way we force this property to be set, even if it just resets itself to the same value, but then a trace
+        will become active and our get_snp_network method will succeed.
+        """
+        # TODO: Good chance this will fail if no measurement is on the set channel, need to think about that...
+        mnum = self.scpi.query_meas_number_list(channel)[0]
+        self.scpi.set_selected_meas_by_number(channel, mnum)
+        return
+
+    def sweep(self, **kwargs):
+        """
+        Initialize a fresh sweep of data on the specified channels
+
+        Parameters
+        ----------
+        kwargs : dict
+            channel ("all", int or list of channels), timeout (milliseconds)
+
+        trigger a fresh sweep on the specified channels (default is "all" if no channel specified)
+        Autoset timeout and sweep mode based upon the analyzers current averaging setting,
+        and then return to the prior state of continuous trigger or hold.
+        """
+        #self.resource.clear()
+        self.scpi.set_trigger_source("IMM")
+        original_timeout = self.resource.timeout
+
+        # expecting either an int or a list of ints for the channel(s)
+        channels_to_sweep = kwargs.get("channels", None)
+        if not channels_to_sweep:
+            channels_to_sweep = kwargs.get("channel", "all")
+        if not type(channels_to_sweep) in (list, tuple):
+            channels_to_sweep = [channels_to_sweep]
+        channels = self.scpi.query_available_channels()
+
+        for i, channel in enumerate(channels):
+            sweep_mode = self.scpi.query_sweep_mode(channel)
+            was_continuous = "CONT" in sweep_mode.upper()
+            sweep_time = self.scpi.query_sweep_time(channel)
+            averaging_on = self.scpi.query_averaging_state(channel)
+            averaging_mode = self.scpi.query_averaging_mode(channel)
+
+            if averaging_on and "SWE" in averaging_mode.upper():
+                sweep_mode = "GROUPS"
+                number_of_sweeps = self.scpi.query_averaging_count(channel)
+                self.scpi.set_groups_count(channel, number_of_sweeps)
+                number_of_sweeps *= self.nports
+            else:
+                sweep_mode = "SINGLE"
+                number_of_sweeps = self.nports
+            channels[i] = {
+                "cnum": channel,
+                "sweep_time": sweep_time,
+                "number_of_sweeps": number_of_sweeps,
+                "sweep_mode": sweep_mode,
+                "was_continuous": was_continuous
+            }
+            self.scpi.set_sweep_mode(channel, "HOLD")
+        timeout = kwargs.get("timeout", None)  # recommend not setting this variable, as autosetting is preferred
+
+        try:
+            for channel in channels:
+                import time
+                if "all" not in channels_to_sweep and channel["cnum"] not in channels_to_sweep:
+                    continue  # default for sweep is all, else if we specify, then sweep
+                if not timeout:  # autoset timeout based on sweep time
+                    sweep_time = channel["sweep_time"] * channel[
+                        "number_of_sweeps"] * 1000  # convert to milliseconds, and double for buffer
+                    self.resource.timeout = max(sweep_time * 2, 5000)  # give ourselves a minimum 5 seconds for a sweep
+                else:
+                    self.resource.timeout = timeout
+                self.scpi.set_sweep_mode(channel["cnum"], channel["sweep_mode"])
+                self.wait_until_finished()
+        finally:
+            self.resource.clear()
+            for channel in channels:
+                if channel["was_continuous"]:
+                    self.scpi.set_sweep_mode(channel["cnum"], "CONT")
+            self.resource.timeout = original_timeout
+        return
+
+    def get_frequency(self, **kwargs):
+        """
+        get an skrf.Frequency object for the current channel
+
+        Parameters
+        ----------
+        kwargs : dict
+            channel (int), f_unit (str)
+
+        Returns
+        -------
+        skrf.Frequency
+        """
+        #self.resource.clear()
+        channel = kwargs.get("channel", self.active_channel)
+        use_log = "LOG" in self.scpi.query_sweep_type(channel).upper()
+        f_start = self.scpi.query_f_start(channel)
+        f_stop = self.scpi.query_f_stop(channel)
+        f_npoints = self.scpi.query_sweep_n_points(channel)
+        if use_log:
+            freq = np.logspace(np.log10(f_start), np.log10(f_stop), f_npoints)
+        else:
+            freq = np.linspace(f_start, f_stop, f_npoints)
+
+        frequency = skrf.Frequency.from_f(freq, unit="Hz")
+        frequency.unit = kwargs.get("f_unit", "Hz")
+        return frequency
+
+    def set_frequency_sweep(self, f_start, f_stop, f_npoints, **kwargs):
+        f_unit = kwargs.get("f_unit", "hz").lower()
+        if f_unit != "hz":
+            f_start = self.to_hz(f_start, f_unit)
+            f_stop = self.to_hz(f_stop, f_unit)
+        channel = kwargs.get("channel", self.active_channel)
+        self.scpi.set_f_start(channel, f_start)
+        self.scpi.set_f_stop(channel, f_stop)
+        self.scpi.set_sweep_n_points(f_npoints)
+
+    def get_measurement(self, mname=None, mnum=None, **kwargs):
+        """
+        get a measurement trace from the analyzer, specified by either name or number
+
+        Parameters
+        ----------
+        mname : str
+            the name of the measurement, e.g. 'CH1_S11_1'
+        mnum : int
+            the number of number of the measurement
+        kwargs : dict
+            channel (int), sweep (bool)
+
+        Returns
+        -------
+        skrf.Network
+        """
+        if mname is None and mnum is None:
+            raise ValueError("must provide either a measurement mname or a mnum")
+
+        channel = kwargs.get("channel", self.active_channel)
+
+        if type(mname) is str:
+            self.scpi.set_selected_meas(channel, mname)
+        else:
+            self.scpi.set_selected_meas_by_number(channel, mnum)
+        return self.get_active_trace_as_network(**kwargs)
+

--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -1,0 +1,877 @@
+import re
+
+null_parameter = re.compile(",{2,}")  # detect optional null parameter as two consecutive commas, and remove
+converters = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": lambda x: bool(int(x)),
+}
+
+
+def to_string(value):
+    tval = type(value)
+    if tval is str:
+        return value
+    elif tval is bool:
+        return str(int(value))
+    elif tval in (list, tuple):
+        return ",".join(map(to_string, value))
+    elif value is None:
+        return ""
+    else:
+        return str(value)
+
+
+def scpi_preprocess(command_string, *args):
+    args = list(args)
+    for i, arg in enumerate(args):
+        args[i] = to_string(arg)
+    cmd = command_string.format(*args)
+    return null_parameter.sub(",", cmd)
+
+
+def process_query(query, csv=False, strip_outer_quotes=True, returns="str"):
+    if strip_outer_quotes is True:
+        if query[0] + query[-1] in ('""', "''"):
+            query = query[1:-1]
+    if csv is True:
+        query = query.split(",")
+
+    converter = None if returns == "str" else converters.get(returns, None)
+    if converter:
+        if csv is True:
+            query = list(map(converter, query))
+        else:
+            query = converter(query)
+
+    return query
+
+
+class SCPI(object):
+    def __init__(self, resource):
+        self.resource = resource
+        self.echo = False  # print scpi command string to scpi out
+
+    def write(self, scpi, *args, **kwargs):
+        if self.echo:
+            print(scpi)
+        self.resource.write(scpi, *args, **kwargs)
+
+    def query(self, scpi, *args, **kwargs):
+        if self.echo:
+            print(scpi)
+        return self.resource.query(scpi, *args, **kwargs)
+
+    def write_values(self, scpi, *args, **kwargs):
+        if self.echo:
+            print(scpi)
+        self.resource.write_values(scpi, *args, **kwargs)
+
+    def query_values(self, scpi, *args, **kwargs):
+        if self.echo:
+            print(scpi)
+        return self.resource.query_values(scpi, *args, **kwargs)
+
+    def set_active_channel(self, channel=1):
+        """Selects channel as the active channel.
+    
+         INSTrument:NSELect <Channel>
+         """
+        scpi_command = scpi_preprocess(":INST:NSEL {:}", channel)
+        self.write(scpi_command)
+
+    def set_averaging_clear(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:AVER:CLE", cnum)
+        self.write(scpi_command)
+
+    def set_averaging_count(self, cnum=1, FACTOR=10):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:AVER:COUN {:}", cnum, FACTOR)
+        self.write(scpi_command)
+
+    def set_averaging_state(self, cnum=1, ONOFF="ON"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:AVER:STAT {:}", cnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_converter_mode(self, cnum=1, MODE="RILI"):
+        """Selects the test setup (internal or external sources) for the frequency converter measurement (with option ZVA-K8, Converter Control).
+    
+         [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
+    
+         The available test setups depend on the instrument type:
+    
+                             RILI    RILE    RILI4    RILI56
+         ---------------------------------------------------
+         R&S ZVA 24|40|50      x      x
+         R&S ZVA 67                   x        x
+         R&S ZVT 20                            x        x
+    
+         <Ch>    Channel number. This suffix is ignored, the command affects all channels.
+         RILI    RF internal, LO internal (4-Port)
+                 Ports 1 and 2: Converter RF Signal
+                 Ports 3 and 4: Converter LO
+         RILE    RF internal, LO external (4-Port)
+                 Ports 1 to 4: Converter RF Signal
+                 External Generator #1: Converter LO
+         RILI4    RF internal, LO internal, Port4=LO (R&S ZVA 67 only)
+                 Ports 1 and 2: Converter RF Signal
+                 Port 4: Converter LO
+         RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
+                 Ports 1 to 4: Converter RF Signal
+                 Ports 5 and 6: Converter LO 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE {:}", cnum, MODE)
+        self.write(scpi_command)
+
+    def set_converter_name(self, cnum=1, TYPE=""):
+        """Selects the frequency converter type for enhanced frequency-converting measurements (with option ZVA-K8, Converter Control).
+    
+         The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
+         and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
+    
+         [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
+    
+         <Ch>                Channel number.
+                             This suffix is ignored, the command affects all channels.
+         '<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110
+                             '' - No frequency converter selected 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME {:}", cnum, TYPE)
+        self.write(scpi_command)
+
+    def set_corr_connection(self, cnum=1, pnum=1, CONN=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:} {:}", cnum, pnum, CONN)
+        self.write(scpi_command)
+
+    def set_corr_connection_genders(self, cnum=1, pnum=1, GENDERS="ALL"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:}:GEND {:}", cnum, pnum, GENDERS)
+        self.write(scpi_command)
+
+    def set_corr_connection_ports(self, cnum=1, pnum=1, PORTS="ALL"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:}:PORT {:}", cnum, pnum, PORTS)
+        self.write(scpi_command)
+
+    def set_corr_state(self, cnum=1, STATE="ON"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:STAT {:}", cnum, STATE)
+        self.write(scpi_command)
+
+    def set_data(self, cnum=1, SDATA="", data=None):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA {:},", cnum, SDATA)
+        self.write_values(scpi_command, data)
+
+    def set_disp_color(self, COLOR="DBAC"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SYST:DISP:COL {:}", COLOR)
+        self.write(scpi_command)
+
+    def set_disp_maximize(self, wnum=1, ONOFF="OFF"):
+        """Maximizes all diagram areas in the active setup or restores the previous display configuration."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:MAX {:}", wnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_disp_name(self, wnum=1, name=""):
+        """Defines a name for diagram area <Wnd>.
+    
+         The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME {:}", wnum, name)
+        self.write(scpi_command)
+
+    def set_disp_state(self, wnum=1, ONOFF=""):
+        """Creates or deletes a diagram area, identified by its area number <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:STATe <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT {:}", wnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_disp_title_data(self, wnum=1, TITLE=""):
+        """Defines a title for diagram area <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA {:}", wnum, TITLE)
+        self.write(scpi_command)
+
+    def set_disp_title_state(self, wnum=1, ONOFF="ON"):
+        """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
+    
+         DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT {:}", wnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_disp_trace_auto(self, wnum=1, tnum=1, TRACENAME="None"):
+        """Displays the entire trace in the diagram area, leaving an appropriate display margin.
+    
+         The trace can be referenced either by its number <WndTr> or by its name <trace_name>.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:AUTO ONCE[, '<trace_name>']
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:AUTO ONCE,'{:}'", wnum, tnum, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_bottom(self, wnum=1, tnum=1, lower_value="", TRACENAME="None"):
+        """Sets the lower (minimum) edge of the diagram area <Wnd>."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:BOTT {:},{:}", wnum, tnum, lower_value, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_delete(self, wnum=1, tnum=1):
+        """Releases the assignment between a trace and a diagram area.
+    
+         As defined by means of DISPlay:WINDow<Wnd>:TRACe<WndTr>:FEED <Trace_Name>
+         and expressed by the <WndTr> suffix. The trace itself is not deleted; this
+         must be done via CALCulate<Ch>:PARameter:DELete <Trace_Name>.
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:DEL", wnum, tnum)
+        self.write(scpi_command)
+
+    def set_disp_trace_efeed(self, wnum=1, tnum=1, TRACENAME=""):
+        """Assigns an existing trace to a diagram area.
+    
+         Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
+         to a diagram area <Wnd>, and displays the trace. Use
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:FEED to assign the trace to a diagram area
+         using a numeric suffix (e.g. in order to use the
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y:OFFSet command).
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:EFE {:}", wnum, tnum, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_feed(self, wnum=1, tnum=1, TRACENAME=""):
+        """Assigns an existing traceto a diagram area.
+    
+         Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
+         to a diagram area, using the <WndTr> suffix, and displays the trace. Use
+         DISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area
+         without using a numeric suffix.
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:FEED {:}", wnum, tnum, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_pdiv(self, wnum=1, tnum=1, value="", TRACENAME="None"):
+        """Sets the value between two grid lines (value “per division”) for the diagram area <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:PDIVision  <numeric_value>[, '<trace_name>']
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:PDIV {:},{:}", wnum, tnum, value, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_reflevel(self, wnum=1, tnum=1, value="", TRACENAME="None"):
+        """Sets the reference level (or reference value) for a particular displayed trace.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']     """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RLEV {:},{:}", wnum, tnum, value, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_refpos(self, wnum=1, tnum=1, value="", TRACENAME="None"):
+        """Sets the point on the y-axis to be used as the reference position as a percentage of the length of the y-axis.
+    
+     DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RPOS {:},{:}", wnum, tnum, value, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_show(self, wnum=1, tnum=1, DMTRACES="", TRACENAME=""):
+        """Displays or hides an existing trace, identified by its trace name, or a group of traces.
+    
+         Displays or hides an existing trace, identified by its trace name
+         (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW {:} {:}", wnum, tnum, DMTRACES, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_top(self, wnum=1, tnum=1, upper_value="", TRACENAME="None"):
+        """Sets the upper (maximum) edge of the diagram area <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:TOP  <upper_value>[, '<trace_name>']
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:TOP {:},{:}", wnum, tnum, upper_value, TRACENAME)
+        self.write(scpi_command)
+
+    def set_disp_trace_x_offset(self, wnum=1, tnum=1, range=""):
+        """Shifts the trace <WndTr> in horizontal direction, leaving the positions of all markers unchanged."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:X:OFFS {:}", wnum, tnum, range)
+        self.write(scpi_command)
+
+    def set_disp_trace_y_offset(self, wnum=1, tnum=1, MAG="", PHASE=0, REAL=0, IMAG=0):
+        """Modifies all points of the trace <WndTr> by means of an added and/or a multiplied complex constant."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:OFFS {:}{:}{:}{:}", wnum, tnum, MAG, PHASE, REAL, IMAG)
+        self.write(scpi_command)
+
+    def set_disp_update(self, UPDATE="OFF"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SYST:DISP:UPD {:}", UPDATE)
+        self.write(scpi_command)
+
+    def set_f_start(self, cnum=1, freq=""):
+        """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
+    
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR {:}", cnum, freq)
+        self.write(scpi_command)
+
+    def set_f_stop(self, cnum=1, freq=""):
+        """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
+    
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP {:}", cnum, freq)
+        self.write(scpi_command)
+
+    def set_init_continuous(self, cnum=1, STATE="ON"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":INIT{:}:CONT {:}", cnum, STATE)
+        self.write(scpi_command)
+
+    def set_init_immediate(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":INIT{:}:IMM", cnum)
+        self.write(scpi_command)
+
+    def set_init_immediate_scope(self, cnum=1, SCOPE="ALL"):
+        """no help available"""
+        scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP {:}", cnum, SCOPE)
+        self.write(scpi_command)
+
+    def set_par_del(self, cnum=1, TRACE=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL '{:}'", cnum, TRACE)
+        self.write(scpi_command)
+
+    def set_par_del_all(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:ALL", cnum)
+        self.write(scpi_command)
+
+    def set_par_del_call(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:CALL", cnum)
+        self.write(scpi_command)
+
+    def set_par_del_sgroup(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:SGR", cnum)
+        self.write(scpi_command)
+
+    def set_par_sdef(self, cnum=1, TRACE="", COEFF=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:SDEF '{:}', '{:}'", cnum, TRACE, COEFF)
+        self.write(scpi_command)
+
+    def set_par_sdef_sgroup(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:SDEF:SGR", cnum)
+        self.write(scpi_command)
+
+    def set_par_select(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL 'TRACE'", cnum)
+        self.write(scpi_command)
+
+    def set_rbw(self, cnum=1, BW=""):
+        """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
+    
+         <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
+         <bandwidth>
+         Resolution bandwidth
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:RES {:}", cnum, BW)
+        self.write(scpi_command)
+
+    def set_rbw_reduction(self, cnum=1, ONOFF="OFF"):
+        """Enables or disables dynamic bandwidth reduction at low frequencies.
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
+    
+         <Ch>        Channel number
+         <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:DRED {:}", cnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_rbw_select(self, cnum=1):
+        """Defines the selectivity of the IF filter for an unsegmented sweep.
+    
+         The value is also used for all segments of a segmented sweep,
+         provided that separate selectivity setting is disabled
+         ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL", cnum)
+        self.write(scpi_command)
+
+    def set_sweep_count(self, cnum=1, NUMSWEEP=1):
+        """Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."""
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN {:}", cnum, NUMSWEEP)
+        self.write(scpi_command)
+
+    def set_sweep_n_points(self, cnum=1, NUMPOINTS=201):
+        """Defines the total number of measurement points per sweep (Number of Points)."""
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:POIN {:}", cnum, NUMPOINTS)
+        self.write(scpi_command)
+
+    def set_sweep_spacing(self, cnum=1, SPACING="LIN"):
+        """Defines the frequency vs. time characteristics of a frequency sweep
+    
+         (Lin. Frequency or Log Frequency). The command has no effect on segmented
+         frequency, power or time sweeps.
+    
+         [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC {:}", cnum, SPACING)
+        self.write(scpi_command)
+
+    def set_sweep_step(self, cnum=1, step_size=""):
+        """Sets the distance between two consecutive sweep points.
+    
+         [SENSe<Ch>:]SWEep:STEP <step_size>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP {:}", cnum, step_size)
+        self.write(scpi_command)
+
+    def set_sweep_time(self, cnum=1, duration=""):
+        """Sets the duration of the sweep (Sweep Time).
+    
+         Setting a duration disables the automatic calculation of the (minimum) sweep time;
+         see [SENSe<Ch>:]SWEep:TIME:AUTO.
+    
+         [SENSe<Ch>:]SWEep:TIME <duration>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME {:}", cnum, duration)
+        self.write(scpi_command)
+
+    def set_sweep_time_auto(self, cnum=1, ONOFF="ON"):
+        """When enabled, the (minimum) sweep duration is calculated internally
+    
+         using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
+    
+         [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO {:}", cnum, ONOFF)
+        self.write(scpi_command)
+
+    def set_sweep_type(self, cnum=1, TYPE="LIN"):
+        """Selects the sweep type,
+    
+         i.e. the sweep variable (frequency/power/time) and the position of the
+         sweep points across the sweep range.
+    
+         [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE {:}", cnum, TYPE)
+        self.write(scpi_command)
+
+    def query_active_channel(self):
+        """Selects channel as the active channel.
+    
+         INSTrument:NSELect <Channel>
+         """
+        scpi_command = ":INST:NSEL?"
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
+        return value
+
+    def query_average_factor_current(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:AVER:COUN:CURR?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
+        return value
+
+    def query_averaging_state(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:AVER:STAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_converter_mode(self, cnum=1):
+        """Selects the test setup (internal or external sources) for the frequency converter measurement (with option ZVA-K8, Converter Control).
+    
+         [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
+    
+         The available test setups depend on the instrument type:
+    
+                             RILI    RILE    RILI4    RILI56
+         ---------------------------------------------------
+         R&S ZVA 24|40|50      x      x
+         R&S ZVA 67                   x        x
+         R&S ZVT 20                            x        x
+    
+         <Ch>    Channel number. This suffix is ignored, the command affects all channels.
+         RILI    RF internal, LO internal (4-Port)
+                 Ports 1 and 2: Converter RF Signal
+                 Ports 3 and 4: Converter LO
+         RILE    RF internal, LO external (4-Port)
+                 Ports 1 to 4: Converter RF Signal
+                 External Generator #1: Converter LO
+         RILI4    RF internal, LO internal, Port4=LO (R&S ZVA 67 only)
+                 Ports 1 and 2: Converter RF Signal
+                 Port 4: Converter LO
+         RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
+                 Ports 1 to 4: Converter RF Signal
+                 Ports 5 and 6: Converter LO 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_converter_name(self, cnum=1):
+        """Selects the frequency converter type for enhanced frequency-converting measurements (with option ZVA-K8, Converter Control).
+    
+         The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
+         and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
+    
+         [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
+    
+         <Ch>                Channel number.
+                             This suffix is ignored, the command affects all channels.
+         '<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110
+                             '' - No frequency converter selected 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_corr_connection(self, cnum=1, pnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:}?", cnum, pnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_corr_connection_genders(self, cnum=1, pnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:}:GEND?", cnum, pnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_corr_connection_ports(self, cnum=1, pnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:COLL:CONN{:}:PORT?", cnum, pnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_corr_date(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:DATE?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_corr_state(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:CORR:STAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_data(self, cnum=1, SDATA=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA? {:}", cnum, SDATA)
+        return self.query_values(scpi_command)
+
+    def query_data_all(self, cnum=1, SDATA=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA:ALL? {:}", cnum, SDATA)
+        return self.query_values(scpi_command)
+
+    def query_data_call(self, cnum=1, SDATA=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA:CALL? {:}", cnum, SDATA)
+        return self.query_values(scpi_command)
+
+    def query_data_call_catalog(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA:CALL:CAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_data_dall(self, cnum=1, SDATA=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA:DALL? {:}", cnum, SDATA)
+        return self.query_values(scpi_command)
+
+    def query_data_sgroup(self, cnum=1, SDATA=""):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:DATA:SGR? {:}", cnum, SDATA)
+        return self.query_values(scpi_command)
+
+    def query_disp_catalog(self, wnum=1):
+        """Returns the numbers and names of all diagram areas in the current setup."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:CAT?", wnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_disp_name(self, wnum=1):
+        """Defines a name for diagram area <Wnd>.
+    
+         The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME?", wnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_disp_state(self, wnum=1):
+        """Creates or deletes a diagram area, identified by its area number <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:STATe <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT?", wnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_disp_title_data(self, wnum=1):
+        """Defines a title for diagram area <Wnd>.
+    
+         DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA?", wnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_disp_title_state(self, wnum=1):
+        """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
+    
+         DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT?", wnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_disp_trace_catalog(self, wnum=1, tnum=1):
+        """Returns the numbers and names of all traces in diagram area no. <Wnd>."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:CAT?", wnum, tnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_disp_trace_show(self, wnum=1, tnum=1, DMTRACES=""):
+        """Displays or hides an existing trace, identified by its trace name, or a group of traces.
+    
+         Displays or hides an existing trace, identified by its trace name
+         (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
+    
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
+         """
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW? {:}", wnum, tnum, DMTRACES)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_disp_trace_x_offset(self, wnum=1, tnum=1):
+        """Shifts the trace <WndTr> in horizontal direction, leaving the positions of all markers unchanged."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:X:OFFS?", wnum, tnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_disp_trace_y_offset(self, wnum=1, tnum=1):
+        """Modifies all points of the trace <WndTr> by means of an added and/or a multiplied complex constant."""
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:OFFS?", wnum, tnum)
+        return self.query_values(scpi_command)
+
+    def query_f_start(self, cnum=1):
+        """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
+    
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
+        return value
+
+    def query_f_stop(self, cnum=1):
+        """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
+    
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
+        return value
+
+    def query_init_continuous(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":INIT{:}:CONT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_init_immediate_scope(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_par_catalog(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:CAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_par_select(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_rbw(self, cnum=1):
+        """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
+    
+         <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
+         <bandwidth>
+         Resolution bandwidth
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:RES?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_rbw_reduction(self, cnum=1):
+        """Enables or disables dynamic bandwidth reduction at low frequencies.
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
+    
+         <Ch>        Channel number
+         <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:DRED?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_rbw_select(self, cnum=1):
+        """Defines the selectivity of the IF filter for an unsegmented sweep.
+    
+         The value is also used for all segments of a segmented sweep,
+         provided that separate selectivity setting is disabled
+         ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
+    
+         [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
+        """
+        scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_sweep_count(self, cnum=1):
+        """Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."""
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
+        return value
+
+    def query_sweep_n_points(self, cnum=1):
+        """Defines the total number of measurement points per sweep (Number of Points)."""
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:POIN?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
+        return value
+
+    def query_sweep_spacing(self, cnum=1):
+        """Defines the frequency vs. time characteristics of a frequency sweep
+    
+         (Lin. Frequency or Log Frequency). The command has no effect on segmented
+         frequency, power or time sweeps.
+    
+         [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_sweep_step(self, cnum=1):
+        """Sets the distance between two consecutive sweep points.
+    
+         [SENSe<Ch>:]SWEep:STEP <step_size>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_sweep_time(self, cnum=1):
+        """Sets the duration of the sweep (Sweep Time).
+    
+         Setting a duration disables the automatic calculation of the (minimum) sweep time;
+         see [SENSe<Ch>:]SWEep:TIME:AUTO.
+    
+         [SENSe<Ch>:]SWEep:TIME <duration>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_sweep_time_auto(self, cnum=1):
+        """When enabled, the (minimum) sweep duration is calculated internally
+    
+         using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
+    
+         [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
+    def query_sweep_type(self, cnum=1):
+        """Selects the sweep type,
+    
+         i.e. the sweep variable (frequency/power/time) and the position of the
+         sweep points across the sweep range.
+    
+         [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
+         """
+        scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_system_err_next(self):
+        """no help available"""
+        scpi_command = ":SYST:ERR:NEXT?"
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_system_error_all(self):
+        """no help available"""
+        scpi_command = ":SYST:ERR:ALL?"
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -1,0 +1,286 @@
+# vim: shiftwidth=2
+# R&S ZVA SCPI online manual: https://www.rohde-schwarz.com/webhelp/webhelp_zva/start.htm
+
+DEFAULTS:
+  csv: False
+  returns: str
+  strip_outer_quotes: True
+  kwarg_value: ""
+COMMAND_TREE:
+  CALC<cnum=1>:
+    DATA:
+      command: {name: data, set_values: "<SDATA>,<data>", query_values: "<SDATA>"}
+      branch:
+        ALL: {name: data_all, query_values: "<SDATA>"}
+        CALL:
+          command: {name: data_call, query_values: "<SDATA>"}
+          branch:
+            CAT: {name: data_call_catalog, query: ""}
+        DALL: {name: data_dall, query_values: "<SDATA>"}
+        SGR: {name: data_sgroup, query_values: "<SDATA>"}
+    PAR:
+      CAT: {name: par_catalog, query: ""}
+      DEL:
+        command: {name: par_del, set: "'<TRACE>'"}
+        branch:
+          ALL: {name: par_del_all, set: ""}
+          CALL: {name: par_del_call, set: ""}
+          SGR: {name: par_del_sgroup, set: ""}
+      SDEF:
+        command: {name: par_sdef, set: "'<TRACE>', '<COEFF>'"}
+        branch:
+          SGR: {name: par_sdef_sgroup, set: ""}
+      SEL: {name: par_select, set: "'TRACE'", query: ""}
+  DISP:
+    WIND<wnum=1>:
+      CAT: {name: disp_catalog, query: "",
+        help: "Returns the numbers and names of all diagram areas in the current setup."
+      }
+      MAX: {name: disp_maximize, set: "<ONOFF=OFF>", returns: bool,
+        help: "Maximizes all diagram areas in the active setup or restores the previous display configuration."
+      }
+      NAME: {name: disp_name, set: "<name>", query: "",
+        help: "Defines a name for diagram area <Wnd>.\n\n
+        \tThe name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.\n
+        \t"
+      }
+      STAT: {name: disp_state, set: "<ONOFF>", query: "", returns: bool,
+        help: "Creates or deletes a diagram area, identified by its area number <Wnd>.\n\n
+        \tDISPlay[:WINDow<Wnd>]:STATe <Boolean>\n
+        \t"
+      }
+      TITL:
+        DATA: {name: disp_title_data, set: "<TITLE>", query: "",
+          help: "Defines a title for diagram area <Wnd>.\n\n
+          \tDISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'\n
+          \t"
+        }
+        STAT: {name: disp_title_state, set: "<ONOFF=ON>", query: "", returns: bool,
+          help: "Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.\n\n
+          \tDISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>\n
+          \t"
+        }
+      TRAC<tnum=1>:
+        CAT: {name: disp_trace_catalog, query: "",
+          help: "Returns the numbers and names of all traces in diagram area no. <Wnd>."
+        }
+        DEL: {name: disp_trace_delete, set: "",
+          help: "Releases the assignment between a trace and a diagram area.\n\n
+          \tAs defined by means of DISPlay:WINDow<Wnd>:TRACe<WndTr>:FEED <Trace_Name>\n
+          \tand expressed by the <WndTr> suffix. The trace itself is not deleted; this\n
+          \tmust be done via CALCulate<Ch>:PARameter:DELete <Trace_Name>.\n
+          \t"
+        }
+        EFE: {name: disp_trace_efeed, set: "<TRACENAME>",
+          help: "Assigns an existing trace to a diagram area.\n\n
+          \tAssigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)\n
+          \tto a diagram area <Wnd>, and displays the trace. Use\n
+          \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:FEED to assign the trace to a diagram area\n
+          \tusing a numeric suffix (e.g. in order to use the\n
+          \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y:OFFSet command).\n\n
+          \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'\n
+          \t"
+        }
+        FEED: {name: disp_trace_feed, set: "<TRACENAME>",
+          help: "Assigns an existing traceto a diagram area.\n\n
+          \tAssigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)\n
+          \tto a diagram area, using the <WndTr> suffix, and displays the trace. Use\n
+          \tDISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area\n
+          \twithout using a numeric suffix.\n
+          \t"
+        }
+        SHOW: {name: disp_trace_show, set: "<DMTRACES> <TRACENAME>", query: "<DMTRACES>", returns: bool,
+          help: "Displays or hides an existing trace, identified by its trace name, or a group of traces.\n\n
+          \tDisplays or hides an existing trace, identified by its trace name\n
+          \t(CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.\n\n
+          \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>\n
+          \t"
+        }
+        X:
+          OFFS:  {name: disp_trace_x_offset, set: "<range>", query: "",
+            help: "Shifts the trace <WndTr> in horizontal direction, leaving the positions of all markers unchanged."
+          }
+        Y:
+          OFFS:  {name: disp_trace_y_offset, set: "<MAG><PHASE=0><REAL=0><IMAG=0>", query_values: "",
+            help: "Modifies all points of the trace <WndTr> by means of an added and/or a multiplied complex constant."
+          }
+          SCAL:
+            AUTO: {name: disp_trace_auto, set: "ONCE,'<TRACENAME=None>'",
+              help: "Displays the entire trace in the diagram area, leaving an appropriate display margin.\n\n
+              \tThe trace can be referenced either by its number <WndTr> or by its name <trace_name>.\n\n
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:AUTO ONCE[, '<trace_name>']\n
+              \t"
+            }
+            BOTT:  {name: disp_trace_bottom, set: "<lower_value>,<TRACENAME=None>",
+              help: "Sets the lower (minimum) edge of the diagram area <Wnd>."
+            }
+            PDIV: {name: disp_trace_pdiv, set: "<value>,<TRACENAME=None>",
+              help: "Sets the value between two grid lines (value “per division”) for the diagram area <Wnd>.\n\n
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:PDIVision  <numeric_value>[, '<trace_name>']\n
+              \t"
+            }
+            RLEV:  {name: disp_trace_reflevel, set: "<value>,<TRACENAME=None>",
+              help: "Sets the reference level (or reference value) for a particular displayed trace.\n\n
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']
+              \t"
+            }
+            RPOS: {name: disp_trace_refpos, set: "<value>,<TRACENAME=None>",
+              help: "Sets the point on the y-axis to be used as the reference position as a percentage of the length of the y-axis.\n\n
+              DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']\n
+              \t"
+              }
+            TOP: {name: disp_trace_top, set: "<upper_value>,<TRACENAME=None>",
+              help: "Sets the upper (maximum) edge of the diagram area <Wnd>.\n\n
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:TOP  <upper_value>[, '<trace_name>']\n
+              \t"
+              }
+  INIT<cnum=1>:
+    CONT: {name: init_continuous, set: "<STATE=ON>", query: ""}
+    IMM:
+      command: {name: init_immediate, set: ""}
+      branch:
+        SCOP: {name: init_immediate_scope, set: "<SCOPE=ALL>", query: ""}
+  INST:
+    NSEL: {name: active_channel, set: "<channel=1>", query: "", returns: int,
+      help: "Selects channel as the active channel.\n\n
+        \tINSTrument:NSELect <Channel>\n
+        \t"
+      }
+  SENS<cnum=1>:
+    AVER:
+      CLE: {name: averaging_clear, set: ""}
+      COUN:
+        command: {name: averaging_count, set: "<FACTOR=10>"}
+        branch:
+          CURR: {name: average_factor_current, query: "", returns: "int"}
+      STAT: {name: averaging_state, set: "<ONOFF=ON>", query: "", returns: bool}
+    BAND:
+      RES: {name: rbw, set: "<BW>", query: "",
+        help: "Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).\n\n
+        \t[SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>\n\n
+        \t<Ch>  Channel number. If unspecified the numeric suffix is set to 1.\n
+        \t<bandwidth>\n
+        \tResolution bandwidth\n\t"
+      }
+      DRED: {name: rbw_reduction, set: "<ONOFF=OFF>", query: "", returns: bool,
+        help: "Enables or disables dynamic bandwidth reduction at low frequencies.\n\n
+        \t[SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>\n\n
+        \t<Ch>\t\tChannel number\n
+        \t<Boolean>\tON | OFF – enable or disable dynamic bandwidth reduction.\n\t"
+      }
+      SEL: {name: rbw_select, set: "", query: "",
+        help: "Defines the selectivity of the IF filter for an unsegmented sweep.\n\n
+        \tThe value is also used for all segments of a segmented sweep,\n
+        \tprovided that separate selectivity setting is disabled\n
+        \t([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).\n\n
+        \t[SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH\n\t"
+      }
+    CORR:
+      COLL:
+        CONN<pnum=1>:
+          command: {name: corr_connection, set: "<CONN>", query: ""}
+          branch:
+            PORT: {name: corr_connection_ports, set: "<PORTS=ALL>", query: ""}
+            GEND: {name: corr_connection_genders, set: "<GENDERS=ALL>", query: ""}
+      DATE: {name: corr_date, query: ""}
+      STAT: {name: corr_state, set: "<STATE=ON>", query: ""}
+    FREQ:
+      CONV:
+        DEV:
+          MODE: {name: converter_mode, set: "<MODE=RILI>", query: "",
+            help: "Selects the test setup (internal or external sources) for the frequency
+            converter measurement (with option ZVA-K8, Converter Control).\n\n
+            \t[SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56\n\n
+            \tThe available test setups depend on the instrument type:\n\n
+            \t\t\t\t\t\tRILI\tRILE\tRILI4\tRILI56\n
+            \t---------------------------------------------------\n
+            \tR&S ZVA 24|40|50\t  x\t  x\n
+            \tR&S ZVA 67\t\t\t\t   x\t\tx\n
+            \tR&S ZVT 20\t\t\t\t\t\t\tx\t\tx\n\n
+            \t<Ch>\tChannel number. This suffix is ignored, the command affects all channels.\n
+            \tRILI\tRF internal, LO internal (4-Port)\n
+            \t\t\tPorts 1 and 2: Converter RF Signal\n
+            \t\t\tPorts 3 and 4: Converter LO\n
+            \tRILE\tRF internal, LO external (4-Port)\n
+            \t\t\tPorts 1 to 4: Converter RF Signal\n
+            \t\t\tExternal Generator #1: Converter LO\n
+            \tRILI4\tRF internal, LO internal, Port4=LO (R&S ZVA 67 only)\n
+            \t\t\tPorts 1 and 2: Converter RF Signal\n
+            \t\t\tPort 4: Converter LO\n
+            \tRILI56\tRF internal, LO internal, 6-Port (R&S ZVT 20 only)\n
+            \t\t\tPorts 1 to 4: Converter RF Signal\n
+            \t\t\tPorts 5 and 6: Converter LO
+            \n\t"
+          }
+          NAME: {name: converter_name, set: "<TYPE>", query: "",
+            help: "Selects the frequency converter type for enhanced frequency-converting
+            measurements (with option ZVA-K8, Converter Control).\n\n
+            \tThe preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)\n
+            \tand Factory Preset (SYSTem:PRESet:USER:STATe OFF).\n\n
+            \t[SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'\n\n
+            \t<Ch>\t\t\t\tChannel number.\n
+            \t\t\t\t\t\tThis suffix is ignored, the command affects all channels.\n
+            \t'<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110\n
+            \t\t\t\t\t\t'' - No frequency converter selected
+            \n\t"
+          }
+      STAR: {name: f_start, set: <freq>, query: "", returns: float,
+        help: "Defines the start frequency for a frequency sweep which is equal to the
+        left edge of a Cartesian diagram.\n\n
+            \t[SENSe<Ch>:]FREQuency:STARt <start_frequency>
+            \n\t"
+      }
+      STOP: {name: f_stop, set: <freq>, query: "", returns: float,
+        help: "Defines the stop frequency for a frequency sweep which is equal to the
+        right edge of a Cartesian diagram.\n\n
+        \t[SENSe<Ch>:]FREQuency:STOP <stop_frequency>
+        \n\t"
+      }
+    SWE:
+      COUN: {name: sweep_count, set: "<NUMSWEEP=1>", query: "", returns: int,
+        help: "Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."
+      }
+      POIN: {name: sweep_n_points, set: "<NUMPOINTS=201>", query: "", returns: int,
+        help: "Defines the total number of measurement points per sweep (Number of Points)."
+      }
+      SPAC: {name: sweep_spacing, set: "<SPACING=LIN>", query: "",
+        help: "Defines the frequency vs. time characteristics of a frequency sweep\n\n
+        \t(Lin. Frequency or Log Frequency). The command has no effect on segmented\n
+        \tfrequency, power or time sweeps.\n\n
+        \t[SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic\n
+        \t"
+      }
+      STEP: {name: sweep_step, set: "<step_size>", query: "",
+        help: "Sets the distance between two consecutive sweep points.\n\n
+        \t[SENSe<Ch>:]SWEep:STEP <step_size>\n
+        \t"
+      }
+      TIME:
+        command: {name: sweep_time, set: "<duration>", query: "",
+          help: "Sets the duration of the sweep (Sweep Time).\n\n
+          \tSetting a duration disables the automatic calculation of the (minimum) sweep time;\n
+          \tsee [SENSe<Ch>:]SWEep:TIME:AUTO.\n\n
+          \t[SENSe<Ch>:]SWEep:TIME <duration>\n
+          \t"
+        }
+        branch:
+          AUTO: {name: sweep_time_auto, set: "<ONOFF=ON>", query: "", returns: bool,
+            help: "When enabled, the (minimum) sweep duration is calculated internally\n\n
+            \tusing the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).\n\n
+            \t[SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>\n
+            \t"
+          }
+      TYPE: {name: sweep_type, set: "<TYPE=LIN>", query: "",
+        help: "Selects the sweep type,\n\n
+        \ti.e. the sweep variable (frequency/power/time) and the position of the\n
+        \tsweep points across the sweep range.\n\n
+        \t[SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase\n
+        \t"
+      }
+  SYST:
+    DISP:
+      COL: {name: disp_color, set: "<COLOR=DBAC>"}
+      UPD: {name: disp_update, set: "<UPDATE=OFF>"}
+    ERR:
+      NEXT: {name: system_err_next, query: ""}
+      ALL: {name: system_error_all, query: ""}


### PR DESCRIPTION
I made changes to the SCPI parser to handle an additional `help` field in the
YAML file, to insert this help as a block comment in the function description.

I already added quite some commands to the YAML file, but it is still work in
progress. Not all meta functions from `keysight_pna.py` are currently
implemented in `rs_zva.py`.