### PR TITLE
merge fixed ZVA class and additional ZVA SCPI commands

### DIFF
--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -138,6 +138,9 @@ class VNA(object):
     def idn(self):
         return self.query("*IDN?")
 
+    def reset(self):
+        self.write("*RST")
+
     def wait_until_finished(self):
         self.query("*OPC?")
 

--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -188,10 +188,10 @@ class VNA(object):
 
     @property
     def idn(self):
-        return self.resource.query("*IDN?")
+        return self.query("*IDN?")
 
     def wait_until_finished(self):
-        self.resource.query("*OPC?")
+        self.query("*OPC?")
 
     def get_list_of_traces(self, **kwargs):
         """

--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -48,16 +48,8 @@ class VNA(object):
     get_switch_terms
     set_frequency_sweep
     """
-    DEFAULT_VISA_ADDRESS = "GPIB::16::INSTR"
-    NAME = "Two Port Analyzer"
-    NPORTS = 2
-    NCHANNELS = 32
-    MEASUREMENT_PARAMETERS = {
-        "port1": 1, "port2": 2, "ports": (1, 2),
-        "raw_data": True, "sweep": False,
-    }
 
-    def __init__(self, address=DEFAULT_VISA_ADDRESS, **kwargs):
+    def __init__(self, address, **kwargs):
         """
         Initialize a network analyzer object
 
@@ -119,49 +111,9 @@ class VNA(object):
         self.query = self.resource.query
         self.query_values = self.resource.query_values
 
-        # set the default values that will be used for measurements
-        self._measurement_parameters = self.MEASUREMENT_PARAMETERS.copy()
-
     @property
     def nports(self):
         return self.NPORTS
-
-    @property
-    def measurement_parameters(self):
-        """
-        provide the dict of values that will be the measurement_parameters for grabbing data from the instrument
-        
-        the primary purpose of this is to provide a mechanism to attach desired parameters onto a vna object which
-        may be transient from a "generator" to a "receiver" where a generator would be some object like a Gui Widget 
-        through which the end user sets desired vna parameters and the receiver is something that is calling the
-        measurement routines, but doesn't have direct access to the generator.
-
-        relevant dict keys
-        ------------------
-        port1, port2 : int
-            specify the 1st and second ports
-        ports : tuple of ints
-            specify which set of ports to grab data from
-        corrected : bool
-            whether to retrieve corrected data or not
-        sweep : bool
-            whether to initiate a fresh sweep or not
-        """
-        return self._measurement_parameters
-
-    @property
-    def params_twoport(self):
-        params = copy.copy(self.measurement_parameters)
-        params["ports"] = (params["port1"], params["port2"])
-        return params
-
-    def set_measurement_parameters(self, **kwargs):
-        valid_keys = self._measurement_parameters.keys()
-        for key, value in kwargs.items():
-            if key in valid_keys:
-                self._measurement_parameters[key] = value
-            else:
-                warnings.warn("default parameter {} not recognized and not set".format(key))
 
     def __enter__(self):
         """

--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -1,5 +1,6 @@
 """
-This is a model module.  It will not function correctly to pull data, but needs to be subclassed.
+This is a model module.  It will not function correctly to pull data, but needs
+to be subclassed.
 """
 import copy
 import warnings
@@ -16,8 +17,9 @@ class VNA(object):
     """
     class defining a base analyzer for using with scikit-rf
 
-    This class defines the base functionality expected for all Network Analyzers.  To keep this manageable,
-    it defines only the most commonly used applications, which currently are:
+    This class defines the base functionality expected for all Network
+    Analyzers. To keep this manageable, it defines only the most commonly used
+    applications, which currently are:
     * grabbing data (SNP networks, and traces)
     * grabbing a catalogue of available traces
     * instantiating and grabbing switch terms for calibration
@@ -64,20 +66,24 @@ class VNA(object):
         address : str
             a visa resource string, or an ip address
         kwargs : dict
-            visa_library (str), timemout in milliseconds (int), card_number (int), interface (str)
+            visa_library (str), timemout in milliseconds (int), card_number
+            (int), interface (str)
 
         Notes
         -----
-        General initialization of a skrf vna object.  Defines the class methods that all subclasses should
-        provide, and therefore defines the basic functionality, currently focused on grabbing data more than
-        on controlling the state of the vna
+        General initialization of a skrf vna object.  Defines the class methods
+        that all subclasses should provide, and therefore defines the basic
+        functionality, currently focused on grabbing data more than on
+        controlling the state of the vna
 
         Keyword Arguments
         -----------------
         visa_library : str
-            allows pyvisa to use different visa_library backends, including the python-based pyvisa-py.
-            backend which can handle SOCKET and Serial (though not GPIB) connections.  It should be possible
-            to use this library without NI-VISA libraries installed if the analyzer is so configured.
+            allows pyvisa to use different visa_library backends, including the
+            python-based pyvisa-py.  backend which can handle SOCKET and Serial
+            (though not GPIB) connections.  It should be possible to use this
+            library without NI-VISA libraries installed if the analyzer is so
+            configured.
         timeout : int
             milliseconds
         interface : str
@@ -199,35 +205,41 @@ class VNA(object):
         Returns
         -------
         list
-            catalogue of the available traces with description and all information necessary to index the trace
-            and grab it from the analyzer (i.e. channel, name, parameter etc.
+            catalogue of the available traces with description and all
+            information necessary to index the trace and grab it from the
+            analyzer (i.e. channel, name, parameter etc.
 
         Notes
         -----
-        the purpose of this function is to query the analyzer for the available traces, and then
-        it then returns a list where each list-item represents one available trace.  How this is
-        achieved is completely up to the user with the only requirement that the items from this list
-        must be passed to the self.get_traces function, which will return one network item for each item
-        in the list that is passed.
+        the purpose of this function is to query the analyzer for the available
+        traces, and then it then returns a list where each list-item represents
+        one available trace.  How this is achieved is completely up to the user
+        with the only requirement that the items from this list must be passed
+        to the self.get_traces function, which will return one network item for
+        each item in the list that is passed.
 
-        Typically the user will get this list of all available traces, and then by some functionality
-        in the widgets (or whatever) will down-select the list and then return that down-selected list
-        to the get_traces function to retrieve the desired networks.
+        Typically the user will get this list of all available traces, and then
+        by some functionality in the widgets (or whatever) will down-select the
+        list and then return that down-selected list to the get_traces function
+        to retrieve the desired networks.
 
-        Each list item then must be a python object (str, list, dict, etc.) with all necessary information to
-        retrieve the trace as an Network object.  For example, each item could be a python dict with the
-        following keys:
+        Each list item then must be a python object (str, list, dict, etc.) with
+        all necessary information to retrieve the trace as an Network object.
+        For example, each item could be a python dict with the following keys:
         * "name": the name of the measurement e.g. "CH1_S11_1"
         * "channel": the channel number the measurement is on
         * "measurement": the measurement number (MNUM in SCPI)
-        * "parameter": the parameter of the measurement, e.g. "S11", "S22" or "a1b1,2"
-        * "label": the text the item will use to identify itself to the user e.g "Measurement 1 on Channel 1"
+        * "parameter": the parameter of the measurement, e.g. "S11", "S22" or
+          "a1b1,2"
+        * "label": the text the item will use to identify itself to the user e.g
+          "Measurement 1 on Channel 1"
         """
         raise NotImplementedError("must implement with subclass")
 
     def get_traces(self, traces, **kwargs):
         """
-        retrieve traces as 1-port networks from a list returned by get_list_of_traces
+        retrieve traces as 1-port networks from a list returned by
+        get_list_of_traces
 
         Parameters
         ----------
@@ -243,26 +255,28 @@ class VNA(object):
 
         Notes
         -----
-        There is no current way to distinguish between traces and 1-port networks within skrf
+        There is no current way to distinguish between traces and 1-port
+        networks within skrf
         """
         raise NotImplementedError("must implement with subclass")
 
     def get_snp_network(self, ports, **kwargs):
         """
         return n-port network as an Network object
-        
+
         Parameters
         ----------
         ports : Iterable
             a iterable of integers designating the ports to query
         kwargs : dict
             optional arguments for subclassing
-        
+
         Returns
         -------
         Network
 
-        general function to take in a list of ports and return the full snp network as a Network object
+        general function to take in a list of ports and return the full snp
+        network as a Network object
         """
         raise NotImplementedError("must implement with subclass")
 
@@ -313,7 +327,8 @@ class VNA(object):
 
     def get_switch_terms(self, ports=(1, 2), **kwargs):
         """
-        create new traces for the switch terms and return as a 2-length list of forward and reverse terms
+        create new traces for the switch terms and return as a 2-length list of
+        forward and reverse terms
 
         Parameters
         ----------
@@ -326,7 +341,8 @@ class VNA(object):
         Returns
         -------
         list
-            a 2-length list of 1-port networks [forward_switch_terms, reverse_switch_terms]
+            a 2-length list of 1-port networks [forward_switch_terms,
+            reverse_switch_terms]
         """
         raise NotImplementedError("must implement with subclass")
 
@@ -343,14 +359,16 @@ class VNA(object):
         num_points : int
             the number of points in the frequency sweep
         kwargs : dict
-            channel (int), f_units (str), sweep_type (str -> lin, log), other optional parameters
+            channel (int), f_units (str), sweep_type (str -> lin, log), other
+            optional parameters
         """
         raise NotImplementedError("must implement with subclass")
 
     @staticmethod
     def to_hz(freq, f_unit):
         """
-        A simple convenience function to create frequency in Hz if it is in a different unit
+        A simple convenience function to create frequency in Hz if it is in a
+        different unit
 
         Parameters
         ----------

--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -111,10 +111,6 @@ class VNA(object):
         self.query = self.resource.query
         self.query_values = self.resource.query_values
 
-    @property
-    def nports(self):
-        return self.NPORTS
-
     def __enter__(self):
         """
         context manager entry point

--- a/skrf/vi/vna/rs_zva.py
+++ b/skrf/vi/vna/rs_zva.py
@@ -14,13 +14,12 @@ class ZVA(abcvna.VNA):
     Class for modern Rohde&Schwarz ZVA Vector Network Analyzers
     """
 
-    DEFAULT_VISA_ADDRESS = "GPIB::16::INSTR"
     NAME = "R&S ZVA"
     NPORTS = 4
     NCHANNELS = 32
     SCPI_VERSION_TESTED = 'A.09.20.08'  # taken from PNA class
 
-    def __init__(self, address=DEFAULT_VISA_ADDRESS, **kwargs):
+    def __init__(self, address, **kwargs):
         """
         initialization of ZVA Class
 
@@ -30,25 +29,25 @@ class ZVA(abcvna.VNA):
             visa resource string (full string or ip address)
         kwargs : dict
             interface (str), port (int), timeout (int),
-        :param address:
-        :param kwargs:
         """
         super(ZVA, self).__init__(address, **kwargs)
         self.resource.timeout = kwargs.get("timeout", 2000)
         self.scpi = rs_zva_scpi.SCPI(self.resource)
-        # self.use_binary()
-        #self.use_ascii()
         print(self.idn)
 
     def use_binary(self):
-        """setup the analyzer to transfer in binary which is faster, especially for large datasets"""
-        self.resource.write(':FORM:BORD SWAP')
-        self.resource.write(':FORM:DATA REAL,64')
-        self.resource.values_format.use_binary(datatype='d', is_big_endian=False, container=np.array)
+        """setup the analyzer to transfer in binary which is faster, especially
+        for large datasets"""
+        self.scpi.set_format_binary(ORDER='SWAP')
+        self.scpi.set_format_data(DATA='REAL,64')
+        self.resource.values_format.use_binary(datatype='d',
+                                               is_big_endian=False,
+                                               container=np.array)
 
     def use_ascii(self):
-        self.resource.write(':FORM:DATA ASCII')
-        self.resource.values_format.use_ascii(converter='f', separator=',', container=np.array)
+        self.scpi.set_format_data(DATA='ASCII')
+        self.resource.values_format.use_ascii(converter='f', separator=',',
+                                              container=np.array)
 
     @property
     def echo(self):
@@ -87,89 +86,24 @@ class ZVA(abcvna.VNA):
 
         Notes
         -----
-        There is no specific command to activate a channel, so we ask which channel we want and then activate the first
-        trace on that channel.  We do this because if the analyzer gets into a state where it doesn't recognize
-        any activated measurements, the get_snp_network method will fail, and possibly others as well.  That is why in
-        some methods you will see the fillowing line:
-        self.active_channel = channel = kwargs.get("channel", self.active_channel)
-        this way we force this property to be set, even if it just resets itself to the same value, but then a trace
-        will become active and our get_snp_network method will succeed.
         """
-        # TODO: Good chance this will fail if no measurement is on the set channel, need to think about that...
-        mnum = self.scpi.query_meas_number_list(channel)[0]
-        self.scpi.set_selected_meas_by_number(channel, mnum)
-        return
+        old_timeout = self.resource.timeout
+        self.resource.timeout = 500
+        if channel in self.channel_list:
+            self.scpi.set_active_channel(channel)
+        else:
+            print('Channel %i not in list of channels. Create channel first'
+                  % channel)
+        return self.scpi.query_active_channel()
 
-    def sweep(self, **kwargs):
-        """
-        Initialize a fresh sweep of data on the specified channels
-
-        Parameters
-        ----------
-        kwargs : dict
-            channel ("all", int or list of channels), timeout (milliseconds)
-
-        trigger a fresh sweep on the specified channels (default is "all" if no channel specified)
-        Autoset timeout and sweep mode based upon the analyzers current averaging setting,
-        and then return to the prior state of continuous trigger or hold.
-        """
-        #self.resource.clear()
-        self.scpi.set_trigger_source("IMM")
-        original_timeout = self.resource.timeout
-
-        # expecting either an int or a list of ints for the channel(s)
-        channels_to_sweep = kwargs.get("channels", None)
-        if not channels_to_sweep:
-            channels_to_sweep = kwargs.get("channel", "all")
-        if not type(channels_to_sweep) in (list, tuple):
-            channels_to_sweep = [channels_to_sweep]
-        channels = self.scpi.query_available_channels()
-
-        for i, channel in enumerate(channels):
-            sweep_mode = self.scpi.query_sweep_mode(channel)
-            was_continuous = "CONT" in sweep_mode.upper()
-            sweep_time = self.scpi.query_sweep_time(channel)
-            averaging_on = self.scpi.query_averaging_state(channel)
-            averaging_mode = self.scpi.query_averaging_mode(channel)
-
-            if averaging_on and "SWE" in averaging_mode.upper():
-                sweep_mode = "GROUPS"
-                number_of_sweeps = self.scpi.query_averaging_count(channel)
-                self.scpi.set_groups_count(channel, number_of_sweeps)
-                number_of_sweeps *= self.nports
-            else:
-                sweep_mode = "SINGLE"
-                number_of_sweeps = self.nports
-            channels[i] = {
-                "cnum": channel,
-                "sweep_time": sweep_time,
-                "number_of_sweeps": number_of_sweeps,
-                "sweep_mode": sweep_mode,
-                "was_continuous": was_continuous
-            }
-            self.scpi.set_sweep_mode(channel, "HOLD")
-        timeout = kwargs.get("timeout", None)  # recommend not setting this variable, as autosetting is preferred
-
-        try:
-            for channel in channels:
-                import time
-                if "all" not in channels_to_sweep and channel["cnum"] not in channels_to_sweep:
-                    continue  # default for sweep is all, else if we specify, then sweep
-                if not timeout:  # autoset timeout based on sweep time
-                    sweep_time = channel["sweep_time"] * channel[
-                        "number_of_sweeps"] * 1000  # convert to milliseconds, and double for buffer
-                    self.resource.timeout = max(sweep_time * 2, 5000)  # give ourselves a minimum 5 seconds for a sweep
-                else:
-                    self.resource.timeout = timeout
-                self.scpi.set_sweep_mode(channel["cnum"], channel["sweep_mode"])
-                self.wait_until_finished()
-        finally:
-            self.resource.clear()
-            for channel in channels:
-                if channel["was_continuous"]:
-                    self.scpi.set_sweep_mode(channel["cnum"], "CONT")
-            self.resource.timeout = original_timeout
-        return
+    @property
+    def channel_list(self):
+        """Return list of channels"""
+        return_str = self.scpi.query_channel_catalog().split(',')
+        channel_dct = {}
+        for i in range(int(len(return_str)/2)):
+            channel_dct[int(return_str[2 * i])] = return_str[2 * i + 1]
+        return channel_dct
 
     def get_frequency(self, **kwargs):
         """
@@ -208,32 +142,4 @@ class ZVA(abcvna.VNA):
         self.scpi.set_f_start(channel, f_start)
         self.scpi.set_f_stop(channel, f_stop)
         self.scpi.set_sweep_n_points(f_npoints)
-
-    def get_measurement(self, mname=None, mnum=None, **kwargs):
-        """
-        get a measurement trace from the analyzer, specified by either name or number
-
-        Parameters
-        ----------
-        mname : str
-            the name of the measurement, e.g. 'CH1_S11_1'
-        mnum : int
-            the number of number of the measurement
-        kwargs : dict
-            channel (int), sweep (bool)
-
-        Returns
-        -------
-        skrf.Network
-        """
-        if mname is None and mnum is None:
-            raise ValueError("must provide either a measurement mname or a mnum")
-
-        channel = kwargs.get("channel", self.active_channel)
-
-        if type(mname) is str:
-            self.scpi.set_selected_meas(channel, mname)
-        else:
-            self.scpi.set_selected_meas_by_number(channel, mnum)
-        return self.get_active_trace_as_network(**kwargs)
 

--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -75,7 +75,7 @@ class SCPI(object):
 
     def set_active_channel(self, channel=1):
         """Selects channel as the active channel.
-    
+
          INSTrument:NSELect <Channel>
          """
         scpi_command = scpi_preprocess(":INST:NSEL {:}", channel)
@@ -96,19 +96,47 @@ class SCPI(object):
         scpi_command = scpi_preprocess(":SENS{:}:AVER:STAT {:}", cnum, ONOFF)
         self.write(scpi_command)
 
+    def set_channel_name(self, cnum=1, CNAME=""):
+        """Assigns a name to channel number <Ch>.
+
+         The channel must be created before (CONFigure:CHANnel<Ch>[:STATe] ON).
+         Moreover it is not possible to assign the same name to two
+         different channels. CONFigure:CHANnel<Ch>:CATalog? returns a list of
+         all defined channels with their names.
+
+         CONFigure:CHANnel<Ch>:NAME '<Ch_name>'
+         """
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME '{:}'", cnum, CNAME)
+        self.write(scpi_command)
+
+    def set_channel_state(self, cnum=1, STATE="ON"):
+        """Creates or deletes channel no. <Ch> and selects it as the active channel.
+
+         CONFigure:CHANnel<Ch>:NAME defines the channel name.
+         """
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:STAT {:}", cnum, STATE)
+        self.write(scpi_command)
+
+    def set_channel_trace_name(self, cnum=1, TRNAME=""):
+        """Assigns a (new) name to the active trace in channel <Ch>."""
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:TRAC:REN '{:}'", cnum, TRNAME)
+        self.write(scpi_command)
+
     def set_converter_mode(self, cnum=1, MODE="RILI"):
-        """Selects the test setup (internal or external sources) for the frequency converter measurement (with option ZVA-K8, Converter Control).
-    
+        """Selects the test setup (internal or external sources)
+
+         for the frequency converter measurement (with option ZVA-K8, Converter Control).
+
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
-    
+
          The available test setups depend on the instrument type:
-    
+
                              RILI    RILE    RILI4    RILI56
          ---------------------------------------------------
          R&S ZVA 24|40|50      x      x
          R&S ZVA 67                   x        x
          R&S ZVT 20                            x        x
-    
+
          <Ch>    Channel number. This suffix is ignored, the command affects all channels.
          RILI    RF internal, LO internal (4-Port)
                  Ports 1 and 2: Converter RF Signal
@@ -121,23 +149,29 @@ class SCPI(object):
                  Port 4: Converter LO
          RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
                  Ports 1 to 4: Converter RF Signal
-                 Ports 5 and 6: Converter LO 
+                 Ports 5 and 6: Converter LO
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE {:}", cnum, MODE)
         self.write(scpi_command)
 
     def set_converter_name(self, cnum=1, TYPE=""):
-        """Selects the frequency converter type for enhanced frequency-converting measurements (with option ZVA-K8, Converter Control).
-    
+        """Selects the frequency converter type for enhanced frequency-converting measurements
+
+         (with option ZVA-K8, Converter Control).
+
          The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
          and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
-    
+
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
-    
-         <Ch>                Channel number.
-                             This suffix is ignored, the command affects all channels.
-         '<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110
-                             '' - No frequency converter selected 
+
+         | TYPE      | frequency range    |
+         |-----------|--------------------|
+         | R&S®ZC170 | 110 GHz to 170 GHz |
+         | R&S®ZC220 | 140 GHz to 220 GHz |
+         | R&S®ZC330 | 220 GHz to 330 GHz |
+         | R&S®ZC500 | 330 GHz to 500 GHz |
+         |-----------|--------------------|
+
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME {:}", cnum, TYPE)
         self.write(scpi_command)
@@ -179,7 +213,7 @@ class SCPI(object):
 
     def set_disp_name(self, wnum=1, name=""):
         """Defines a name for diagram area <Wnd>.
-    
+
          The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME {:}", wnum, name)
@@ -187,7 +221,7 @@ class SCPI(object):
 
     def set_disp_state(self, wnum=1, ONOFF=""):
         """Creates or deletes a diagram area, identified by its area number <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:STATe <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT {:}", wnum, ONOFF)
@@ -195,7 +229,7 @@ class SCPI(object):
 
     def set_disp_title_data(self, wnum=1, TITLE=""):
         """Defines a title for diagram area <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA {:}", wnum, TITLE)
@@ -203,7 +237,7 @@ class SCPI(object):
 
     def set_disp_title_state(self, wnum=1, ONOFF="ON"):
         """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
-    
+
          DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT {:}", wnum, ONOFF)
@@ -211,9 +245,9 @@ class SCPI(object):
 
     def set_disp_trace_auto(self, wnum=1, tnum=1, TRACENAME="None"):
         """Displays the entire trace in the diagram area, leaving an appropriate display margin.
-    
+
          The trace can be referenced either by its number <WndTr> or by its name <trace_name>.
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:AUTO ONCE[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:AUTO ONCE,'{:}'", wnum, tnum, TRACENAME)
@@ -226,7 +260,7 @@ class SCPI(object):
 
     def set_disp_trace_delete(self, wnum=1, tnum=1):
         """Releases the assignment between a trace and a diagram area.
-    
+
          As defined by means of DISPlay:WINDow<Wnd>:TRACe<WndTr>:FEED <Trace_Name>
          and expressed by the <WndTr> suffix. The trace itself is not deleted; this
          must be done via CALCulate<Ch>:PARameter:DELete <Trace_Name>.
@@ -236,13 +270,13 @@ class SCPI(object):
 
     def set_disp_trace_efeed(self, wnum=1, tnum=1, TRACENAME=""):
         """Assigns an existing trace to a diagram area.
-    
+
          Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
          to a diagram area <Wnd>, and displays the trace. Use
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:FEED to assign the trace to a diagram area
          using a numeric suffix (e.g. in order to use the
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y:OFFSet command).
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:EFE {:}", wnum, tnum, TRACENAME)
@@ -250,7 +284,7 @@ class SCPI(object):
 
     def set_disp_trace_feed(self, wnum=1, tnum=1, TRACENAME=""):
         """Assigns an existing traceto a diagram area.
-    
+
          Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
          to a diagram area, using the <WndTr> suffix, and displays the trace. Use
          DISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area
@@ -261,7 +295,7 @@ class SCPI(object):
 
     def set_disp_trace_pdiv(self, wnum=1, tnum=1, value="", TRACENAME="None"):
         """Sets the value between two grid lines (value “per division”) for the diagram area <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:PDIVision  <numeric_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:PDIV {:},{:}", wnum, tnum, value, TRACENAME)
@@ -269,25 +303,28 @@ class SCPI(object):
 
     def set_disp_trace_reflevel(self, wnum=1, tnum=1, value="", TRACENAME="None"):
         """Sets the reference level (or reference value) for a particular displayed trace.
-    
-         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']     """
+
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']
+         """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RLEV {:},{:}", wnum, tnum, value, TRACENAME)
         self.write(scpi_command)
 
     def set_disp_trace_refpos(self, wnum=1, tnum=1, value="", TRACENAME="None"):
-        """Sets the point on the y-axis to be used as the reference position as a percentage of the length of the y-axis.
-    
-     DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']
+        """Sets the point on the y-axis to be used as the reference position
+
+         (as a percentage of the length of the y-axis).
+
+         DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RPOS {:},{:}", wnum, tnum, value, TRACENAME)
         self.write(scpi_command)
 
     def set_disp_trace_show(self, wnum=1, tnum=1, DMTRACES="", TRACENAME=""):
         """Displays or hides an existing trace, identified by its trace name, or a group of traces.
-    
+
          Displays or hides an existing trace, identified by its trace name
          (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW {:} {:}", wnum, tnum, DMTRACES, TRACENAME)
@@ -295,7 +332,7 @@ class SCPI(object):
 
     def set_disp_trace_top(self, wnum=1, tnum=1, upper_value="", TRACENAME="None"):
         """Sets the upper (maximum) edge of the diagram area <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:TOP  <upper_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:TOP {:},{:}", wnum, tnum, upper_value, TRACENAME)
@@ -318,75 +355,132 @@ class SCPI(object):
 
     def set_f_start(self, cnum=1, freq=""):
         """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
-    
-         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
+
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency>
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR {:}", cnum, freq)
         self.write(scpi_command)
 
     def set_f_stop(self, cnum=1, freq=""):
         """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
-    
-         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
+
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency>
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP {:}", cnum, freq)
         self.write(scpi_command)
 
+    def set_format_binary(self, ORDER="SWAP"):
+        """Controls whether binary data is transferred in normal or swapped byte order.
+
+         FORMat:BORDer NORMal | SWAPped
+         """
+        scpi_command = scpi_preprocess(":FORM:BORD {:}", ORDER)
+        self.write(scpi_command)
+
+    def set_format_data(self, DATA="ASCII"):
+        """Selects the format for numeric data transferred to and from the analyzer.
+
+         FORMat[:DATA] ASCii | REAL [,<length>]
+
+         NOTE:
+         The format setting is only valid for commands and queries whose
+         description states that the response is formatted as described by
+         FORMat[:DATA]. In particular, it affects trace data transferred by means
+         of the commands in the TRACe:... system.
+
+         The default length of REAL data is 32 bits (single precision).
+         """
+        scpi_command = scpi_preprocess(":FORM:DATA {:}", DATA)
+        self.write(scpi_command)
+
     def set_init_continuous(self, cnum=1, STATE="ON"):
-        """no help available"""
+        """Qualifies whether the analyzer measures in single sweep or in continuous sweep mode.
+
+         INITiate<Ch>:CONTinuous <Boolean>
+         """
         scpi_command = scpi_preprocess(":INIT{:}:CONT {:}", cnum, STATE)
         self.write(scpi_command)
 
     def set_init_immediate(self, cnum=1):
-        """no help available"""
+        """Starts a new single sweep sequence.
+
+         This command is available in single sweep mode only
+         (INITiate<Ch>:CONTinuous OFF). The data of the last sweep (or previous
+         sweeps, see Sweep History) can be read using
+         CALCulate<Ch>:DATA:NSWeep:FIRSt? SDATa, <count>.
+         """
         scpi_command = scpi_preprocess(":INIT{:}:IMM", cnum)
         self.write(scpi_command)
 
     def set_init_immediate_scope(self, cnum=1, SCOPE="ALL"):
-        """no help available"""
+        """Selects the scope of the single sweep sequence.
+
+         The setting is applied in single sweep mode only (INITiate<Ch>:CONTinuous OFF).
+
+         NITiate<Ch>[:IMMediate]:SCOPe ALL | SINGle
+         """
         scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP {:}", cnum, SCOPE)
         self.write(scpi_command)
 
     def set_par_del(self, cnum=1, TRACE=""):
-        """no help available"""
+        """Deletes a trace with a specified trace name and channel.
+
+         CALCulate<Ch>:PARameter:DELete '<trace>'
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL '{:}'", cnum, TRACE)
         self.write(scpi_command)
 
     def set_par_del_all(self, cnum=1):
-        """no help available"""
+        """Deletes all traces in all channels of the active setup,
+
+         including the default trace Trc1 in channel no. 1. The manual
+         control screen shows 'No Trace'
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:ALL", cnum)
         self.write(scpi_command)
 
     def set_par_del_call(self, cnum=1):
-        """no help available"""
+        """Deletes all traces in channel no. <Ch>."""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:CALL", cnum)
         self.write(scpi_command)
 
     def set_par_del_sgroup(self, cnum=1):
-        """no help available"""
+        """Deletes a group of logical ports (S-parameter group),
+
+         previously defined via CALCulate<Ch>:PARameter:DEFine:SGRoup.
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:SGR", cnum)
         self.write(scpi_command)
 
     def set_par_sdef(self, cnum=1, TRACE="", COEFF=""):
-        """no help available"""
+        """Creates a trace and assigns a channel number, a name and a measured quantity to it.
+
+         The trace becomes the active trace in the channel but is not displayed.
+
+         To select an existing trace as the active trace, use
+         CALCulate:PARameter:SELect. You can open the trace manager
+         (DISPlay:MENU:KEY:EXECute 'Trace Manager') to obtain an overview of
+         all channels and traces, including the traces that are not displayed.
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SDEF '{:}', '{:}'", cnum, TRACE, COEFF)
         self.write(scpi_command)
 
-    def set_par_sdef_sgroup(self, cnum=1):
-        """no help available"""
-        scpi_command = scpi_preprocess(":CALC{:}:PAR:SDEF:SGR", cnum)
-        self.write(scpi_command)
-
     def set_par_select(self, cnum=1):
-        """no help available"""
+        """Selects an existing trace as the active trace of the channel.
+
+         All trace commands without explicit reference to the trace name act on
+         the active trace (e.g. CALCulate<Chn>:FORMat).
+         CALCulate<Ch>:PARameter:SELect is also necessary if the active trace of
+         a channel has been deleted.
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL 'TRACE'", cnum)
         self.write(scpi_command)
 
     def set_rbw(self, cnum=1, BW=""):
         """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
-    
+
          <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
          <bandwidth>
          Resolution bandwidth
@@ -396,9 +490,9 @@ class SCPI(object):
 
     def set_rbw_reduction(self, cnum=1, ONOFF="OFF"):
         """Enables or disables dynamic bandwidth reduction at low frequencies.
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
-    
+
          <Ch>        Channel number
          <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
         """
@@ -407,18 +501,21 @@ class SCPI(object):
 
     def set_rbw_select(self, cnum=1):
         """Defines the selectivity of the IF filter for an unsegmented sweep.
-    
+
          The value is also used for all segments of a segmented sweep,
          provided that separate selectivity setting is disabled
          ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
         """
         scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL", cnum)
         self.write(scpi_command)
 
     def set_sweep_count(self, cnum=1, NUMSWEEP=1):
-        """Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."""
+        """Defines the number of sweeps to be measured in single sweep mode
+
+         (INITiate<Ch>:CONTinuous OFF).
+         """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN {:}", cnum, NUMSWEEP)
         self.write(scpi_command)
 
@@ -429,10 +526,10 @@ class SCPI(object):
 
     def set_sweep_spacing(self, cnum=1, SPACING="LIN"):
         """Defines the frequency vs. time characteristics of a frequency sweep
-    
+
          (Lin. Frequency or Log Frequency). The command has no effect on segmented
          frequency, power or time sweeps.
-    
+
          [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC {:}", cnum, SPACING)
@@ -440,7 +537,7 @@ class SCPI(object):
 
     def set_sweep_step(self, cnum=1, step_size=""):
         """Sets the distance between two consecutive sweep points.
-    
+
          [SENSe<Ch>:]SWEep:STEP <step_size>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP {:}", cnum, step_size)
@@ -448,10 +545,10 @@ class SCPI(object):
 
     def set_sweep_time(self, cnum=1, duration=""):
         """Sets the duration of the sweep (Sweep Time).
-    
+
          Setting a duration disables the automatic calculation of the (minimum) sweep time;
          see [SENSe<Ch>:]SWEep:TIME:AUTO.
-    
+
          [SENSe<Ch>:]SWEep:TIME <duration>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME {:}", cnum, duration)
@@ -459,9 +556,9 @@ class SCPI(object):
 
     def set_sweep_time_auto(self, cnum=1, ONOFF="ON"):
         """When enabled, the (minimum) sweep duration is calculated internally
-    
+
          using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
-    
+
          [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO {:}", cnum, ONOFF)
@@ -469,10 +566,10 @@ class SCPI(object):
 
     def set_sweep_type(self, cnum=1, TYPE="LIN"):
         """Selects the sweep type,
-    
+
          i.e. the sweep variable (frequency/power/time) and the position of the
          sweep points across the sweep range.
-    
+
          [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE {:}", cnum, TYPE)
@@ -480,7 +577,7 @@ class SCPI(object):
 
     def query_active_channel(self):
         """Selects channel as the active channel.
-    
+
          INSTrument:NSELect <Channel>
          """
         scpi_command = ":INST:NSEL?"
@@ -502,19 +599,67 @@ class SCPI(object):
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
         return value
 
+    def query_channel_catalog(self, cnum=1):
+        """Returns the numbers and names of all channels in the current setup."""
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:CAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_channel_name(self, cnum=1):
+        """Assigns a name to channel number <Ch>.
+
+         The channel must be created before (CONFigure:CHANnel<Ch>[:STATe] ON).
+         Moreover it is not possible to assign the same name to two
+         different channels. CONFigure:CHANnel<Ch>:CATalog? returns a list of
+         all defined channels with their names.
+
+         CONFigure:CHANnel<Ch>:NAME '<Ch_name>'
+         """
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_channel_name_id(self, cnum=1, CNAME="Ch1"):
+        """Queries the channel number (numeric suffix) of a channel with known channel name.
+
+         A channel name must be assigned before (CONFigure:CHANnel<Ch>NAME '<Ch_name>').
+         CONFigure:CHANnel<Ch>:CATalog? returns a list of all defined
+         channels with their names.
+
+         CONFigure:CHANnel<Ch>:NAME:ID? '<Ch_name>'
+         """
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME:ID? '{:}'", cnum, CNAME)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_channel_state(self, cnum=1):
+        """Creates or deletes channel no. <Ch> and selects it as the active channel.
+
+         CONFigure:CHANnel<Ch>:NAME defines the channel name.
+         """
+        scpi_command = scpi_preprocess(":CONF:CHAN{:}:STAT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
     def query_converter_mode(self, cnum=1):
-        """Selects the test setup (internal or external sources) for the frequency converter measurement (with option ZVA-K8, Converter Control).
-    
+        """Selects the test setup (internal or external sources)
+
+         for the frequency converter measurement (with option ZVA-K8, Converter Control).
+
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
-    
+
          The available test setups depend on the instrument type:
-    
+
                              RILI    RILE    RILI4    RILI56
          ---------------------------------------------------
          R&S ZVA 24|40|50      x      x
          R&S ZVA 67                   x        x
          R&S ZVT 20                            x        x
-    
+
          <Ch>    Channel number. This suffix is ignored, the command affects all channels.
          RILI    RF internal, LO internal (4-Port)
                  Ports 1 and 2: Converter RF Signal
@@ -527,7 +672,7 @@ class SCPI(object):
                  Port 4: Converter LO
          RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
                  Ports 1 to 4: Converter RF Signal
-                 Ports 5 and 6: Converter LO 
+                 Ports 5 and 6: Converter LO
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE?", cnum)
         value = self.query(scpi_command)
@@ -535,17 +680,23 @@ class SCPI(object):
         return value
 
     def query_converter_name(self, cnum=1):
-        """Selects the frequency converter type for enhanced frequency-converting measurements (with option ZVA-K8, Converter Control).
-    
+        """Selects the frequency converter type for enhanced frequency-converting measurements
+
+         (with option ZVA-K8, Converter Control).
+
          The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
          and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
-    
+
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
-    
-         <Ch>                Channel number.
-                             This suffix is ignored, the command affects all channels.
-         '<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110
-                             '' - No frequency converter selected 
+
+         | TYPE      | frequency range    |
+         |-----------|--------------------|
+         | R&S®ZC170 | 110 GHz to 170 GHz |
+         | R&S®ZC220 | 140 GHz to 220 GHz |
+         | R&S®ZC330 | 220 GHz to 330 GHz |
+         | R&S®ZC500 | 330 GHz to 500 GHz |
+         |-----------|--------------------|
+
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME?", cnum)
         value = self.query(scpi_command)
@@ -628,7 +779,7 @@ class SCPI(object):
 
     def query_disp_name(self, wnum=1):
         """Defines a name for diagram area <Wnd>.
-    
+
          The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME?", wnum)
@@ -638,7 +789,7 @@ class SCPI(object):
 
     def query_disp_state(self, wnum=1):
         """Creates or deletes a diagram area, identified by its area number <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:STATe <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT?", wnum)
@@ -648,7 +799,7 @@ class SCPI(object):
 
     def query_disp_title_data(self, wnum=1):
         """Defines a title for diagram area <Wnd>.
-    
+
          DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA?", wnum)
@@ -658,7 +809,7 @@ class SCPI(object):
 
     def query_disp_title_state(self, wnum=1):
         """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
-    
+
          DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT?", wnum)
@@ -675,10 +826,10 @@ class SCPI(object):
 
     def query_disp_trace_show(self, wnum=1, tnum=1, DMTRACES=""):
         """Displays or hides an existing trace, identified by its trace name, or a group of traces.
-    
+
          Displays or hides an existing trace, identified by its trace name
          (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
-    
+
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW? {:}", wnum, tnum, DMTRACES)
@@ -700,8 +851,8 @@ class SCPI(object):
 
     def query_f_start(self, cnum=1):
         """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
-    
-         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
+
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency>
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR?", cnum)
         value = self.query(scpi_command)
@@ -710,37 +861,79 @@ class SCPI(object):
 
     def query_f_stop(self, cnum=1):
         """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
-    
-         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
+
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency>
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
-    def query_init_continuous(self, cnum=1):
-        """no help available"""
-        scpi_command = scpi_preprocess(":INIT{:}:CONT?", cnum)
+    def query_format_binary(self):
+        """Controls whether binary data is transferred in normal or swapped byte order.
+
+         FORMat:BORDer NORMal | SWAPped
+         """
+        scpi_command = ":FORM:BORD?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
+    def query_format_data(self):
+        """Selects the format for numeric data transferred to and from the analyzer.
+
+         FORMat[:DATA] ASCii | REAL [,<length>]
+
+         NOTE:
+         The format setting is only valid for commands and queries whose
+         description states that the response is formatted as described by
+         FORMat[:DATA]. In particular, it affects trace data transferred by means
+         of the commands in the TRACe:... system.
+
+         The default length of REAL data is 32 bits (single precision).
+         """
+        scpi_command = ":FORM:DATA?"
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        return value
+
+    def query_init_continuous(self, cnum=1):
+        """Qualifies whether the analyzer measures in single sweep or in continuous sweep mode.
+
+         INITiate<Ch>:CONTinuous <Boolean>
+         """
+        scpi_command = scpi_preprocess(":INIT{:}:CONT?", cnum)
+        value = self.query(scpi_command)
+        value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
+        return value
+
     def query_init_immediate_scope(self, cnum=1):
-        """no help available"""
+        """Selects the scope of the single sweep sequence.
+
+         The setting is applied in single sweep mode only (INITiate<Ch>:CONTinuous OFF).
+
+         NITiate<Ch>[:IMMediate]:SCOPe ALL | SINGle
+         """
         scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_par_catalog(self, cnum=1):
-        """no help available"""
+        """Returns the trace names and measured quantities of all traces assigned to a particular channel."""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:CAT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_par_select(self, cnum=1):
-        """no help available"""
+        """Selects an existing trace as the active trace of the channel.
+
+         All trace commands without explicit reference to the trace name act on
+         the active trace (e.g. CALCulate<Chn>:FORMat).
+         CALCulate<Ch>:PARameter:SELect is also necessary if the active trace of
+         a channel has been deleted.
+         """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
@@ -748,9 +941,9 @@ class SCPI(object):
 
     def query_rbw(self, cnum=1):
         """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
-    
+
          <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
          <bandwidth>
          Resolution bandwidth
@@ -762,9 +955,9 @@ class SCPI(object):
 
     def query_rbw_reduction(self, cnum=1):
         """Enables or disables dynamic bandwidth reduction at low frequencies.
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
-    
+
          <Ch>        Channel number
          <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
         """
@@ -775,11 +968,11 @@ class SCPI(object):
 
     def query_rbw_select(self, cnum=1):
         """Defines the selectivity of the IF filter for an unsegmented sweep.
-    
+
          The value is also used for all segments of a segmented sweep,
          provided that separate selectivity setting is disabled
          ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
-    
+
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
         """
         scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL?", cnum)
@@ -788,7 +981,10 @@ class SCPI(object):
         return value
 
     def query_sweep_count(self, cnum=1):
-        """Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."""
+        """Defines the number of sweeps to be measured in single sweep mode
+
+         (INITiate<Ch>:CONTinuous OFF).
+         """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
@@ -803,10 +999,10 @@ class SCPI(object):
 
     def query_sweep_spacing(self, cnum=1):
         """Defines the frequency vs. time characteristics of a frequency sweep
-    
+
          (Lin. Frequency or Log Frequency). The command has no effect on segmented
          frequency, power or time sweeps.
-    
+
          [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC?", cnum)
@@ -816,7 +1012,7 @@ class SCPI(object):
 
     def query_sweep_step(self, cnum=1):
         """Sets the distance between two consecutive sweep points.
-    
+
          [SENSe<Ch>:]SWEep:STEP <step_size>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP?", cnum)
@@ -826,10 +1022,10 @@ class SCPI(object):
 
     def query_sweep_time(self, cnum=1):
         """Sets the duration of the sweep (Sweep Time).
-    
+
          Setting a duration disables the automatic calculation of the (minimum) sweep time;
          see [SENSe<Ch>:]SWEep:TIME:AUTO.
-    
+
          [SENSe<Ch>:]SWEep:TIME <duration>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME?", cnum)
@@ -839,9 +1035,9 @@ class SCPI(object):
 
     def query_sweep_time_auto(self, cnum=1):
         """When enabled, the (minimum) sweep duration is calculated internally
-    
+
          using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
-    
+
          [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO?", cnum)
@@ -851,10 +1047,10 @@ class SCPI(object):
 
     def query_sweep_type(self, cnum=1):
         """Selects the sweep type,
-    
+
          i.e. the sweep variable (frequency/power/time) and the position of the
          sweep points across the sweep range.
-    
+
          [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE?", cnum)

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -1,4 +1,4 @@
-# vim: shiftwidth=2
+# vim: shiftwidth=2 foldmethod=indent
 # R&S ZVA SCPI online manual: https://www.rohde-schwarz.com/webhelp/webhelp_zva/start.htm
 
 DEFAULTS:
@@ -19,18 +19,80 @@ COMMAND_TREE:
         DALL: {name: data_dall, query_values: "<SDATA>"}
         SGR: {name: data_sgroup, query_values: "<SDATA>"}
     PAR:
-      CAT: {name: par_catalog, query: ""}
+      CAT: {name: par_catalog, query: "",
+        help: "Returns the trace names and measured quantities of all traces assigned to a particular channel."
+      }
       DEL:
-        command: {name: par_del, set: "'<TRACE>'"}
+        command: {name: par_del, set: "'<TRACE>'",
+          help: "Deletes a trace with a specified trace name and channel.\n\n
+          \tCALCulate<Ch>:PARameter:DELete '<trace>'\n
+          \t"
+        }
         branch:
-          ALL: {name: par_del_all, set: ""}
-          CALL: {name: par_del_call, set: ""}
-          SGR: {name: par_del_sgroup, set: ""}
-      SDEF:
-        command: {name: par_sdef, set: "'<TRACE>', '<COEFF>'"}
+          ALL: {name: par_del_all, set: "",
+            help: "Deletes all traces in all channels of the active setup,\n\n
+            \tincluding the default trace Trc1 in channel no. 1. The manual\n
+            \tcontrol screen shows 'No Trace'\n
+            \t"
+          }
+          CALL: {name: par_del_call, set: "",
+            help: "Deletes all traces in channel no. <Ch>."
+          }
+          SGR: {name: par_del_sgroup, set: "",
+            help: "Deletes a group of logical ports (S-parameter group),\n\n
+            \tpreviously defined via CALCulate<Ch>:PARameter:DEFine:SGRoup.\n
+            \t"
+          }
+      SDEF: {name: par_sdef, set: "'<TRACE>', '<COEFF>'",
+        help: "Creates a trace and assigns a channel number, a name and a measured quantity to it.\n\n
+        \tThe trace becomes the active trace in the channel but is not displayed.\n\n
+        \tTo select an existing trace as the active trace, use\n
+        \tCALCulate:PARameter:SELect. You can open the trace manager\n
+        \t(DISPlay:MENU:KEY:EXECute 'Trace Manager') to obtain an overview of\n
+        \tall channels and traces, including the traces that are not displayed.\n
+        \t"
+      }
+      SEL: {name: par_select, set: "'TRACE'", query: "",
+        help: "Selects an existing trace as the active trace of the channel.\n\n
+        \tAll trace commands without explicit reference to the trace name act on\n
+        \tthe active trace (e.g. CALCulate<Chn>:FORMat).\n
+        \tCALCulate<Ch>:PARameter:SELect is also necessary if the active trace of\n
+        \ta channel has been deleted.\n
+        \t"
+      }
+  CONF:
+    CHAN<cnum=1>:
+      CAT: {name: channel_catalog, query: "",
+        help: "Returns the numbers and names of all channels in the current setup."
+      }
+      NAME:
+        command: {name: channel_name, set: "'<CNAME>'", query: "",
+          help: "Assigns a name to channel number <Ch>.\n\n
+          \tThe channel must be created before (CONFigure:CHANnel<Ch>[:STATe] ON).\n
+          \tMoreover it is not possible to assign the same name to two\n
+          \tdifferent channels. CONFigure:CHANnel<Ch>:CATalog? returns a list of\n
+          \tall defined channels with their names.\n\n
+          \tCONFigure:CHANnel<Ch>:NAME '<Ch_name>'\n
+          \t"
+        }
         branch:
-          SGR: {name: par_sdef_sgroup, set: ""}
-      SEL: {name: par_select, set: "'TRACE'", query: ""}
+          ID: {name: channel_name_id, query: "'<CNAME=Ch1>'",
+            help: "Queries the channel number (numeric suffix) of a channel with known channel name.\n\n
+            \tA channel name must be assigned before (CONFigure:CHANnel<Ch>NAME '<Ch_name>').\n
+            \tCONFigure:CHANnel<Ch>:CATalog? returns a list of all defined\n
+            \tchannels with their names.\n\n
+            \tCONFigure:CHANnel<Ch>:NAME:ID? '<Ch_name>'\n
+            \t"
+          }
+      TRAC:
+        REN: {name: channel_trace_name, set: "'<TRNAME>'",
+          help: "Assigns a (new) name to the active trace in channel <Ch>."
+        }
+      STAT: {name: channel_state, set: "<STATE=ON>", query: "",
+          help: "Creates or deletes channel no. <Ch> and selects it as the active channel.\n\n
+          \tCONFigure:CHANnel<Ch>:NAME defines the channel name.\n
+          \t"
+          }
   DISP:
     WIND<wnum=1>:
       CAT: {name: disp_catalog, query: "",
@@ -121,12 +183,13 @@ COMMAND_TREE:
             }
             RLEV:  {name: disp_trace_reflevel, set: "<value>,<TRACENAME=None>",
               help: "Sets the reference level (or reference value) for a particular displayed trace.\n\n
-              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']\n
               \t"
             }
             RPOS: {name: disp_trace_refpos, set: "<value>,<TRACENAME=None>",
-              help: "Sets the point on the y-axis to be used as the reference position as a percentage of the length of the y-axis.\n\n
-              DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']\n
+              help: "Sets the point on the y-axis to be used as the reference position\n\n
+              \t(as a percentage of the length of the y-axis).\n\n
+              \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']\n
               \t"
               }
             TOP: {name: disp_trace_top, set: "<upper_value>,<TRACENAME=None>",
@@ -134,12 +197,45 @@ COMMAND_TREE:
               \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:TOP  <upper_value>[, '<trace_name>']\n
               \t"
               }
+  FORM:
+    BORD: {name: format_binary, set: "<ORDER=SWAP>", query: "",
+      help: "Controls whether binary data is transferred in normal or swapped byte order.\n\n
+      \tFORMat:BORDer NORMal | SWAPped\n
+      \t"
+    }
+    DATA: {name: format_data, set: "<DATA=ASCII>", query: "",
+      help: "Selects the format for numeric data transferred to and from the analyzer.\n\n
+      \tFORMat[:DATA] ASCii | REAL [,<length>]\n\n
+      \tNOTE:\n
+      \tThe format setting is only valid for commands and queries whose\n
+      \tdescription states that the response is formatted as described by\n
+      \tFORMat[:DATA]. In particular, it affects trace data transferred by means\n
+      \tof the commands in the TRACe:... system.\n\n
+      \tThe default length of REAL data is 32 bits (single precision).\n
+      \t"
+    }
   INIT<cnum=1>:
-    CONT: {name: init_continuous, set: "<STATE=ON>", query: ""}
+    CONT: {name: init_continuous, set: "<STATE=ON>", query: "", returns: bool,
+      help: "Qualifies whether the analyzer measures in single sweep or in continuous sweep mode.\n\n
+      \tINITiate<Ch>:CONTinuous <Boolean>\n
+      \t"
+    }
     IMM:
-      command: {name: init_immediate, set: ""}
+      command: {name: init_immediate, set: "",
+        help: "Starts a new single sweep sequence.\n\n
+        \tThis command is available in single sweep mode only\n
+        \t(INITiate<Ch>:CONTinuous OFF). The data of the last sweep (or previous\n
+        \tsweeps, see Sweep History) can be read using\n
+        \tCALCulate<Ch>:DATA:NSWeep:FIRSt? SDATa, <count>.\n
+        \t"
+      }
       branch:
-        SCOP: {name: init_immediate_scope, set: "<SCOPE=ALL>", query: ""}
+        SCOP: {name: init_immediate_scope, set: "<SCOPE=ALL>", query: "",
+          help: "Selects the scope of the single sweep sequence.\n\n
+          \tThe setting is applied in single sweep mode only (INITiate<Ch>:CONTinuous OFF).\n\n
+          \tNITiate<Ch>[:IMMediate]:SCOPe ALL | SINGle\n
+          \t"
+        }
   INST:
     NSEL: {name: active_channel, set: "<channel=1>", query: "", returns: int,
       help: "Selects channel as the active channel.\n\n
@@ -188,8 +284,8 @@ COMMAND_TREE:
       CONV:
         DEV:
           MODE: {name: converter_mode, set: "<MODE=RILI>", query: "",
-            help: "Selects the test setup (internal or external sources) for the frequency
-            converter measurement (with option ZVA-K8, Converter Control).\n\n
+            help: "Selects the test setup (internal or external sources)\n\n
+            \tfor the frequency converter measurement (with option ZVA-K8, Converter Control).\n\n
             \t[SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56\n\n
             \tThe available test setups depend on the instrument type:\n\n
             \t\t\t\t\t\tRILI\tRILE\tRILI4\tRILI56\n
@@ -213,15 +309,18 @@ COMMAND_TREE:
             \n\t"
           }
           NAME: {name: converter_name, set: "<TYPE>", query: "",
-            help: "Selects the frequency converter type for enhanced frequency-converting
-            measurements (with option ZVA-K8, Converter Control).\n\n
+            help: "Selects the frequency converter type for enhanced frequency-converting measurements\n\n
+            \t(with option ZVA-K8, Converter Control).\n\n
             \tThe preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)\n
             \tand Factory Preset (SYSTem:PRESet:USER:STATe OFF).\n\n
             \t[SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'\n\n
-            \t<Ch>\t\t\t\tChannel number.\n
-            \t\t\t\t\t\tThis suffix is ignored, the command affects all channels.\n
-            \t'<Converter Type>'  'ZVA-Z110' - Frequency converter R&S ZVA-Z110\n
-            \t\t\t\t\t\t'' - No frequency converter selected
+            \t| TYPE      | frequency range    |\n
+            \t|-----------|--------------------|\n
+            \t| R&S®ZC170 | 110 GHz to 170 GHz |\n
+            \t| R&S®ZC220 | 140 GHz to 220 GHz |\n
+            \t| R&S®ZC330 | 220 GHz to 330 GHz |\n
+            \t| R&S®ZC500 | 330 GHz to 500 GHz |\n
+            \t|-----------|--------------------|\n
             \n\t"
           }
       STAR: {name: f_start, set: <freq>, query: "", returns: float,
@@ -238,7 +337,9 @@ COMMAND_TREE:
       }
     SWE:
       COUN: {name: sweep_count, set: "<NUMSWEEP=1>", query: "", returns: int,
-        help: "Defines the number of sweeps to be measured in single sweep mode (INITiate<Ch>:CONTinuous OFF)."
+        help: "Defines the number of sweeps to be measured in single sweep mode\n\n
+        \t(INITiate<Ch>:CONTinuous OFF).\n
+        \t"
       }
       POIN: {name: sweep_n_points, set: "<NUMPOINTS=201>", query: "", returns: int,
         help: "Defines the total number of measurement points per sweep (Number of Points)."


### PR DESCRIPTION
This pull request fixes #178 (see discussion there). The non-working functions copied from PNA are fixed or removed.

More SCPI commands are defined in the YAML file.

Example instantiation:

```python
from skrf.vi.vna import ZVA


class VNA(ZVA):
    ADDRESS = '192.168.1.83'
    VISA = '@py'
    INTERFACE = 'SOCKET'

    def __init__(self, address=ADDRESS, visa=VISA, **kwargs):
        """Initialization function"""
        super(VNA, self).__init__(address=address, visa_library=visa,
                                  interface=self.INTERFACE)

        if return_bool(kwargs.get('id', False)):
            print(self.idn)

        if return_bool(kwargs.get('reset', True)):
            self.reset()

        if kwargs.get('converter', False):
            self.set_converter_name(kwargs['converter'])

        if return_bool(kwargs.get('display', False)):
            self.set_display_update(UPDATE=1)
        elif not return_bool(kwargs.get('display', True)):
            self.set_display_update(UPDATE=0)

        if return_bool(kwargs.get('correction', False)):
            self.set_corr_state(STATE=1)
        elif not return_bool(kwargs.get('correction', True)):
            self.set_corr_state(STATE=0)


def return_bool(arg):
    """return boolean value for input"""
    if type(arg) is str:
        arg = arg.upper()
    true_set = [True, 1, 'ON', 'YES', 'Y']
    if arg in true_set:
        return True
    else:
        return False
```


some function testing:

```python
In [2]: from vna import VNA

In [3]: v = VNA()
Rohde&Schwarz,ZVA24-4Port,1145111028101513,3.60

In [16]: v.idn
Out[16]: 'Rohde&Schwarz,ZVA24-4Port,1145111028101513,3.60'

In [17]: v.use_ascii()

In [18]: v.scpi.query_format_data()
Out[18]: 'ASC,0'

In [19]: v.use_binary()

In [20]: v.scpi.query_format_data()
Out[20]: 'REAL,64'

In [21]: v.scpi.query_format_binary()
Out[21]: 'SWAP'

In [23]: v.set_frequency_sweep(220e9, 325e9, 201)

In [24]: v.get_frequency()
Out[24]: 220000000000.0-325000000000.0 Hz, 201 pts

In [32]: v.active_channel = 2
Channel 2 not in list of channels. Create channel first

In [33]: v.active_channel = 1

In [34]: v.scpi.set_channel_state(cnum=3)

In [35]: v.active_channel = 3

In [36]: v.active_channel
Out[36]: 3
```

I will continue to work on implementing meta-functions in the ZVA class (new functions, and try to make it compatible to the PNA class) and add additional SCPI functions in the YAML if needed.