### PR TITLE
Increase support for R&S ZVA

### DIFF
--- a/qtapps/skrf_qtwidgets/analyzers/analyzer_rs_zva.py
+++ b/qtapps/skrf_qtwidgets/analyzers/analyzer_rs_zva.py
@@ -1,0 +1,9 @@
+from skrf.vi.vna import rs_zva
+
+
+class Analyzer(rs_zva.ZVA):
+    DEFAULT_VISA_ADDRESS = "GPIB::16::INSTR"
+    NAME = "Rhode & Schwartz ZVA"
+    NPORTS = 4
+    NCHANNELS = 32
+    SCPI_VERSION_TESTED = ''

--- a/qtapps/skrf_qtwidgets/networkPlotWidget.py
+++ b/qtapps/skrf_qtwidgets/networkPlotWidget.py
@@ -173,6 +173,7 @@ class NetworkPlotWidget(QtWidgets.QWidget):
         legend = self.plot.legend
         if legend is not None:
             legend.scene().removeItem(legend)
+        self.plot.legend = None
         self.plot.addLegend()
 
     def clear_plot(self):

--- a/skrf/vi/scpi/parser.py
+++ b/skrf/vi/scpi/parser.py
@@ -297,12 +297,8 @@ def parse_yaml_file(driver_yaml_file):
     driver = os.path.splitext(driver_yaml_file)[0] + ".py"
 
     driver_template = None
-    try:
-        with open(driver_yaml_file, 'r') as yaml_file:
-            driver_template = yaml.load(yaml_file)
-    except UnicodeDecodeError:
-        with open(driver_yaml_file, 'r', encoding='utf8') as yaml_file:
-            driver_template = yaml.load(yaml_file)
+    with open(driver_yaml_file, 'r', encoding='utf-8') as yaml_file:
+        driver_template = yaml.load(yaml_file)
 
     sets, queries = parse_branch(driver_template["COMMAND_TREE"])
 
@@ -314,7 +310,7 @@ def parse_yaml_file(driver_yaml_file):
     for q in sorted(queries, key=str.lower):
         driver_str += "\n" + indent(q, 1) + "\n"
 
-    with open(driver, 'w') as scpi_driver:
+    with open(driver, 'w', encoding='utf8') as scpi_driver:
         scpi_driver.write(driver_str)
 
 

--- a/skrf/vi/scpi/parser.py
+++ b/skrf/vi/scpi/parser.py
@@ -297,8 +297,13 @@ def parse_yaml_file(driver_yaml_file):
     driver = os.path.splitext(driver_yaml_file)[0] + ".py"
 
     driver_template = None
-    with open(driver_yaml_file, 'r') as yaml_file:
-        driver_template = yaml.load(yaml_file)
+    try:
+        with open(driver_yaml_file, 'r') as yaml_file:
+            driver_template = yaml.load(yaml_file)
+    except UnicodeDecodeError:
+        with open(driver_yaml_file, 'r', encoding='utf8') as yaml_file:
+            driver_template = yaml.load(yaml_file)
+
     sets, queries = parse_branch(driver_template["COMMAND_TREE"])
 
     driver_str = "\n\n\n".join((header_string, string_converter, scpi_preprocessor, query_processor)) + "\n\n\n"

--- a/skrf/vi/vna/abcvna.py
+++ b/skrf/vi/vna/abcvna.py
@@ -134,6 +134,9 @@ class VNA(object):
         """
         self.resource.close()
 
+    def close(self):
+        self.__exit__(None, None, None)
+
     @property
     def idn(self):
         return self.query("*IDN?")
@@ -270,7 +273,7 @@ class VNA(object):
                 raise ValueError("specify the port as an integer")
         else:
             if type(port) is int:
-                port = (port)
+                port = (port,)
             else:
                 raise ValueError("specify the port as an integer")
 

--- a/skrf/vi/vna/keysight_fieldfox_scpi.py
+++ b/skrf/vi/vna/keysight_fieldfox_scpi.py
@@ -52,168 +52,198 @@ class SCPI(object):
     def __init__(self, resource):
         self.resource = resource
         self.echo = False  # print scpi command string to scpi out
-    
+
     def write(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write(scpi, *args, **kwargs)
-    
+
     def query(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         return self.resource.query(scpi, *args, **kwargs)
-    
+
     def write_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write_values(scpi, *args, **kwargs)
-    
+
     def query_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         return self.resource.query_values(scpi, *args, **kwargs)
 
     def set_averaging_count(self, avg_count=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":AVER:COUN {:}", avg_count)
         self.write(scpi_command)
 
     def set_averaging_mode(self, avg_mode="SWEEP"):
+        """no help available"""
         scpi_command = scpi_preprocess(":AVER:MODE {:}", avg_mode)
         self.write(scpi_command)
 
     def set_clear_averaging(self):
+        """no help available"""
         scpi_command = ":AVER:CLE"
         self.write(scpi_command)
 
     def set_continuous_sweep(self, onoff="ON"):
+        """no help available"""
         scpi_command = scpi_preprocess(":INIT:CONT {:}", onoff)
         self.write(scpi_command)
 
     def set_current_trace(self, trace=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC:PAR{:}:SEL", trace)
         self.write(scpi_command)
 
     def set_display_format(self, fmt="MLOG"):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC:FORM {:}", fmt)
         self.write(scpi_command)
 
     def set_f_start(self, freq=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":FREQ:START {:}", freq)
         self.write(scpi_command)
 
     def set_f_stop(self, freq=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":FREQ:STOP {:}", freq)
         self.write(scpi_command)
 
     def set_if_bandwidth(self, bandwidth=1000):
+        """no help available"""
         scpi_command = scpi_preprocess(":BWID {:}", bandwidth)
         self.write(scpi_command)
 
     def set_instrument(self, instr="NA"):
+        """no help available"""
         scpi_command = scpi_preprocess(":INST '{:}'", instr)
         self.write(scpi_command)
 
     def set_single_sweep(self):
+        """no help available"""
         scpi_command = ":INIT"
         self.write(scpi_command)
 
     def set_sweep_n_points(self, n_points=401):
+        """no help available"""
         scpi_command = scpi_preprocess(":SWE:POIN {:}", n_points)
         self.write(scpi_command)
 
     def set_trace_autoscale(self, tnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":DISP:WIND:TRAC{:}:Y:AUTO", tnum)
         self.write(scpi_command)
 
     def set_trace_count(self, num=4):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC:PAR:COUN {:}", num)
         self.write(scpi_command)
 
     def set_trace_display_config(self, config="D12_34"):
+        """no help available"""
         scpi_command = scpi_preprocess(":DISP:WIND:SPL {:}", config)
         self.write(scpi_command)
 
     def set_trace_measurement(self, trace=1, meas='S11'):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC:PAR{:}:DEF {:}", trace, meas)
         self.write(scpi_command)
 
     def query_averaging_count(self):
+        """no help available"""
         scpi_command = ":AVER:COUN?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_averaging_mode(self):
+        """no help available"""
         scpi_command = ":AVER:MODE?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_continuous_sweep(self):
+        """no help available"""
         scpi_command = ":INIT:CONT?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
         return value
 
     def query_current_trace_data(self):
+        """no help available"""
         scpi_command = ":CALC:DATA:SDAT?"
         return self.query_values(scpi_command)
 
     def query_display_format(self):
+        """no help available"""
         scpi_command = ":CALC:FORM?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_f_start(self):
+        """no help available"""
         scpi_command = ":FREQ:START?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_f_stop(self):
+        """no help available"""
         scpi_command = ":FREQ:STOP?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_if_bandwidth(self):
+        """no help available"""
         scpi_command = ":BWID?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_instrument(self):
+        """no help available"""
         scpi_command = ":INST?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_sweep_n_points(self):
+        """no help available"""
         scpi_command = ":SWE:POIN?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_sweep_time(self):
+        """no help available"""
         scpi_command = ":SWE:TIME?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_trace_count(self):
+        """no help available"""
         scpi_command = ":CALC:PAR:COUN?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_trace_display_config(self):
+        """no help available"""
         scpi_command = ":DISP:WIND:SPL?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_trace_measurement(self, trace=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC:PAR{:}:DEF?", trace)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')

--- a/skrf/vi/vna/keysight_pna_scpi.py
+++ b/skrf/vi/vna/keysight_pna_scpi.py
@@ -52,324 +52,385 @@ class SCPI(object):
     def __init__(self, resource):
         self.resource = resource
         self.echo = False  # print scpi command string to scpi out
-    
+
     def write(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write(scpi, *args, **kwargs)
-    
+
     def query(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         return self.resource.query(scpi, *args, **kwargs)
-    
+
     def write_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         self.resource.write_values(scpi, *args, **kwargs)
-    
+
     def query_values(self, scpi, *args, **kwargs):
         if self.echo:
             print(scpi)
         return self.resource.query_values(scpi, *args, **kwargs)
 
     def set_active_calset(self, cnum=1, calset_name="", onoff=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:ACT '{:}',{:}", cnum, calset_name, onoff)
         self.write(scpi_command)
 
     def set_averaging_count(self, cnum=1, avg_count=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:COUN {:}", cnum, avg_count)
         self.write(scpi_command)
 
     def set_averaging_mode(self, cnum=1, avg_mode="SWEEP"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:MODE {:}", cnum, avg_mode)
         self.write(scpi_command)
 
     def set_averaging_state(self, cnum=1, onoff="ON"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:STAT {:}", cnum, onoff)
         self.write(scpi_command)
 
     def set_calset_data(self, cnum=1, eterm="", portA=1, portB=2, param="", eterm_data=None):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:DATA {:},{:},{:},{:},", cnum, eterm, portA, portB, param)
         self.write_values(scpi_command, eterm_data)
 
     def set_calset_description(self, cnum=1, description=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:DESC '{:}'", cnum, description)
         self.write(scpi_command)
 
     def set_calset_eterm(self, cnum=1, eterm="", eterm_data=None):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:ETER '{:}',", cnum, eterm)
         self.write_values(scpi_command, eterm_data)
 
     def set_calset_name(self, cnum=1, calset_name=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:NAME '{:}'", cnum, calset_name)
         self.write(scpi_command)
 
     def set_channel_correction_state(self, cnum=1, onoff="ON"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:STAT {:}", cnum, onoff)
         self.write(scpi_command)
 
     def set_create_calset(self, cnum=1, calset_name=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:CRE '{:}'", cnum, calset_name)
         self.write(scpi_command)
 
     def set_create_meas(self, cnum=1, mname="", param=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEF:EXT '{:}','{:}'", cnum, mname, param)
         self.write(scpi_command)
 
     def set_data(self, cnum=1, fmt="SDATA", data=None):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:DATA {:},", cnum, fmt)
         self.write_values(scpi_command, data)
 
     def set_delete_calset(self, cnum=1, calset_name=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:DEL '{:}'", cnum, calset_name)
         self.write(scpi_command)
 
     def set_delete_meas(self, cnum=1, mname=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL '{:}'", cnum, mname)
         self.write(scpi_command)
 
     def set_display_format(self, cnum=1, fmt="MLOG"):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:FORM {:}", cnum, fmt)
         self.write(scpi_command)
 
     def set_display_onoff(self, onoff="ON"):
+        """no help available"""
         scpi_command = scpi_preprocess(":DISP:ENAB {:}", onoff)
         self.write(scpi_command)
 
     def set_display_trace(self, wnum="", tnum="", mname=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:FEED '{:}'", wnum, tnum, mname)
         self.write(scpi_command)
 
     def set_f_start(self, cnum=1, freq=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:START {:}", cnum, freq)
         self.write(scpi_command)
 
     def set_f_stop(self, cnum=1, freq=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP {:}", cnum, freq)
         self.write(scpi_command)
 
     def set_groups_count(self, cnum=1, groups_count=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:GRO:COUN {:}", cnum, groups_count)
         self.write(scpi_command)
 
     def set_meas_correction_state(self, cnum=1, onoff="ON"):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:CORR:STAT {:}", cnum, onoff)
         self.write(scpi_command)
 
     def set_save_calset(self, cnum=1, user='01'):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:SAVE {:}", cnum, user)
         self.write(scpi_command)
 
     def set_selected_meas(self, cnum=1, mname=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL '{:}'", cnum, mname)
         self.write(scpi_command)
 
     def set_selected_meas_by_number(self, cnum=1, mnum=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:MNUM {:}", cnum, mnum)
         self.write(scpi_command)
 
     def set_sweep_mode(self, cnum=1, sweep_mode="CONT"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:MODE {:}", cnum, sweep_mode)
         self.write(scpi_command)
 
     def set_sweep_n_points(self, cnum=1, n_points=401):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:POIN {:}", cnum, n_points)
         self.write(scpi_command)
 
     def set_sweep_type(self, cnum=1, sweep_type="LIN"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE {:}", cnum, sweep_type)
         self.write(scpi_command)
 
     def set_trigger_source(self, trigger_source="IMM"):
+        """no help available"""
         scpi_command = scpi_preprocess(":TRIG:SOUR {:}", trigger_source)
         self.write(scpi_command)
 
     def query_active_calset(self, cnum=1, form="NAME"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:ACT? {:}", cnum, form)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_active_channel(self):
+        """no help available"""
         scpi_command = ":SYST:ACT:CHAN?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_available_channels(self):
+        """no help available"""
         scpi_command = ":SYST:CHAN:CAT?"
         value = self.query(scpi_command)
         value = process_query(value, csv=True, strip_outer_quotes=True, returns='int')
         return value
 
     def query_averaging_count(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:COUN?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_averaging_mode(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:MODE?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_averaging_state(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:AVER:STAT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
         return value
 
     def query_calset_catalog(self, cnum=1, form="NAME"):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:CAT? {:}", cnum, form)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_calset_data(self, cnum=1, eterm="", portA=1, portB=2):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:DATA? {:},{:},{:}", cnum, eterm, portA, portB)
         return self.query_values(scpi_command)
 
     def query_calset_description(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:DESC?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_calset_eterm(self, cnum=1, eterm=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:ETER? '{:}'", cnum, eterm)
         return self.query_values(scpi_command)
 
     def query_calset_eterm_catalog(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:ETER:CAT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_calset_name(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:NAME?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_channel_correction_state(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:STAT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
         return value
 
     def query_data(self, cnum=1, fmt="SDATA"):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:DATA? {:}", cnum, fmt)
         return self.query_values(scpi_command)
 
     def query_display_format(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:FORM?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_display_onoff(self):
+        """no help available"""
         scpi_command = ":DISP:ENAB?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='bool')
         return value
 
     def query_f_start(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:START?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_f_stop(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_groups_count(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:GRO:COUN?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_meas_correction_state(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:CORR:STAT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_meas_name_from_number(self, mnum=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SYST:MEAS{:}:NAME?", mnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_meas_name_list(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:CAT:EXT?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=True, strip_outer_quotes=True, returns='str')
         return value
 
     def query_meas_number_list(self, cnum=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":SYST:MEAS:CAT? {:}", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=True, strip_outer_quotes=True, returns='int')
         return value
 
     def query_save_calset(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:CORR:CSET:SAVE?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_selected_meas(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_selected_meas_by_number(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:MNUM?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_snp_data(self, cnum=1, ports=(1, 2)):
+        """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:DATA:SNP:PORT? '{:}'", cnum, ports)
         return self.query_values(scpi_command)
 
     def query_sweep_mode(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:MODE?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_sweep_n_points(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:POIN?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='int')
         return value
 
     def query_sweep_time(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='float')
         return value
 
     def query_sweep_type(self, cnum=1):
+        """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE?", cnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_trigger_source(self):
+        """no help available"""
         scpi_command = ":TRIG:SOUR?"
         value = self.query(scpi_command)
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
     def query_window_trace_numbers(self, wnum=""):
+        """no help available"""
         scpi_command = scpi_preprocess(":DISP:WIND{:}:CAT?", wnum)
         value = self.query(scpi_command)
         value = process_query(value, csv=True, strip_outer_quotes=True, returns='int')

--- a/skrf/vi/vna/rs_zva.py
+++ b/skrf/vi/vna/rs_zva.py
@@ -143,3 +143,18 @@ class ZVA(abcvna.VNA):
         self.scpi.set_f_stop(channel, f_stop)
         self.scpi.set_sweep_n_points(f_npoints)
 
+    def get_active_trace_as_network(self, **kwargs):
+        """get the current trace as a 1-port network object"""
+        channel = self.active_channel
+        f_unit = kwargs.get("f_unit", "GHz")
+        ntwk = skrf.Network()
+        ntwk.frequency = self.get_frequency(channel=channel, f_unit=f_unit)
+        sdata = self.scpi.query_data(channel, "SDATA")
+        ntwk.s = sdata[::2] + 1j * sdata[1::2]
+        return ntwk
+
+    def get_twoport(self, ports=(1, 2), **kwargs):
+        # TODO: write get_snp_network function, learning to start
+        # initial code will get a catalog of the measurements and parse for
+        # the indicated ports
+        raise NotImplementedError

--- a/skrf/vi/vna/rs_zva.py
+++ b/skrf/vi/vna/rs_zva.py
@@ -18,7 +18,7 @@ class ZVA(abcvna.VNA):
     NAME = "R&S ZVA"
     NPORTS = 4
     NCHANNELS = 32
-    SCPI_VERSION_TESTED = 'A.09.20.08'  # taken from PNA class
+    SCPI_VERSION_TESTED = 'unconfirmed'
 
     def __init__(self, address=DEFAULT_VISA_ADDRESS, **kwargs):
         """

--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -465,7 +465,7 @@ class SCPI(object):
         scpi_command = scpi_preprocess(":CALC{:}:PAR:SDEF '{:}', '{:}'", cnum, TRACE, COEFF)
         self.write(scpi_command)
 
-    def set_par_select(self, cnum=1):
+    def set_par_select(self, cnum=1, TRACE=""):
         """Selects an existing trace as the active trace of the channel.
     
          All trace commands without explicit reference to the trace name act on
@@ -473,7 +473,7 @@ class SCPI(object):
          CALCulate<Ch>:PARameter:SELect is also necessary if the active trace of
          a channel has been deleted.
          """
-        scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL 'TRACE'", cnum)
+        scpi_command = scpi_preprocess(":CALC{:}:PAR:SEL '{:}'", cnum, TRACE)
         self.write(scpi_command)
 
     def set_rbw(self, cnum=1, BW=""):

--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -75,7 +75,7 @@ class SCPI(object):
 
     def set_active_channel(self, channel=1):
         """Selects channel as the active channel.
-
+    
          INSTrument:NSELect <Channel>
          """
         scpi_command = scpi_preprocess(":INST:NSEL {:}", channel)
@@ -98,12 +98,12 @@ class SCPI(object):
 
     def set_channel_name(self, cnum=1, CNAME=""):
         """Assigns a name to channel number <Ch>.
-
+    
          The channel must be created before (CONFigure:CHANnel<Ch>[:STATe] ON).
          Moreover it is not possible to assign the same name to two
          different channels. CONFigure:CHANnel<Ch>:CATalog? returns a list of
          all defined channels with their names.
-
+    
          CONFigure:CHANnel<Ch>:NAME '<Ch_name>'
          """
         scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME '{:}'", cnum, CNAME)
@@ -111,7 +111,7 @@ class SCPI(object):
 
     def set_channel_state(self, cnum=1, STATE="ON"):
         """Creates or deletes channel no. <Ch> and selects it as the active channel.
-
+    
          CONFigure:CHANnel<Ch>:NAME defines the channel name.
          """
         scpi_command = scpi_preprocess(":CONF:CHAN{:}:STAT {:}", cnum, STATE)
@@ -124,19 +124,19 @@ class SCPI(object):
 
     def set_converter_mode(self, cnum=1, MODE="RILI"):
         """Selects the test setup (internal or external sources)
-
+    
          for the frequency converter measurement (with option ZVA-K8, Converter Control).
-
+    
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
-
+    
          The available test setups depend on the instrument type:
-
+    
                              RILI    RILE    RILI4    RILI56
          ---------------------------------------------------
          R&S ZVA 24|40|50      x      x
          R&S ZVA 67                   x        x
          R&S ZVT 20                            x        x
-
+    
          <Ch>    Channel number. This suffix is ignored, the command affects all channels.
          RILI    RF internal, LO internal (4-Port)
                  Ports 1 and 2: Converter RF Signal
@@ -149,21 +149,21 @@ class SCPI(object):
                  Port 4: Converter LO
          RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
                  Ports 1 to 4: Converter RF Signal
-                 Ports 5 and 6: Converter LO
+                 Ports 5 and 6: Converter LO 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE {:}", cnum, MODE)
         self.write(scpi_command)
 
     def set_converter_name(self, cnum=1, TYPE=""):
         """Selects the frequency converter type for enhanced frequency-converting measurements
-
+    
          (with option ZVA-K8, Converter Control).
-
+    
          The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
          and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
-
+    
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
-
+    
          | TYPE      | frequency range    |
          |-----------|--------------------|
          | R&S®ZC170 | 110 GHz to 170 GHz |
@@ -171,7 +171,7 @@ class SCPI(object):
          | R&S®ZC330 | 220 GHz to 330 GHz |
          | R&S®ZC500 | 330 GHz to 500 GHz |
          |-----------|--------------------|
-
+     
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME {:}", cnum, TYPE)
         self.write(scpi_command)
@@ -213,7 +213,7 @@ class SCPI(object):
 
     def set_disp_name(self, wnum=1, name=""):
         """Defines a name for diagram area <Wnd>.
-
+    
          The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME {:}", wnum, name)
@@ -221,7 +221,7 @@ class SCPI(object):
 
     def set_disp_state(self, wnum=1, ONOFF=""):
         """Creates or deletes a diagram area, identified by its area number <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:STATe <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT {:}", wnum, ONOFF)
@@ -229,7 +229,7 @@ class SCPI(object):
 
     def set_disp_title_data(self, wnum=1, TITLE=""):
         """Defines a title for diagram area <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA {:}", wnum, TITLE)
@@ -237,7 +237,7 @@ class SCPI(object):
 
     def set_disp_title_state(self, wnum=1, ONOFF="ON"):
         """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
-
+    
          DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT {:}", wnum, ONOFF)
@@ -245,9 +245,9 @@ class SCPI(object):
 
     def set_disp_trace_auto(self, wnum=1, tnum=1, TRACENAME="None"):
         """Displays the entire trace in the diagram area, leaving an appropriate display margin.
-
+    
          The trace can be referenced either by its number <WndTr> or by its name <trace_name>.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:AUTO ONCE[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:AUTO ONCE,'{:}'", wnum, tnum, TRACENAME)
@@ -260,7 +260,7 @@ class SCPI(object):
 
     def set_disp_trace_delete(self, wnum=1, tnum=1):
         """Releases the assignment between a trace and a diagram area.
-
+    
          As defined by means of DISPlay:WINDow<Wnd>:TRACe<WndTr>:FEED <Trace_Name>
          and expressed by the <WndTr> suffix. The trace itself is not deleted; this
          must be done via CALCulate<Ch>:PARameter:DELete <Trace_Name>.
@@ -270,13 +270,13 @@ class SCPI(object):
 
     def set_disp_trace_efeed(self, wnum=1, tnum=1, TRACENAME=""):
         """Assigns an existing trace to a diagram area.
-
+    
          Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
          to a diagram area <Wnd>, and displays the trace. Use
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:FEED to assign the trace to a diagram area
          using a numeric suffix (e.g. in order to use the
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y:OFFSet command).
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:EFE {:}", wnum, tnum, TRACENAME)
@@ -284,7 +284,7 @@ class SCPI(object):
 
     def set_disp_trace_feed(self, wnum=1, tnum=1, TRACENAME=""):
         """Assigns an existing traceto a diagram area.
-
+    
          Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
          to a diagram area, using the <WndTr> suffix, and displays the trace. Use
          DISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area
@@ -295,7 +295,7 @@ class SCPI(object):
 
     def set_disp_trace_pdiv(self, wnum=1, tnum=1, value="", TRACENAME="None"):
         """Sets the value between two grid lines (value “per division”) for the diagram area <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:PDIVision  <numeric_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:PDIV {:},{:}", wnum, tnum, value, TRACENAME)
@@ -303,7 +303,7 @@ class SCPI(object):
 
     def set_disp_trace_reflevel(self, wnum=1, tnum=1, value="", TRACENAME="None"):
         """Sets the reference level (or reference value) for a particular displayed trace.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RLEVel  <numeric_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RLEV {:},{:}", wnum, tnum, value, TRACENAME)
@@ -311,9 +311,9 @@ class SCPI(object):
 
     def set_disp_trace_refpos(self, wnum=1, tnum=1, value="", TRACENAME="None"):
         """Sets the point on the y-axis to be used as the reference position
-
+    
          (as a percentage of the length of the y-axis).
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:RPOSition  <numeric_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:RPOS {:},{:}", wnum, tnum, value, TRACENAME)
@@ -321,10 +321,10 @@ class SCPI(object):
 
     def set_disp_trace_show(self, wnum=1, tnum=1, DMTRACES="", TRACENAME=""):
         """Displays or hides an existing trace, identified by its trace name, or a group of traces.
-
+    
          Displays or hides an existing trace, identified by its trace name
          (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW {:} {:}", wnum, tnum, DMTRACES, TRACENAME)
@@ -332,7 +332,7 @@ class SCPI(object):
 
     def set_disp_trace_top(self, wnum=1, tnum=1, upper_value="", TRACENAME="None"):
         """Sets the upper (maximum) edge of the diagram area <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:Y[:SCALe]:TOP  <upper_value>[, '<trace_name>']
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:Y:SCAL:TOP {:},{:}", wnum, tnum, upper_value, TRACENAME)
@@ -355,23 +355,23 @@ class SCPI(object):
 
     def set_f_start(self, cnum=1, freq=""):
         """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
-
-         [SENSe<Ch>:]FREQuency:STARt <start_frequency>
+    
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR {:}", cnum, freq)
         self.write(scpi_command)
 
     def set_f_stop(self, cnum=1, freq=""):
         """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
-
-         [SENSe<Ch>:]FREQuency:STOP <stop_frequency>
+    
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP {:}", cnum, freq)
         self.write(scpi_command)
 
     def set_format_binary(self, ORDER="SWAP"):
         """Controls whether binary data is transferred in normal or swapped byte order.
-
+    
          FORMat:BORDer NORMal | SWAPped
          """
         scpi_command = scpi_preprocess(":FORM:BORD {:}", ORDER)
@@ -379,15 +379,15 @@ class SCPI(object):
 
     def set_format_data(self, DATA="ASCII"):
         """Selects the format for numeric data transferred to and from the analyzer.
-
+    
          FORMat[:DATA] ASCii | REAL [,<length>]
-
+    
          NOTE:
          The format setting is only valid for commands and queries whose
          description states that the response is formatted as described by
          FORMat[:DATA]. In particular, it affects trace data transferred by means
          of the commands in the TRACe:... system.
-
+    
          The default length of REAL data is 32 bits (single precision).
          """
         scpi_command = scpi_preprocess(":FORM:DATA {:}", DATA)
@@ -395,7 +395,7 @@ class SCPI(object):
 
     def set_init_continuous(self, cnum=1, STATE="ON"):
         """Qualifies whether the analyzer measures in single sweep or in continuous sweep mode.
-
+    
          INITiate<Ch>:CONTinuous <Boolean>
          """
         scpi_command = scpi_preprocess(":INIT{:}:CONT {:}", cnum, STATE)
@@ -403,7 +403,7 @@ class SCPI(object):
 
     def set_init_immediate(self, cnum=1):
         """Starts a new single sweep sequence.
-
+    
          This command is available in single sweep mode only
          (INITiate<Ch>:CONTinuous OFF). The data of the last sweep (or previous
          sweeps, see Sweep History) can be read using
@@ -414,9 +414,9 @@ class SCPI(object):
 
     def set_init_immediate_scope(self, cnum=1, SCOPE="ALL"):
         """Selects the scope of the single sweep sequence.
-
+    
          The setting is applied in single sweep mode only (INITiate<Ch>:CONTinuous OFF).
-
+    
          NITiate<Ch>[:IMMediate]:SCOPe ALL | SINGle
          """
         scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP {:}", cnum, SCOPE)
@@ -424,7 +424,7 @@ class SCPI(object):
 
     def set_par_del(self, cnum=1, TRACE=""):
         """Deletes a trace with a specified trace name and channel.
-
+    
          CALCulate<Ch>:PARameter:DELete '<trace>'
          """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL '{:}'", cnum, TRACE)
@@ -432,7 +432,7 @@ class SCPI(object):
 
     def set_par_del_all(self, cnum=1):
         """Deletes all traces in all channels of the active setup,
-
+    
          including the default trace Trc1 in channel no. 1. The manual
          control screen shows 'No Trace'
          """
@@ -446,7 +446,7 @@ class SCPI(object):
 
     def set_par_del_sgroup(self, cnum=1):
         """Deletes a group of logical ports (S-parameter group),
-
+    
          previously defined via CALCulate<Ch>:PARameter:DEFine:SGRoup.
          """
         scpi_command = scpi_preprocess(":CALC{:}:PAR:DEL:SGR", cnum)
@@ -454,9 +454,9 @@ class SCPI(object):
 
     def set_par_sdef(self, cnum=1, TRACE="", COEFF=""):
         """Creates a trace and assigns a channel number, a name and a measured quantity to it.
-
+    
          The trace becomes the active trace in the channel but is not displayed.
-
+    
          To select an existing trace as the active trace, use
          CALCulate:PARameter:SELect. You can open the trace manager
          (DISPlay:MENU:KEY:EXECute 'Trace Manager') to obtain an overview of
@@ -467,7 +467,7 @@ class SCPI(object):
 
     def set_par_select(self, cnum=1):
         """Selects an existing trace as the active trace of the channel.
-
+    
          All trace commands without explicit reference to the trace name act on
          the active trace (e.g. CALCulate<Chn>:FORMat).
          CALCulate<Ch>:PARameter:SELect is also necessary if the active trace of
@@ -478,9 +478,9 @@ class SCPI(object):
 
     def set_rbw(self, cnum=1, BW=""):
         """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
-
+    
          <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
          <bandwidth>
          Resolution bandwidth
@@ -490,9 +490,9 @@ class SCPI(object):
 
     def set_rbw_reduction(self, cnum=1, ONOFF="OFF"):
         """Enables or disables dynamic bandwidth reduction at low frequencies.
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
-
+    
          <Ch>        Channel number
          <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
         """
@@ -501,11 +501,11 @@ class SCPI(object):
 
     def set_rbw_select(self, cnum=1):
         """Defines the selectivity of the IF filter for an unsegmented sweep.
-
+    
          The value is also used for all segments of a segmented sweep,
          provided that separate selectivity setting is disabled
          ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
         """
         scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL", cnum)
@@ -513,7 +513,7 @@ class SCPI(object):
 
     def set_sweep_count(self, cnum=1, NUMSWEEP=1):
         """Defines the number of sweeps to be measured in single sweep mode
-
+    
          (INITiate<Ch>:CONTinuous OFF).
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN {:}", cnum, NUMSWEEP)
@@ -526,10 +526,10 @@ class SCPI(object):
 
     def set_sweep_spacing(self, cnum=1, SPACING="LIN"):
         """Defines the frequency vs. time characteristics of a frequency sweep
-
+    
          (Lin. Frequency or Log Frequency). The command has no effect on segmented
          frequency, power or time sweeps.
-
+    
          [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC {:}", cnum, SPACING)
@@ -537,7 +537,7 @@ class SCPI(object):
 
     def set_sweep_step(self, cnum=1, step_size=""):
         """Sets the distance between two consecutive sweep points.
-
+    
          [SENSe<Ch>:]SWEep:STEP <step_size>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP {:}", cnum, step_size)
@@ -545,10 +545,10 @@ class SCPI(object):
 
     def set_sweep_time(self, cnum=1, duration=""):
         """Sets the duration of the sweep (Sweep Time).
-
+    
          Setting a duration disables the automatic calculation of the (minimum) sweep time;
          see [SENSe<Ch>:]SWEep:TIME:AUTO.
-
+    
          [SENSe<Ch>:]SWEep:TIME <duration>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME {:}", cnum, duration)
@@ -556,9 +556,9 @@ class SCPI(object):
 
     def set_sweep_time_auto(self, cnum=1, ONOFF="ON"):
         """When enabled, the (minimum) sweep duration is calculated internally
-
+    
          using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
-
+    
          [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO {:}", cnum, ONOFF)
@@ -566,10 +566,10 @@ class SCPI(object):
 
     def set_sweep_type(self, cnum=1, TYPE="LIN"):
         """Selects the sweep type,
-
+    
          i.e. the sweep variable (frequency/power/time) and the position of the
          sweep points across the sweep range.
-
+    
          [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE {:}", cnum, TYPE)
@@ -577,7 +577,7 @@ class SCPI(object):
 
     def query_active_channel(self):
         """Selects channel as the active channel.
-
+    
          INSTrument:NSELect <Channel>
          """
         scpi_command = ":INST:NSEL?"
@@ -608,12 +608,12 @@ class SCPI(object):
 
     def query_channel_name(self, cnum=1):
         """Assigns a name to channel number <Ch>.
-
+    
          The channel must be created before (CONFigure:CHANnel<Ch>[:STATe] ON).
          Moreover it is not possible to assign the same name to two
          different channels. CONFigure:CHANnel<Ch>:CATalog? returns a list of
          all defined channels with their names.
-
+    
          CONFigure:CHANnel<Ch>:NAME '<Ch_name>'
          """
         scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME?", cnum)
@@ -623,11 +623,11 @@ class SCPI(object):
 
     def query_channel_name_id(self, cnum=1, CNAME="Ch1"):
         """Queries the channel number (numeric suffix) of a channel with known channel name.
-
+    
          A channel name must be assigned before (CONFigure:CHANnel<Ch>NAME '<Ch_name>').
          CONFigure:CHANnel<Ch>:CATalog? returns a list of all defined
          channels with their names.
-
+    
          CONFigure:CHANnel<Ch>:NAME:ID? '<Ch_name>'
          """
         scpi_command = scpi_preprocess(":CONF:CHAN{:}:NAME:ID? '{:}'", cnum, CNAME)
@@ -637,7 +637,7 @@ class SCPI(object):
 
     def query_channel_state(self, cnum=1):
         """Creates or deletes channel no. <Ch> and selects it as the active channel.
-
+    
          CONFigure:CHANnel<Ch>:NAME defines the channel name.
          """
         scpi_command = scpi_preprocess(":CONF:CHAN{:}:STAT?", cnum)
@@ -647,19 +647,19 @@ class SCPI(object):
 
     def query_converter_mode(self, cnum=1):
         """Selects the test setup (internal or external sources)
-
+    
          for the frequency converter measurement (with option ZVA-K8, Converter Control).
-
+    
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:MODE RILI | RILE | RILI4 | RILI56
-
+    
          The available test setups depend on the instrument type:
-
+    
                              RILI    RILE    RILI4    RILI56
          ---------------------------------------------------
          R&S ZVA 24|40|50      x      x
          R&S ZVA 67                   x        x
          R&S ZVT 20                            x        x
-
+    
          <Ch>    Channel number. This suffix is ignored, the command affects all channels.
          RILI    RF internal, LO internal (4-Port)
                  Ports 1 and 2: Converter RF Signal
@@ -672,7 +672,7 @@ class SCPI(object):
                  Port 4: Converter LO
          RILI56    RF internal, LO internal, 6-Port (R&S ZVT 20 only)
                  Ports 1 to 4: Converter RF Signal
-                 Ports 5 and 6: Converter LO
+                 Ports 5 and 6: Converter LO 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:MODE?", cnum)
         value = self.query(scpi_command)
@@ -681,14 +681,14 @@ class SCPI(object):
 
     def query_converter_name(self, cnum=1):
         """Selects the frequency converter type for enhanced frequency-converting measurements
-
+    
          (with option ZVA-K8, Converter Control).
-
+    
          The preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)
          and Factory Preset (SYSTem:PRESet:USER:STATe OFF).
-
+    
          [SENSe<Ch>:]FREQuency:CONVersion:DEVice:NAME '<Converter Type>'
-
+    
          | TYPE      | frequency range    |
          |-----------|--------------------|
          | R&S®ZC170 | 110 GHz to 170 GHz |
@@ -696,7 +696,7 @@ class SCPI(object):
          | R&S®ZC330 | 220 GHz to 330 GHz |
          | R&S®ZC500 | 330 GHz to 500 GHz |
          |-----------|--------------------|
-
+     
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME?", cnum)
         value = self.query(scpi_command)
@@ -757,7 +757,7 @@ class SCPI(object):
         """no help available"""
         scpi_command = scpi_preprocess(":CALC{:}:DATA:CALL:CAT?", cnum)
         value = self.query(scpi_command)
-        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        value = process_query(value, csv=True, strip_outer_quotes=True, returns='str')
         return value
 
     def query_data_dall(self, cnum=1, SDATA=""):
@@ -779,7 +779,7 @@ class SCPI(object):
 
     def query_disp_name(self, wnum=1):
         """Defines a name for diagram area <Wnd>.
-
+    
          The name appears in the list of diagram areas, to be queried by DISPlay[:WINDow<Wnd>]:CAT?.
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:NAME?", wnum)
@@ -789,7 +789,7 @@ class SCPI(object):
 
     def query_disp_state(self, wnum=1):
         """Creates or deletes a diagram area, identified by its area number <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:STATe <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:STAT?", wnum)
@@ -799,7 +799,7 @@ class SCPI(object):
 
     def query_disp_title_data(self, wnum=1):
         """Defines a title for diagram area <Wnd>.
-
+    
          DISPlay[:WINDow<Wnd>]:TITLe:DATA '<string>'
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:DATA?", wnum)
@@ -809,7 +809,7 @@ class SCPI(object):
 
     def query_disp_title_state(self, wnum=1):
         """Displays or hides the title for area number <Wnd>, defined by means of DISPlay:WINDow<Wnd>:TITLe:DATA.
-
+    
          DISPlay[:WINDow<Wnd>]:TITLe[:STATe] <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TITL:STAT?", wnum)
@@ -826,10 +826,10 @@ class SCPI(object):
 
     def query_disp_trace_show(self, wnum=1, tnum=1, DMTRACES=""):
         """Displays or hides an existing trace, identified by its trace name, or a group of traces.
-
+    
          Displays or hides an existing trace, identified by its trace name
          (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>), or a group of traces.
-
+    
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:SHOW DALL | MALL | '<trace_name>', <Boolean>
          """
         scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:SHOW? {:}", wnum, tnum, DMTRACES)
@@ -851,8 +851,8 @@ class SCPI(object):
 
     def query_f_start(self, cnum=1):
         """Defines the start frequency for a frequency sweep which is equal to the left edge of a Cartesian diagram.
-
-         [SENSe<Ch>:]FREQuency:STARt <start_frequency>
+    
+         [SENSe<Ch>:]FREQuency:STARt <start_frequency> 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STAR?", cnum)
         value = self.query(scpi_command)
@@ -861,8 +861,8 @@ class SCPI(object):
 
     def query_f_stop(self, cnum=1):
         """Defines the stop frequency for a frequency sweep which is equal to the right edge of a Cartesian diagram.
-
-         [SENSe<Ch>:]FREQuency:STOP <stop_frequency>
+    
+         [SENSe<Ch>:]FREQuency:STOP <stop_frequency> 
         """
         scpi_command = scpi_preprocess(":SENS{:}:FREQ:STOP?", cnum)
         value = self.query(scpi_command)
@@ -871,7 +871,7 @@ class SCPI(object):
 
     def query_format_binary(self):
         """Controls whether binary data is transferred in normal or swapped byte order.
-
+    
          FORMat:BORDer NORMal | SWAPped
          """
         scpi_command = ":FORM:BORD?"
@@ -881,15 +881,15 @@ class SCPI(object):
 
     def query_format_data(self):
         """Selects the format for numeric data transferred to and from the analyzer.
-
+    
          FORMat[:DATA] ASCii | REAL [,<length>]
-
+    
          NOTE:
          The format setting is only valid for commands and queries whose
          description states that the response is formatted as described by
          FORMat[:DATA]. In particular, it affects trace data transferred by means
          of the commands in the TRACe:... system.
-
+    
          The default length of REAL data is 32 bits (single precision).
          """
         scpi_command = ":FORM:DATA?"
@@ -899,7 +899,7 @@ class SCPI(object):
 
     def query_init_continuous(self, cnum=1):
         """Qualifies whether the analyzer measures in single sweep or in continuous sweep mode.
-
+    
          INITiate<Ch>:CONTinuous <Boolean>
          """
         scpi_command = scpi_preprocess(":INIT{:}:CONT?", cnum)
@@ -909,9 +909,9 @@ class SCPI(object):
 
     def query_init_immediate_scope(self, cnum=1):
         """Selects the scope of the single sweep sequence.
-
+    
          The setting is applied in single sweep mode only (INITiate<Ch>:CONTinuous OFF).
-
+    
          NITiate<Ch>[:IMMediate]:SCOPe ALL | SINGle
          """
         scpi_command = scpi_preprocess(":INIT{:}:IMM:SCOP?", cnum)
@@ -923,12 +923,12 @@ class SCPI(object):
         """Returns the trace names and measured quantities of all traces assigned to a particular channel."""
         scpi_command = scpi_preprocess(":CALC{:}:PAR:CAT?", cnum)
         value = self.query(scpi_command)
-        value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
+        value = process_query(value, csv=True, strip_outer_quotes=True, returns='str')
         return value
 
     def query_par_select(self, cnum=1):
         """Selects an existing trace as the active trace of the channel.
-
+    
          All trace commands without explicit reference to the trace name act on
          the active trace (e.g. CALCulate<Chn>:FORMat).
          CALCulate<Ch>:PARameter:SELect is also necessary if the active trace of
@@ -941,9 +941,9 @@ class SCPI(object):
 
     def query_rbw(self, cnum=1):
         """Defines the resolution bandwidth of the analyzer (Meas. Bandwidth).
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution] <bandwidth>
-
+    
          <Ch>  Channel number. If unspecified the numeric suffix is set to 1.
          <bandwidth>
          Resolution bandwidth
@@ -955,9 +955,9 @@ class SCPI(object):
 
     def query_rbw_reduction(self, cnum=1):
         """Enables or disables dynamic bandwidth reduction at low frequencies.
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:DREDuction <Boolean>
-
+    
          <Ch>        Channel number
          <Boolean>    ON | OFF – enable or disable dynamic bandwidth reduction.
         """
@@ -968,11 +968,11 @@ class SCPI(object):
 
     def query_rbw_select(self, cnum=1):
         """Defines the selectivity of the IF filter for an unsegmented sweep.
-
+    
          The value is also used for all segments of a segmented sweep,
          provided that separate selectivity setting is disabled
          ([SENSe<Ch>:]SEGMent<Seg>:BWIDth[:RESolution]:SELect:CONTrol OFF).
-
+    
          [SENSe<Ch>:]BANDwidth|BWIDth[:RESolution]:SELect NORMal | HIGH
         """
         scpi_command = scpi_preprocess(":SENS{:}:BAND:SEL?", cnum)
@@ -982,7 +982,7 @@ class SCPI(object):
 
     def query_sweep_count(self, cnum=1):
         """Defines the number of sweeps to be measured in single sweep mode
-
+    
          (INITiate<Ch>:CONTinuous OFF).
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:COUN?", cnum)
@@ -999,10 +999,10 @@ class SCPI(object):
 
     def query_sweep_spacing(self, cnum=1):
         """Defines the frequency vs. time characteristics of a frequency sweep
-
+    
          (Lin. Frequency or Log Frequency). The command has no effect on segmented
          frequency, power or time sweeps.
-
+    
          [SENSe<Ch>:]SWEep:SPACing  LINear | LOGarithmic
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:SPAC?", cnum)
@@ -1012,7 +1012,7 @@ class SCPI(object):
 
     def query_sweep_step(self, cnum=1):
         """Sets the distance between two consecutive sweep points.
-
+    
          [SENSe<Ch>:]SWEep:STEP <step_size>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:STEP?", cnum)
@@ -1022,10 +1022,10 @@ class SCPI(object):
 
     def query_sweep_time(self, cnum=1):
         """Sets the duration of the sweep (Sweep Time).
-
+    
          Setting a duration disables the automatic calculation of the (minimum) sweep time;
          see [SENSe<Ch>:]SWEep:TIME:AUTO.
-
+    
          [SENSe<Ch>:]SWEep:TIME <duration>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME?", cnum)
@@ -1035,9 +1035,9 @@ class SCPI(object):
 
     def query_sweep_time_auto(self, cnum=1):
         """When enabled, the (minimum) sweep duration is calculated internally
-
+    
          using the other channel settings and zero delay ([SENSe<Ch>:]SWEep:DWELl).
-
+    
          [SENSe<Ch>:]SWEep:TIME:AUTO <Boolean>
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TIME:AUTO?", cnum)
@@ -1047,10 +1047,10 @@ class SCPI(object):
 
     def query_sweep_type(self, cnum=1):
         """Selects the sweep type,
-
+    
          i.e. the sweep variable (frequency/power/time) and the position of the
          sweep points across the sweep range.
-
+    
          [SENSe<Ch>:]SWEep:TYPE LINear | LOGarithmic | SEGMent | POWer | CW | POINt | PULSe | IAMPlitude | IPHase
          """
         scpi_command = scpi_preprocess(":SENS{:}:SWE:TYPE?", cnum)

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -15,11 +15,11 @@ COMMAND_TREE:
         CALL:
           command: {name: data_call, query_values: "<SDATA>"}
           branch:
-            CAT: {name: data_call_catalog, query: ""}
+            CAT: {name: data_call_catalog, query: "", csv: True}
         DALL: {name: data_dall, query_values: "<SDATA>"}
         SGR: {name: data_sgroup, query_values: "<SDATA>"}
     PAR:
-      CAT: {name: par_catalog, query: "",
+      CAT: {name: par_catalog, query: "", csv: True,
         help: "Returns the trace names and measured quantities of all traces assigned to a particular channel."
       }
       DEL:

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -52,7 +52,7 @@ COMMAND_TREE:
         \tall channels and traces, including the traces that are not displayed.\n
         \t"
       }
-      SEL: {name: par_select, set: "'TRACE'", query: "",
+      SEL: {name: par_select, set: "'<TRACE>'", query: "",
         help: "Selects an existing trace as the active trace of the channel.\n\n
         \tAll trace commands without explicit reference to the trace name act on\n
         \tthe active trace (e.g. CALCulate<Chn>:FORMat).\n


### PR DESCRIPTION
Add the following functions to R&Z ZVA:
- get_snp_network (enables get_oneport and get_twoport from base class)
- get_active_trace_as_network

Also changes to the SCPI parser so that everything is read and written with utf8 encoding
Some minor bug fixes as well

@beuerle, @torgovanov - I would appreciate a little testing with your equipment if possible as I have a ZVA here that is running Windows XP, and a little broader testing base would be a good thing.

![image](https://user-images.githubusercontent.com/9872343/32236061-274e9fc8-be2f-11e7-97e8-39bee5b1d1cf.png)
