### PR TITLE
fix xlim error in RWG example

### DIFF
--- a/doc/source/examples/networktheory/Properties of Rectangular Waveguides.ipynb
+++ b/doc/source/examples/networktheory/Properties of Rectangular Waveguides.ipynb
@@ -112,7 +112,6 @@
     "xlabel('Frequency(GHz)')\n",
     "ylabel('Loss (dB/m)')\n",
     "title('Loss in Rectangular Waveguide (Au)');\n",
-    "xlim(100,1300)"
    ]
   },
   {


### PR DESCRIPTION
Frequencies are given in Hz, so the correct command would be

```
xlim(100e9, 1300e9)
```

However, this is not really necessary in this case.

This fixes the _empty plot_ in the documentary.