### PR TITLE
New get_frequency implementation

### DIFF
--- a/skrf/vi/vna/keysight_pna.py
+++ b/skrf/vi/vna/keysight_pna.py
@@ -366,16 +366,13 @@ class PNA(abcvna.VNA):
         """
         self.resource.clear()
         channel = kwargs.get("channel", self.active_channel)
-        use_log = "LOG" in self.scpi.query_sweep_type(channel).upper()
-        f_start = self.scpi.query_f_start(channel)
-        f_stop = self.scpi.query_f_stop(channel)
-        f_npoints = self.scpi.query_sweep_n_points(channel)
-        if use_log:
-            freq = np.logspace(np.log10(f_start), np.log10(f_stop), f_npoints)
+        sweep_type = self.scpi.query_sweep_type(channel)
+        if sweep_type in ["LIN", "LOG", "SEGM"]:
+            freqs = self.scpi.query_sweep_data(channel)
         else:
-            freq = np.linspace(f_start, f_stop, f_npoints)
+            freqs = np.array([self.scpi.query_f_start(channel)])
 
-        frequency = skrf.Frequency.from_f(freq, unit="Hz")
+        frequency = skrf.Frequency.from_f(freqs, unit="Hz")
         frequency.unit = kwargs.get("f_unit", "Hz")
         return frequency
 

--- a/skrf/vi/vna/keysight_pna_scpi.py
+++ b/skrf/vi/vna/keysight_pna_scpi.py
@@ -406,6 +406,11 @@ class SCPI(object):
         value = process_query(value, csv=False, strip_outer_quotes=True, returns='str')
         return value
 
+    def query_sweep_data(self, cnum=1):
+        """no help available"""
+        scpi_command = scpi_preprocess(":SENS{:}:X:VALUES?", cnum)
+        return self.query_values(scpi_command)
+
     def query_sweep_mode(self, cnum=1):
         """no help available"""
         scpi_command = scpi_preprocess(":SENS{:}:SWE:MODE?", cnum)

--- a/skrf/vi/vna/keysight_pna_scpi.yaml
+++ b/skrf/vi/vna/keysight_pna_scpi.yaml
@@ -62,6 +62,8 @@ COMMAND_TREE:
       TIME: {name: sweep_time, query: "", returns: float}
       TYPE: {name: sweep_type, set: <sweep_type=LIN>, query: ""}
       POIN: {name: sweep_n_points, set: <n_points=401>, query: "", returns: int}
+    X:
+      VALUES: {name: sweep_data, query_values: ""}
   SYST:
     CHAN:
       CAT: {name: available_channels, query: "", csv: True, returns: int}


### PR DESCRIPTION
Issue #29 mentions that LOG frequency sweeps are not handled properly and  could be done using np.logspace. This has been fixed recently but there is still another case that is not handled by get_frequency and that is the segmented sweep. A simpler solution is to use the SENS:X? command to read a vector of the x-axis sweep data. But a special case is needed for CW and POW that has constant frequency.

The new implementation use SENS:X:VALUE to get the frequency data when the sweep type is LIN, LOG or SEGM. Otherwise we just query_f_start, POW, CW, use a constant frequency.

I'm new to the scpi.yaml stuff so I may have misunderstood something.