### PR TITLE
Update colors() for matplotlib 2.0

### DIFF
--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -719,7 +719,7 @@ def plot_vector(a, off=0+0j, *args, **kwargs):
 
 
 def colors():
-    return rcParams['axes.color_cycle']
+    return [c['color'] for c in rcParams['axes.prop_cycle']]
 
 
 PRIMARY_PROPERTIES = network.PRIMARY_PROPERTIES


### PR DESCRIPTION
matplotlib was issuing a `MatplotlibDeprecationWarning` for the use of
`rcParams['axes.color_cycle']`.  This uses the Cycler object to accomplish the same task.