### PR TITLE
Matplotlib compatibility updates

### DIFF
--- a/skrf/data/skrf2.mplstyle
+++ b/skrf/data/skrf2.mplstyle
@@ -17,7 +17,7 @@ axes.titlesize : 13
 axes.labelsize : 11
 axes.labelcolor : black #555555
 axes.axisbelow : True     
-axes.color_cycle : 348ABD, b74331,8EBA42, FBC15E, 988ED5,  FFB5B8, 777777
+axes.prop_cycle : cycler('color', ['348ABD', 'b74331', '8EBA42', 'FBC15E', '988ED5', 'FFB5B8', '777777'])
 
 xtick.color : black #555555
 xtick.direction : in #out

--- a/skrf/data/skrf2_wide.mplstyle
+++ b/skrf/data/skrf2_wide.mplstyle
@@ -17,7 +17,7 @@ axes.titlesize : 13
 axes.labelsize : 11
 axes.labelcolor : black #555555
 axes.axisbelow : True     
-axes.color_cycle : 348ABD, b74331,8EBA42, FBC15E, 988ED5,  FFB5B8, 777777
+axes.prop_cycle : cycler('color', ['348ABD', 'b74331', '8EBA42', 'FBC15E', '988ED5', 'FFB5B8', '777777'])
 
 xtick.color : black #555555
 xtick.direction : in #out

--- a/skrf/data/skrf_wide.mplstyle
+++ b/skrf/data/skrf_wide.mplstyle
@@ -17,7 +17,7 @@ axes.titlesize : 16
 axes.labelsize : 11
 axes.labelcolor : 555555
 axes.axisbelow : True     
-axes.color_cycle : 348ABD, b74331,8EBA42, FBC15E, 988ED5,  FFB5B8, 777777
+axes.prop_cycle : cycler('color', ['348ABD', 'b74331', '8EBA42', 'FBC15E', '988ED5', 'FFB5B8', '777777'])
 axes.xmargin: 0
 axes.ymargin: .2
 

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -1395,9 +1395,8 @@ def stylely(rc_dict={}, style_file = 'skrf.mplstyle'):
     '''
 
     from skrf.data import pwd # delayed to solve circular import
-    rc = mpl.rc_params_from_file(os.path.join(pwd, style_file))
-    mpl.rcParams.update(rc)
-    mpl.rcParams.update(rc_dict)
+    mpl.style.use(os.path.join(pwd, style_file))
+    mpl.rc(rc_dict)
 
 
 def plot_calibration_errors(self, *args, **kwargs):


### PR DESCRIPTION
- updated the definition of the color cycler to the latest matplotlib API
- updated the setting RC properties according to the latest matplotlib API
this should avoid some warning when using `skrf.stylely()` function