### PR TITLE
Fix time-domain conversions

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -173,9 +173,9 @@ from .time import time_gate
 
 from .constants import ZERO
 
-def s_to_time(s, pad=0):
+def s_to_time(s, n=None):
     """Transforms S-parameters to time-domain"""
-    return npy.fft.fftshift(npy.fft.irfft(s, axis=0, n=s.shape[0]+pad), axes=0)
+    return npy.fft.fftshift(npy.fft.irfft(s, axis=0, n=n), axes=0)
 
 class Network(object):
     """
@@ -1401,12 +1401,12 @@ class Network(object):
             raise NotImplementedError('only s-parameters supported for now.')
 
         self.comments = touchstoneFile.get_comments()
-        
+
         try:
             self.variables = touchstoneFile.get_comment_variables()
         except:
             pass
-        
+
         self.port_names = touchstoneFile.port_names
 
         # set z0 before s so that y and z can be computed
@@ -1431,8 +1431,8 @@ class Network(object):
                     print('warning: couldn\'t inspect network name')
                     self.name = ''
                 pass
-               
-        
+
+
 
     @classmethod
     def zipped_touchstone(cls, filename, archive):
@@ -2629,7 +2629,7 @@ class Network(object):
         Xi_tilde = npy.einsum('...ij,...jk->...ik', npy.einsum('...ij,...jk->...ik', P, Xi), QT)
         return Xi_tilde[:, :n, :n], Xi_tilde[:, :n, n:], Xi_tilde[:, n:, :n], Xi_tilde[:, n:, n:]
 
-    def impulse_response(self, window='hamming', pad=1000, bandpass=None):
+    def impulse_response(self, window='hamming', n=None, pad=1000, bandpass=None):
         """Calculates time-domain impulse response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
@@ -2646,6 +2646,10 @@ class Network(object):
         -----------
         window : string
                 FFT windowing function.
+        n : int
+                Length of impulse response output.
+                If n is not specified, 2 * (m - 1) points are used,
+                where m = len(self) + pad
         pad : int
                 Number of zeros to add as padding for FFT.
                 Adding more zeros improves accuracy of peaks.
@@ -2669,8 +2673,16 @@ class Network(object):
         """
         if self.nports != 1:
             raise ValueError('Only one-ports are supported')
+        if n is None:
+            # Use zero-padding specification. Note that this does not allow n odd.
+            n = 2 * (self.frequency.npoints + pad - 1)
+
         fstep = self.frequency.step
-        t = npy.linspace(-.5/fstep , .5/fstep, self.frequency.npoints+pad)
+        if n % 2 == 0:
+            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n, endpoint=False))
+        else:
+            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n + 1, endpoint=False))
+            t = t[:-1]
         if bandpass in (True, False):
             center_to_dc = not bandpass
         else:
@@ -2679,9 +2691,9 @@ class Network(object):
             w = self.windowed(window=window, normalize=False, center_to_dc=center_to_dc)
         else:
             w = self
-        return t, s_to_time(w.s, pad=pad).flatten()
+        return t, s_to_time(w.s, n=n).flatten()
 
-    def step_response(self, window='hamming', pad=1000):
+    def step_response(self, window='hamming', n=None, pad=1000):
         """Calculates time-domain step response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
@@ -2696,6 +2708,10 @@ class Network(object):
         -----------
         window : string
                 FFT windowing function.
+        n : int
+                Length of step response output.
+                If n is not specified, 2 * (m - 1) points are used,
+                where m = len(self) + pad
         pad : int
                 Number of zeros to add as padding for FFT.
                 Adding more zeros improves accuracy of peaks.
@@ -2719,13 +2735,22 @@ class Network(object):
                 "Frequency doesn't begin from 0. Step response will not be correct.",
                 RuntimeWarning
             )
+        if n is None:
+            # Use zero-padding specification. Note that this does not allow n odd.
+            pad = 1000
+            n = 2 * (self.frequency.npoints + pad - 1)
+
         fstep = self.frequency.step
-        t = npy.linspace(-.5/fstep , .5/fstep, self.frequency.npoints+pad)
+        if n % 2 == 0:
+            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n, endpoint=False))
+        else:
+            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n + 1, endpoint=False))
+            t = t[:-1]
         if window != None:
             w = self.windowed(window=window, normalize=False, center_to_dc=True)
         else:
             w = self
-        return t, npy.cumsum(s_to_time(w.s, pad=pad).flatten())
+        return t, npy.cumsum(s_to_time(w.s, n=n).flatten())
 
 
 ## Functions operating on Network[s]

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -55,6 +55,31 @@ class NetworkTestCase(unittest.TestCase):
         t = self.ntwk1.s11.s_time
         self.assertTrue(npy.sum(npy.abs(t.imag)) == 0)
 
+    def test_time_transform(self):
+        spb = (4, 5)
+        data_rate = 5e9
+        num_taps = (100, 101)
+        for i in range(2):
+            tps = 1 / spb[i] / data_rate
+            num_points = spb[i] * num_taps[i]
+            # Frequency terms should NOT contain Nyquist frequency if number of points is odd
+            inc_nyq = True if num_points % 2 == 0 else False
+            freq = npy.linspace(0, 1 / 2 / tps, num_points // 2 + 1, endpoint=inc_nyq)
+
+            dut = self.ntwk1.copy()
+            freq_valid = freq[npy.logical_and(freq >= dut.f[0], freq <= dut.f[-1])]
+            dut.interpolate_self(rf.Frequency.from_f(freq_valid, unit='hz'))
+
+            dut_dc = dut.extrapolate_to_dc()
+            t, y = dut_dc.s21.impulse_response(n=num_points)
+            self.assertEqual(len(t), num_points)
+            self.assertEqual(len(y), num_points)
+            self.assertTrue(npy.isclose(t[1]-t[0], tps))
+            t, y = dut_dc.s21.step_response(n=num_points)
+            self.assertEqual(len(t), num_points)
+            self.assertEqual(len(y), num_points)
+            self.assertTrue(npy.isclose(t[1] - t[0], tps))
+
     def test_constructor_empty(self):
         rf.Network()
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -60,11 +60,11 @@ class NetworkTestCase(unittest.TestCase):
         data_rate = 5e9
         num_taps = (100, 101)
         for i in range(2):
-            tps = 1 / spb[i] / data_rate
+            tps = 1. / spb[i] / data_rate
             num_points = spb[i] * num_taps[i]
             # Frequency terms should NOT contain Nyquist frequency if number of points is odd
             inc_nyq = True if num_points % 2 == 0 else False
-            freq = npy.linspace(0, 1 / 2 / tps, num_points // 2 + 1, endpoint=inc_nyq)
+            freq = npy.linspace(0, 1. / 2 / tps, num_points // 2 + 1, endpoint=inc_nyq)
 
             dut = self.ntwk1.copy()
             freq_valid = freq[npy.logical_and(freq >= dut.f[0], freq <= dut.f[-1])]
@@ -74,7 +74,7 @@ class NetworkTestCase(unittest.TestCase):
             t, y = dut_dc.s21.impulse_response(n=num_points)
             self.assertEqual(len(t), num_points)
             self.assertEqual(len(y), num_points)
-            self.assertTrue(npy.isclose(t[1]-t[0], tps))
+            self.assertTrue(npy.isclose(t[1] - t[0], tps))
             t, y = dut_dc.s21.step_response(n=num_points)
             self.assertEqual(len(t), num_points)
             self.assertEqual(len(y), num_points)


### PR DESCRIPTION
Fixes and unit test for #195. Use the expected number of frequency and pad points, and return the correct time vector points and interval spacing. Allow an odd number of points in the output time-domain response by specifying an explicit 'n' argument.