### PR TITLE
ABCD parameters correction

### DIFF
--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 import os
 import numpy as npy

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -72,8 +72,8 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         '''
         a = DefinedGammaZ0 (Frequency(1,10,101),gamma=1j,z0 = 50)
         self.assertEqual(a.line(1),a.line(1))
-        
-        # we should be able to re-sample the media 
+
+        # we should be able to re-sample the media
         a.npoints = 21
         self.assertEqual(len(a.gamma), len(a))
         self.assertEqual(len(a.z0), len(a))
@@ -89,8 +89,8 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
                            gamma = 1j*npy.ones(len(freq)) ,
                            z0 =  50*npy.ones(len(freq)),
                             )
-    
-        
+
+
         self.assertEqual(a.line(1),a.line(1))
         with self.assertRaises(NotImplementedError):
             a.npoints=4
@@ -101,7 +101,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         self.dummy_media.write_csv(fname)
         os.remove(fname)
 
-    
+
     def test_from_csv(self):
         fname = os.path.join(self.files_dir,\
                 'out.csv')
@@ -109,3 +109,204 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         a_media = DefinedGammaZ0.from_csv(fname)
         self.assertEqual(a_media,self.dummy_media)
         os.remove(fname)
+
+
+class STwoPortsNetworkTestCase(unittest.TestCase):
+    '''
+    Check that S parameters of media base elements versus theoretical results.
+    '''
+    def setUp(self):
+        self.dummy_media = DefinedGammaZ0(
+            frequency=Frequency(1, 100, 21, 'GHz'),
+            gamma=1j,
+            z0=50,
+            )
+
+    def test_s_series_element(self):
+        '''
+        Series elements of impedance Z:
+
+        ○---[Z]---○
+
+        ○---------○
+
+        have S matrix of the form:
+        [ Z/Z0 / (Z/Z0 + 2)     2/(Z/Z0 + 2) ]
+        [ 2/(Z/Z0 + 2)          Z/Z0 / (Z/Z0 + 2) ]
+        '''
+        R = 1  # Ohm
+        ntw = self.dummy_media.resistor(R)
+        Z0 = self.dummy_media.z0
+        S11 = (R/Z0) / (R/Z0 + 2)
+        S21 = 2 / (R/Z0 + 2)
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+
+    def test_s_shunt_element(self):
+        '''
+        Shunt elements of admittance Y:
+
+        ○---------○
+            |
+           [Y]
+            |
+        ○---------○
+
+        have S matrix of the form:
+        [ -Y Z0 / (Y Z0 + 2)     2/(Y Z0 + 2) ]
+        [ 2/(Y Z0 + 2)          Z/Z0 / (Y Z0 + 2) ]
+        '''
+        R = 1  # Ohm
+        ntw = self.dummy_media.shunt(self.dummy_media.resistor(R)**self.dummy_media.short())
+        Z0 = self.dummy_media.z0
+        S11 = -(1/R*Z0) / (1/R*Z0 + 2)
+        S21 = 2 / (1/R*Z0 + 2)
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+
+
+class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
+    '''
+    Check that ABCD parameters of media base elements (such as lumped elements)
+    versus theoretical results.
+    '''
+    def setUp(self):
+        self.dummy_media = DefinedGammaZ0(
+            frequency=Frequency(1, 100, 21,'GHz'),
+            gamma=1j,
+            z0=50 ,
+            )
+
+    def test_abcd_series_element(self):
+        '''
+        Series elements of impedance Z:
+
+        ○---[Z]---○
+
+        ○---------○
+
+        have ABCD matrix of the form:
+        [ 1  Z ]
+        [ 0  1 ]
+        '''
+        R = 1  # Ohm
+        ntw = self.dummy_media.resistor(R)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], R)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+
+    def test_abcd_shunt_element(self):
+        '''
+        Shunt elements of admittance Y:
+
+        ○---------○
+            |
+           [Y]
+            |
+        ○---------○
+
+        have ABCD matrix of the form:
+        [ 1  0 ]
+        [ Y  1 ]
+        '''
+        R = 1  # Ohm
+        ntw = self.dummy_media.shunt(self.dummy_media.resistor(R)**self.dummy_media.short())
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/R)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+
+    def test_abcd_series_shunt_elements(self):
+        '''
+        Series and Shunt elements of impedance Zs and Zp:
+
+        ○---[Zs]--------○
+                 |
+                [Zp]
+                 |
+        ○--------------○
+        have ABCD matrix of the form:
+        [ 1 + Zs/Zp    Zs ]
+        [ 1/Zp          1 ]
+        '''
+        Rs = 2
+        Rp = 3
+        serie_resistor = self.dummy_media.resistor(Rs)
+        shunt_resistor = self.dummy_media.shunt(self.dummy_media.resistor(Rp) ** self.dummy_media.short())
+
+        ntw = serie_resistor ** shunt_resistor
+
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1+Rs/Rp)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], Rs)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/Rp)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+
+    def test_abcd_thru(self):
+        '''
+        Thru has ABCD matrix of the form:
+        [ 1  0 ]
+        [ 0  1 ]
+        '''
+        ntw = self.dummy_media.thru()
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+
+    def test_abcd_lossless_line(self):
+        '''
+        Lossless transmission line of characteristic impedance Z0, length l
+        and wavenumber beta
+
+        ○---------○
+
+        ○---------○
+
+        has ABCD matrix of the form:
+
+        [ cos(beta l)       j Z0 sin(beta l) ]
+        [ j/Z0 sin(beta l)  cos(beta l) ]
+        '''
+        l = 5
+        z0 = 80
+        ntw = self.dummy_media.line(d=l, unit='m', z0=z0)
+        beta = self.dummy_media.beta
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], npy.cos(beta*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 1j*z0*npy.sin(beta*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1j/z0*npy.sin(beta*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], npy.cos(beta*l))
+
+    def test_abcd_lossy_line(self):
+        '''
+        Lossy transmission line of characteristic impedance Z0, length l
+        and propagation constant gamma = alpha + j beta
+
+        ○---------○
+
+        ○---------○
+
+        has ABCD matrix of the form:
+
+        [ cosh(gamma l)       Z0 sinh(gamma l) ]
+        [ 1/Z0 sinh(gamma l)  cosh(gamma l) ]
+        '''
+        l = 5
+        z0 = 30
+        alpha = 0.5
+        beta = 2
+        lossy_media = DefinedGammaZ0(
+            frequency=Frequency(1, 100, 21, 'GHz'),
+            gamma=alpha + 1j*beta,
+            z0=z0
+            )
+        ntw = lossy_media.line(d=l, unit='m', z0=z0)
+        gamma = lossy_media.gamma
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], npy.cosh(gamma*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], z0*npy.sinh(gamma*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/z0*npy.sinh(gamma*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], npy.cosh(gamma*l))

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -135,7 +135,7 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         [ Z/Z0 / (Z/Z0 + 2)     2/(Z/Z0 + 2) ]
         [ 2/(Z/Z0 + 2)          Z/Z0 / (Z/Z0 + 2) ]
         '''
-        R = 1  # Ohm
+        R = 1.0  # Ohm
         ntw = self.dummy_media.resistor(R)
         Z0 = self.dummy_media.z0
         S11 = (R/Z0) / (R/Z0 + 2)
@@ -159,7 +159,7 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         [ -Y Z0 / (Y Z0 + 2)     2/(Y Z0 + 2) ]
         [ 2/(Y Z0 + 2)          Z/Z0 / (Y Z0 + 2) ]
         '''
-        R = 1  # Ohm
+        R = 1.0  # Ohm
         ntw = self.dummy_media.shunt(self.dummy_media.resistor(R)**self.dummy_media.short())
         Z0 = self.dummy_media.z0
         S11 = -(1/R*Z0) / (1/R*Z0 + 2)
@@ -179,8 +179,8 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         ○-----_______-----○
 
         '''
-        l = 5
-        z1 = 30
+        l = 5.0
+        z1 = 30.0
         z0 = self.dummy_media.z0
 
         ntw = self.dummy_media.line(d=0, unit='m', z0=z0) \
@@ -238,12 +238,12 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ 1  Z ]
         [ 0  1 ]
         '''
-        R = 1  # Ohm
+        R = 1.0  # Ohm
         ntw = self.dummy_media.resistor(R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
         npy.testing.assert_array_almost_equal(ntw.a[:,0,1], R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_shunt_element(self):
         '''
@@ -259,12 +259,12 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ 1  0 ]
         [ Y  1 ]
         '''
-        R = 1  # Ohm
+        R = 1.0  # Ohm
         ntw = self.dummy_media.shunt(self.dummy_media.resistor(R)**self.dummy_media.short())
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/R)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_series_shunt_elements(self):
         '''
@@ -279,17 +279,17 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ 1 + Zs/Zp    Zs ]
         [ 1/Zp          1 ]
         '''
-        Rs = 2
-        Rp = 3
+        Rs = 2.0
+        Rp = 3.0
         serie_resistor = self.dummy_media.resistor(Rs)
         shunt_resistor = self.dummy_media.shunt(self.dummy_media.resistor(Rp) ** self.dummy_media.short())
 
         ntw = serie_resistor ** shunt_resistor
 
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1+Rs/Rp)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0+Rs/Rp)
         npy.testing.assert_array_almost_equal(ntw.a[:,0,1], Rs)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/Rp)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/Rp)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_thru(self):
         '''
@@ -298,10 +298,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ 0  1 ]
         '''
         ntw = self.dummy_media.thru()
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0.0)
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_lossless_line(self):
         '''
@@ -340,10 +340,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ cosh(gamma l)       Z0 sinh(gamma l) ]
         [ 1/Z0 sinh(gamma l)  cosh(gamma l) ]
         '''
-        l = 5
-        z0 = 30
+        l = 5.0
+        z0 = 30.0
         alpha = 0.5
-        beta = 2
+        beta = 2.0
         lossy_media = DefinedGammaZ0(
             frequency=Frequency(1, 100, 21, 'GHz'),
             gamma=alpha + 1j*beta,
@@ -353,5 +353,5 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         gamma = lossy_media.gamma
         npy.testing.assert_array_almost_equal(ntw.a[:,0,0], npy.cosh(gamma*l))
         npy.testing.assert_array_almost_equal(ntw.a[:,0,1], z0*npy.sinh(gamma*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1/z0*npy.sinh(gamma*l))
+        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/z0*npy.sinh(gamma*l))
         npy.testing.assert_array_almost_equal(ntw.a[:,1,1], npy.cosh(gamma*l))

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -168,6 +168,50 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
         npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
 
+    def test_s_lossless_line(self):
+        '''
+        Lossless transmission line of characteristic impedance z1, length l
+        and wavenumber beta
+              _______
+        ○-----       -----○
+          z0     z1    z0
+        ○-----_______-----○
+
+        '''
+        l = 5
+        z1 = 30
+        z0 = self.dummy_media.z0
+
+        ntw = self.dummy_media.line(d=0, unit='m', z0=z0) \
+            ** self.dummy_media.line(d=l, unit='m', z0=z1) \
+            ** self.dummy_media.line(d=0, unit='m', z0=z0)
+
+        beta = self.dummy_media.beta
+        _z1 = z1/z0
+        S11 = 1j*(_z1**2 - 1)*npy.sin(beta*l) / \
+            (2*_z1*npy.cos(beta*l) + 1j*(_z1**2 + 1)*npy.sin(beta*l))
+        S21 = 2*_z1 / \
+            (2*_z1*npy.cos(beta*l) + 1j*(_z1**2 + 1)*npy.sin(beta*l))
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
+        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
+        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+
+    def test_s_lossy_line(self):
+        '''
+        Lossy transmission line of characteristic impedance Z0, length l
+        and propagation constant gamma = alpha + j beta
+
+        ○---------○
+
+        ○---------○
+
+        has ABCD matrix of the form:
+
+        [ cosh(gamma l)       Z0 sinh(gamma l) ]
+        [ 1/Z0 sinh(gamma l)  cosh(gamma l) ]
+        '''
+
 
 class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
     '''

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4213,8 +4213,34 @@ def a2s(a, z0=50):
         abcd parameters
 
     '''
+    nfreqs, nports, nports = a.shape
 
-    return z2s(a2z(a), z0)
+    if nports != 2:
+        raise IndexError('abcd parameters are defined for 2-ports networks only')
+
+    z0 = fix_z0_shape(z0, nfreqs, nports)
+    z01 = z0[:,0]
+    z02 = z0[:,1]
+    A = a[:,0,0]
+    B = a[:,0,1]
+    C = a[:,1,0]
+    D = a[:,1,1]
+    denom = A*z02 + B + C*z01*z02 + D*z01 
+    
+    s = npy.array([
+        [
+            (A*z02 + B - C*z01.conj()*z02 - D*z01.conj() ) / denom,
+            (2*(A*D - B*C)*npy.sqrt(z01.real * z02.real)) / denom,
+        ],
+        [
+            (2*npy.sqrt(z01.real * z02.real)) / denom,
+            (-A*z02.conj() + B - C*z01*z02.conj() + D*z01) / denom,
+        ],
+    ]).transpose()
+    return s
+
+    #return z2s(a2z(a), z0)
+    
 
 
 def a2z(a):

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4327,8 +4327,27 @@ def s2a(s, z0=50):
     -------
     abcd : numpy.ndarray
         scattering transfer parameters (aka wave cascading matrix)
-    '''
-    return z2a(s2z(s, z0))
+    '''    
+    nfreqs, nports, nports = s.shape
+
+    if nports != 2:
+        raise IndexError('abcd parameters are defined for 2-ports networks only')
+
+    z0 = fix_z0_shape(z0, nfreqs, nports)
+    z01 = z0[:,0]
+    z02 = z0[:,1]
+    denom = (2*s[:,1,0]*npy.sqrt(z01.real * z02.real))
+    a = npy.array([
+        [
+            ((z01.conj() + s[:,0,0]*z01)*(1 - s[:,1,1]) + s[:,0,1]*s[:,1,0]*z01) / denom,
+            ((1 - s[:,0,0])*(1 - s[:,1,1]) - s[:,0,1]*s[:,1,0]) / denom,
+        ],
+        [
+            ((z01.conj() + s[:,0,0]*z01)*(z02.conj() + s[:,1,1]*z02) - s[:,0,1]*s[:,1,0]*z01*z02) / denom,
+            ((1 - s[:,0,0])*(z02.conj() + s[:,1,1]*z02) + s[:,0,1]*s[:,1,0]*z02) / denom,
+        ],
+    ]).transpose()
+    return a
 
 
 def y2s(y, z0=50):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -218,11 +218,11 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_conversions(self):
         #Converting to other format and back to S-parameters should return the original network
-        tinyfloat = 1e-12
+        tinyfloat = 1e-11
         for test_z0 in (50, 10, 90+10j, 4-100j):
             for test_ntwk in (self.ntwk1, self.ntwk2, self.ntwk3):
                 ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0)
-
+       
                 self.assertTrue((abs(rf.a2s(rf.s2a(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
                 self.assertTrue((abs(rf.z2s(rf.s2z(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
                 self.assertTrue((abs(rf.y2s(rf.s2y(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())


### PR DESCRIPTION
Instead of calculating ABCD parameters from Z-parameters, now calculate them from S-parameters (and vice-versa for `a2s`).

This avoid error for some specific components like series impedance, for which Z-parameters do not exist. 

Also added test cases for 2-port networks for series, parallel and transmission line  for S and ABCD parameters.
