### PR TITLE
add missing quotations to trace functions

### DIFF
--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -279,18 +279,18 @@ class SCPI(object):
     
          DISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'
          """
-        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:EFE {:}", wnum, tnum, TRACENAME)
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:EFE '{:}'", wnum, tnum, TRACENAME)
         self.write(scpi_command)
 
     def set_disp_trace_feed(self, wnum=1, tnum=1, TRACENAME=""):
-        """Assigns an existing traceto a diagram area.
+        """Assigns an existing trace to a diagram area.
     
          Assigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)
          to a diagram area, using the <WndTr> suffix, and displays the trace. Use
          DISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area
          without using a numeric suffix.
          """
-        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:FEED {:}", wnum, tnum, TRACENAME)
+        scpi_command = scpi_preprocess(":DISP:WIND{:}:TRAC{:}:FEED '{:}'", wnum, tnum, TRACENAME)
         self.write(scpi_command)
 
     def set_disp_trace_pdiv(self, wnum=1, tnum=1, value="", TRACENAME="None"):

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -133,7 +133,7 @@ COMMAND_TREE:
           \tmust be done via CALCulate<Ch>:PARameter:DELete <Trace_Name>.\n
           \t"
         }
-        EFE: {name: disp_trace_efeed, set: "<TRACENAME>",
+        EFE: {name: disp_trace_efeed, set: "'<TRACENAME>'",
           help: "Assigns an existing trace to a diagram area.\n\n
           \tAssigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)\n
           \tto a diagram area <Wnd>, and displays the trace. Use\n
@@ -143,8 +143,8 @@ COMMAND_TREE:
           \tDISPlay[:WINDow<Wnd>]:TRACe<WndTr>:EFEed '<trace_name>'\n
           \t"
         }
-        FEED: {name: disp_trace_feed, set: "<TRACENAME>",
-          help: "Assigns an existing traceto a diagram area.\n\n
+        FEED: {name: disp_trace_feed, set: "'<TRACENAME>'",
+          help: "Assigns an existing trace to a diagram area.\n\n
           \tAssigns an existing trace (CALCulate<Ch>:PARameter:SDEFine <Trace_Name>)\n
           \tto a diagram area, using the <WndTr> suffix, and displays the trace. Use\n
           \tDISPlay[:WINDow<Wnd>]:TRACe:EFEed to assign the trace to a diagram area\n


### PR DESCRIPTION
The missing quotations caused an error on the VNA and no traces were
added. Fixed and tested.