### PR TITLE
Update time.py (time_gate function)

### DIFF
--- a/skrf/time.py
+++ b/skrf/time.py
@@ -231,7 +231,7 @@ def time_gate(ntwk, start=None, stop=None, center=None, span=None,
         start *= 1e-9
         stop *= 1e-9
         span = abs(stop-start)
-        center = (stop-start)/2.
+        center = (stop+start)/2.
     
     else:
         if center is None:    
@@ -263,7 +263,7 @@ def time_gate(ntwk, start=None, stop=None, center=None, span=None,
                            npy.zeros(len(t) - stop_idx)]
 
     #IFFT the gate, so we have it's frequency response, aka kernel
-    kernel=fft.fftshift(fft.ifft(fft.fftshift(gate, axes=0), axis=0))
+    kernel=fft.fftshift(fft.ifft(fft.ifftshift(gate, axes=0), axis=0))
     kernel =abs(kernel).flatten() # take mag and flatten
     kernel=kernel/sum(kernel) # normalize kernel
     


### PR DESCRIPTION
I've started using skrf recently and find it very intuitive to use! Thanks very much for making this package available.

I'd like to recommend some changes to the time_gate function.
I get strange results using start and stop for the time_gate. I believe line 234 should be:
center = (stop + start)/2  # no minus sign

Also line 266 I believe should be fftshift(ifft(**i**fftshift(...etc in order to be compatible with an odd amount of datapoints. 
Shouldn't matter too much for the end-result though.
Also, using (i)fftshift here (line 266) implies that gate has it's zero phase component in the center of the dataset. This is not how gate is created in line 261. Nevertheless, since only the abs value is used (line 267), it should be sufficient to use only an ifft in line 266:
kernel = fft.ifft(gate)  # not sure, I did not test this (yet)

Cheers, 

Yuri