### PR TITLE
Adding format spec

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1597,12 +1597,6 @@ class Network(object):
         else:
             raise ValueError('`form` must be either `db`,`ma`,`ri`')
 
-        for name,value in zip(['format_spec_A','format_spec_B','format_spec_freq'],[format_spec_A,format_spec_B,format_spec_freq]):
-            try:  # hopefully this doesn't cause anyone to not be able to use a format specifier that doesn't work on 1
-                value.format(1) # dumping anonymous string to test if format specs actually work before throwing mysterious errors
-            except Exception as e:
-                raise ValueError("{} = '{}' failed for 1.0, check format spec.".format(name,value)) from e # couldn't get a warning to work properly here...
-
         # add formatting to funcA and funcB so we don't have to write it out many many times. 
         def c2str_A(c):
             '''Function which takes a complex number for the A part of param and returns an appropriately formatted string'''


### PR DESCRIPTION
Added kwargs to rf.Network.write_touchstone() that allows a user to specify format strings for frequency, the 'A' part of the paramater to be written, and the 'B' part of the parameter to be written ( e.g. separate magnitude and angle format specs for a touchstone with MA format. 

As this addition by default calls the __str__ method on all of the data, it is non-breaking and is consistent with old behaviour ( which just called __str__() on the data )

With format specs:
>>> from skrf import Network
>>> n = Network(r'data\ntwk1.s2p')
>>> print(n.write_touchstone(return_string=True,format_spec_freq='{:<11}',format_spec_A='{: 10.7E}',format_spec_B="{: 10.7E}"))
! Created Thu Nov 11 11:09:06 2010
!
!Created with skrf (http://scikit-rf.org).
# GHz S RI R 50.0
!freq ReS11 ImS11 ReS21 ImS21 ReS12 ImS12 ReS22 ImS22
1.0          2.1792049E-02 -1.5151417E-01  9.2674656E-01 -1.7008943E-01  9.2674656E-01 -1.7008943E-01  2.3476917E-02 -1.2172808E-01
1.1          1.6504040E-02 -1.6581291E-01  9.2149708E-01 -1.8625774E-01  9.2149708E-01 -1.8625774E-01  1.8538756E-02 -1.3307853E-01
1.2          1.0764864E-02 -1.7987713E-01  9.1579936E-01 -2.0219482E-01  9.1579936E-01 -2.0219482E-01  1.3181209E-02 -1.4420286E-01

Without format specs:

>>> print(n.write_touchstone(return_string=True))
! Created Thu Nov 11 11:09:06 2010
!
!Created with skrf (http://scikit-rf.org).
# GHz S RI R 50.0
!freq ReS11 ImS11 ReS21 ImS21 ReS12 ImS12 ReS22 ImS22
1.0 0.0217920488 -0.151514165 0.926746562 -0.170089428 0.926746562 -0.170089428 0.0234769169 -0.121728077
1.1 0.0165040395 -0.165812914 0.92149708 -0.186257735 0.92149708 -0.186257735 0.0185387559 -0.133078528
1.2 0.0107648639 -0.179877134 0.915799359 -0.202194824 0.915799359 -0.202194824 0.0131812086 -0.144202856

