### PR TITLE
Performance Improvements of Network s/z/y parameters conversions

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3930,24 +3930,19 @@ def s2z(s, z0=50):
     '''
     nfreqs, nports, nports = s.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
+   
+    s = s.copy()  # to prevent the original array from being altered
+    s[s == -1.] = -1. + 1e-12  # solve numerical singularity
+    s[s == 1.] = 1. + 1e-12  # solve numerical singularity
 
-    # z = npy.zeros(s.shape, dtype='complex')
-    # I = npy.mat(npy.identity(s.shape[1]))
-    # s = s.copy()  # to prevent the original array from being altered
-    # s[s == 1.] = 1. + 1e-12  # solve numerical singularity
-    # s[s == -1.] = -1. + 1e-12  # solve numerical singularity
-    # for fidx in xrange(s.shape[0]):
-    #     sqrtz0 = npy.mat(npy.sqrt(npy.diagflat(z0[fidx])))
-    #     z[fidx] = sqrtz0 * (I - s[fidx]) ** -1 * (I + s[fidx]) * sqrtz0
-    # return z
-
+    # The following is a vectorized version of a for loop for all frequencies.    
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(s)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', Id)[...] = 1  
+    npy.einsum('ijj->ij', Id)[...] = 1     
     # Creating diagonal matrices of shape (nports, nports) for each nfreqs
     sqrtz0 = npy.zeros_like(s)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', sqrtz0)[...] = npy.sqrt(z0)
-    # y -> s 
+    # s -> z 
     z = npy.zeros_like(s)
     z = sqrtz0 @ npy.linalg.inv(Id - s) @ (Id + s) @ sqrtz0
     return z
@@ -3996,23 +3991,14 @@ def s2y(s, z0=50):
     .. [#] http://en.wikipedia.org/wiki/S-parameters
     .. [#] http://en.wikipedia.org/wiki/Admittance_parameters
     """
-
     nfreqs, nports, nports = s.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
-    # y = npy.zeros(s.shape, dtype='complex')
-    # I = npy.mat(npy.identity(s.shape[1]))
-    # s = s.copy()  # to prevent the original array from being altered
-    # s[s == -1.] = -1. + 1e-12  # solve numerical singularity
-    # s[s == 1.] = 1. + 1e-12  # solve numerical singularity
-    # for fidx in xrange(s.shape[0]):
-    #     sqrty0 = npy.mat(npy.sqrt(npy.diagflat(1.0 / z0[fidx])))
-    #     y[fidx] = sqrty0 * (I - s[fidx]) * (I + s[fidx]) ** -1 * sqrty0
-    # return y
 
     s = s.copy()  # to prevent the original array from being altered
     s[s == -1.] = -1. + 1e-12  # solve numerical singularity
     s[s == 1.] = 1. + 1e-12  # solve numerical singularity
     
+    # The following is a vectorized version of a for loop for all frequencies.
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(s)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', Id)[...] = 1  
@@ -4122,13 +4108,8 @@ def z2s(z, z0=50):
     """
     nfreqs, nports, nports = z.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
-    # s = npy.zeros(z.shape, dtype='complex')
-    # I = npy.mat(npy.identity(z.shape[1]))
-    # for fidx in xrange(z.shape[0]):
-    #     sqrty0 = npy.mat(npy.sqrt(npy.diagflat(1.0 / z0[fidx])))
-    #     s[fidx] = (sqrty0 * z[fidx] * sqrty0 - I) * (sqrty0 * z[fidx] * sqrty0 + I) ** -1
-    # return s
-
+    
+    # The following is a vectorized version of a for loop for all frequencies.
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(z)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', Id)[...] = 1  
@@ -4458,13 +4439,8 @@ def y2s(y, z0=50):
     '''
     nfreqs, nports, nports = y.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
-    # s = npy.zeros(y.shape, dtype='complex')
-    # I = npy.mat(npy.identity(s.shape[1]))
-    # for fidx in xrange(s.shape[0]):
-    #     sqrtz0 = npy.mat(npy.sqrt(npy.diagflat(z0[fidx])))
-    #     s[fidx] = (I - sqrtz0 * y[fidx] * sqrtz0) * (I + sqrtz0 * y[fidx] * sqrtz0) ** -1
-    # return s 
-        
+
+    # The following is a vectorized version of a for loop for all frequencies.        
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(y)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', Id)[...] = 1  

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3938,7 +3938,7 @@ def s2z(s, z0=50):
     # The following is a vectorized version of a for loop for all frequencies.    
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(s)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', Id)[...] = 1     
+    npy.einsum('ijj->ij', Id)[...] = 1.0     
     # Creating diagonal matrices of shape (nports, nports) for each nfreqs
     sqrtz0 = npy.zeros_like(s)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', sqrtz0)[...] = npy.sqrt(z0)
@@ -4002,10 +4002,10 @@ def s2y(s, z0=50):
     # The following is a vectorized version of a for loop for all frequencies.
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(s)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', Id)[...] = 1  
+    npy.einsum('ijj->ij', Id)[...] = 1.0  
     # Creating diagonal matrices of shape (nports, nports) for each nfreqs
     sqrty0 = npy.zeros_like(s)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1/z0)
+    npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1.0/z0)
     # s -> y 
     y = npy.zeros_like(s)
     # y = sqrty0 @ (Id - s) @  npy.linalg.inv(Id + s) @ sqrty0  # Python>3.5
@@ -4114,10 +4114,10 @@ def z2s(z, z0=50):
     # The following is a vectorized version of a for loop for all frequencies.
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(z)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', Id)[...] = 1  
+    npy.einsum('ijj->ij', Id)[...] = 1.0  
     # Creating diagonal matrices of shape (nports, nports) for each nfreqs
     sqrty0 = npy.zeros_like(z)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1/z0)
+    npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1.0/z0)
     # z -> s 
     s = npy.zeros_like(z)
     # s = (sqrty0 @ z @ sqrty0 - Id) @  npy.linalg.inv(sqrty0 @ z @ sqrty0 + Id)  # Python>3.5
@@ -4447,7 +4447,7 @@ def y2s(y, z0=50):
     # The following is a vectorized version of a for loop for all frequencies.        
     # Creating Identity matrices of shape (nports,nports) for each nfreqs 
     Id = npy.zeros_like(y)  # (nfreqs, nports, nports)
-    npy.einsum('ijj->ij', Id)[...] = 1  
+    npy.einsum('ijj->ij', Id)[...] = 1.0  
     # Creating diagonal matrices of shape (nports, nports) for each nfreqs
     sqrtz0 = npy.zeros_like(y)  # (nfreqs, nports, nports)
     npy.einsum('ijj->ij', sqrtz0)[...] = npy.sqrt(z0)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3944,7 +3944,8 @@ def s2z(s, z0=50):
     npy.einsum('ijj->ij', sqrtz0)[...] = npy.sqrt(z0)
     # s -> z 
     z = npy.zeros_like(s)
-    z = sqrtz0 @ npy.linalg.inv(Id - s) @ (Id + s) @ sqrtz0
+    # z = sqrtz0 @ npy.linalg.inv(Id - s) @ (Id + s) @ sqrtz0  # Python>3.5
+    z = npy.matmul(npy.matmul(npy.matmul(sqrtz0, npy.linalg.inv(Id - s)), (Id + s)), sqrtz0)
     return z
 
 def s2y(s, z0=50):
@@ -4007,7 +4008,8 @@ def s2y(s, z0=50):
     npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1/z0)
     # s -> y 
     y = npy.zeros_like(s)
-    y = sqrty0 @ (Id - s) @  npy.linalg.inv(Id + s) @ sqrty0
+    # y = sqrty0 @ (Id - s) @  npy.linalg.inv(Id + s) @ sqrty0  # Python>3.5
+    y = npy.matmul(npy.matmul(npy.matmul(sqrty0, (Id - s)), npy.linalg.inv(Id + s)), sqrty0)
     return y
 
 def s2t(s):
@@ -4118,7 +4120,9 @@ def z2s(z, z0=50):
     npy.einsum('ijj->ij', sqrty0)[...] = npy.sqrt(1/z0)
     # z -> s 
     s = npy.zeros_like(z)
-    s = (sqrty0 @ z @ sqrty0 - Id) @  npy.linalg.inv(sqrty0 @ z @ sqrty0 + Id)
+    # s = (sqrty0 @ z @ sqrty0 - Id) @  npy.linalg.inv(sqrty0 @ z @ sqrty0 + Id)  # Python>3.5
+    s = npy.matmul((npy.matmul(npy.matmul(sqrty0, z), sqrty0) - Id), 
+                    npy.linalg.inv(npy.matmul(npy.matmul(sqrty0, z), sqrty0) + Id))
     return s
 
 def z2y(z):
@@ -4449,7 +4453,9 @@ def y2s(y, z0=50):
     npy.einsum('ijj->ij', sqrtz0)[...] = npy.sqrt(z0)
     # y -> s 
     s = npy.zeros_like(y)
-    s = (Id - sqrtz0 @ y @ sqrtz0) @ npy.linalg.inv(Id + sqrtz0 @ y @ sqrtz0)
+    # s = (Id - sqrtz0 @ y @ sqrtz0) @ npy.linalg.inv(Id + sqrtz0 @ y @ sqrtz0)  # Python>3.5
+    s = npy.matmul( Id - npy.matmul(npy.matmul(sqrtz0, y), sqrtz0),
+                   npy.linalg.inv(Id + npy.matmul(npy.matmul(sqrtz0, y), sqrtz0)))
     return s
 
 def y2z(y):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -8,7 +8,7 @@ import skrf as rf
 from nose.plugins.skip import SkipTest
 
 from skrf import setup_pylab
-
+from skrf.media import CPW
 
 class NetworkTestCase(unittest.TestCase):
     '''
@@ -43,7 +43,7 @@ class NetworkTestCase(unittest.TestCase):
         self.ntwk2 = rf.Network(os.path.join(self.test_dir, 'ntwk2.s2p'))
         self.ntwk3 = rf.Network(os.path.join(self.test_dir, 'ntwk3.s2p'))
         self.freq = rf.Frequency(75,110,101,'ghz')
-        self.cpw =  rf.media.CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
+        self.cpw =  CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
         l1 = self.cpw.line(0.20, 'm', z0=50)
         l2 = self.cpw.line(0.07, 'm', z0=50)
         l3 = self.cpw.line(0.47, 'm', z0=50)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -8,7 +8,7 @@ import skrf as rf
 from nose.plugins.skip import SkipTest
 
 from skrf import setup_pylab
-from skrf.media import CPW
+
 
 class NetworkTestCase(unittest.TestCase):
     '''
@@ -43,7 +43,7 @@ class NetworkTestCase(unittest.TestCase):
         self.ntwk2 = rf.Network(os.path.join(self.test_dir, 'ntwk2.s2p'))
         self.ntwk3 = rf.Network(os.path.join(self.test_dir, 'ntwk3.s2p'))
         self.freq = rf.Frequency(75,110,101,'ghz')
-        self.cpw =  CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
+        self.cpw =  rf.media.CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
         l1 = self.cpw.line(0.20, 'm', z0=50)
         l2 = self.cpw.line(0.07, 'm', z0=50)
         l3 = self.cpw.line(0.47, 'm', z0=50)


### PR DESCRIPTION
The conversion functions `y2s`, `z2s`, `s2y`, `s2z` used a for loop on frequencies. When dealing with many network operations, most of the calculation time was devoted into these loops. 

The proposal uses `einsum` in order to create the  necessary `(nfreqs, nports, nports)` matrices, and use the `matmul` operator (`@`) which uses broadcasting to perform operations for each frequencies. 

NB: As the `@` operator has been introduced in Python 3.5 so this PR will break the compatibility with previous Python versions, unless `matmul` used instead (at the detriment of the code readability)...