### PR TITLE
Docs: Fixed typo

### DIFF
--- a/doc/source/tutorials/Installation.ipynb
+++ b/doc/source/tutorials/Installation.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "## Other Optional Modules\n",
     "\n",
-    "Some features of scikit-rf wont be available untill you install additional\n",
+    "Some features of scikit-rf wont be available until you install additional\n",
     "modules. You can install these using conda or pip.\n",
     "\n",
     "### Instrument Control\n",


### PR DESCRIPTION
I'm just getting started but spotted a typo in the install docs so here's a quick PR.