### PR TITLE
Fix network.plot_s_db_time() issue

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -518,7 +518,14 @@ class Frequency(object):
 
         t_period = 1/f_step
         '''
-        return linspace(-.5/self.step , .5/self.step, self.npoints)
+        n = 2 * (self.npoints - 1)
+        if n % 2 == 0:
+            t = npy.flipud(npy.linspace(.5 / self.step, -.5 / self.step, n, endpoint=False))
+        else:
+            t = npy.flipud(npy.linspace(.5 / self.step, -.5 / self.step, n + 1, endpoint=False))
+            t = t[:-1]
+        #return linspace(-.5/self.step , .5/self.step, self.npoints)
+        return t
 
     @property
     def t_ns(self):

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -1245,7 +1245,7 @@ def plot_reciprocity2(self, db=False, *args, **kwargs):
 
 
 def plot_s_db_time(self,*args,**kwargs):
-    return self.windowed().plot_s_time_db(*args,**kwargs)
+    return self.windowed(center_to_dc=True).plot_s_time_db(*args,**kwargs)
 
 
 # plotting


### PR DESCRIPTION
Fix `network.plot_s_db_time()` issue induced by #197
- `frequency.t` and `frequency.t_ns` range is doubled to be coherent with irfft results.
- `network.windowed` is centered around dc point to produce the correct impulse response.