### PR TITLE
Added active s/y/z/vswr parameters to Network and Circuit

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -539,4 +539,128 @@ class Circuit():
         return ntw
 
 
+    def s_active(self, a):
+        '''
+        Returns active s-parameters of the circuit's network for a defined wave excitation a.
         
+        The active s-parameter at a port is the reflection coefficients 
+        when other ports are excited. It is an important quantity for active
+        phased array antennas.
+        
+        Active s-parameters are defined by [#]_:
+        
+        .. math::
+                    
+            \mathrm{active}(s)_{mn} = \sum_i\left( s_{mi} a_i \right) / a_n
+        
+        Parameters
+        ----------
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude (pseudowave formulation [#]_)
+        
+        Returns
+        ---------
+        s_act : complex array of shape (n_freqs, n_ports)
+            active s-parameters for the excitation a
+        
+        
+        References
+        ---------- 
+        .. [#] D. M. Pozar, IEEE Trans. Antennas Propag. 42, 1176 (1994).
+        
+        .. [#] D. Williams, IEEE Microw. Mag. 14, 38 (2013).
+        
+        '''
+        return self.network.s_active(a)
+
+    def z_active(self, a):
+        '''
+        Returns the active Z-parameters of the circuit's network for a defined wave excitation a.
+        
+        The active Z-parameters are defined by:
+            
+        .. math::
+                    
+            \mathrm{active}(z)_{m} = z_{0,m} \frac{1 + \mathrm{active}(s)_m}{1 - \mathrm{active}(s)_m}
+            
+        where :math:`z_{0,m}` is the characteristic impedance and
+        :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.
+        
+        Parameters
+        ----------
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude
+    
+        Returns
+        ----------
+        z_act : complex array of shape (nfreqs, nports)
+            active Z-parameters for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            y_active : active Y-parameters
+            vswr_active : active VSWR        
+        '''
+        return self.network.z_active(a)
+
+    def y_active(self, a):
+        '''
+        Returns the active Y-parameters of the circuit's network for a defined wave excitation a.
+        
+        The active Y-parameters are defined by:
+            
+        .. math::
+                    
+            \mathrm{active}(y)_{m} = y_{0,m} \frac{1 - \mathrm{active}(s)_m}{1 + \mathrm{active}(s)_m}
+            
+        where :math:`y_{0,m}` is the characteristic admittance and
+        :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.    
+        
+        Parameters
+        ----------            
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude 
+        
+        Returns
+        ----------
+        y_act : complex array of shape (nfreqs, nports)
+            active Y-parameters for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            z_active : active Z-parameters
+            vswr_active : active VSWR       
+        '''
+        return self.network.y_active(a)
+
+    def vswr_active(self, a):
+        '''
+        Returns the active VSWR of the circuit's network for a defined wave excitation a.
+        
+        The active VSWR is defined by :
+            
+        .. math::
+                    
+            \mathrm{active}(vswr)_{m} = \frac{1 + |\mathrm{active}(s)_m|}{1 - |\mathrm{active}(s)_m|}
+    
+        where :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.
+        
+        Parameters
+        ----------       
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude
+    
+        Returns
+        ----------
+        vswr_act : complex array of shape (nfreqs, nports)
+            active VSWR for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            z_active : active Z-parameters
+            y_active : active Y-parameters  
+        '''        
+        return self.network.vswr_active(a)        

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -911,11 +911,11 @@ class Network(object):
         return s2t(self.s)
 
     @property
-    def sa(self):
+    def s_invert(self):
         """
-        Active scattering parameter matrix.
+        Inverted scattering parameter matrix.
 
-        Active scattering parameters are simply inverted s-parameters,
+        Inverted scattering parameters are simply inverted s-parameters,
         defined as a = 1/s. Useful in analysis of active networks.
         The a-matrix is a 3-dimensional :class:`numpy.ndarray` which has shape
         `fxnxn`, where `f` is frequency axis and `n` is number of ports.
@@ -925,8 +925,8 @@ class Network(object):
 
         Returns
         ---------
-        a : complex :class:`numpy.ndarray` of shape `fxnxn`
-                the active scattering parameter matrix.
+        s_inv : complex :class:`numpy.ndarray` of shape `fxnxn`
+                the inverted scattering parameter matrix.
 
         See Also
         ------------
@@ -938,8 +938,8 @@ class Network(object):
         """
         return 1 / self.s
 
-    @sa.setter
-    def sa(self, value):
+    @s_invert.setter
+    def s_invert(self, value):
         raise NotImplementedError
 
     @property

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2863,6 +2863,140 @@ class Network(object):
             w = self
         return t, npy.cumsum(mf.irfft(w.s, n=n).flatten())
 
+    # Network Active s/z/y/vswr parameters
+    def s_active(self, a):
+        '''
+        Returns the active s-parameters of the network for a defined wave excitation a.
+        
+        The active s-parameter at a port is the reflection coefficients 
+        when other ports are excited. It is an important quantity for active
+        phased array antennas.
+        
+        Active s-parameters are defined by [#]_:
+        
+        .. math::
+                    
+            \mathrm{active}(s)_{m} = \sum_{i=1}^N\left( s_{mi} a_i \right) / a_m
+    
+        where :math:`s` are the scattering parameters and :math:`N` the number of ports
+    
+        Parameters
+        ----------       
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude (pseudowave formulation [#]_)
+        
+        Returns
+        ---------
+        s_act : complex array of shape (n_freqs, n_ports)
+            active S-parameters for the excitation a
+    
+        See Also
+        -----------
+            z_active : active Z-parameters
+            y_active : active Y-parameters
+            vswr_active : active VSWR   
+    
+        References
+        ---------- 
+        .. [#] D. M. Pozar, IEEE Trans. Antennas Propag. 42, 1176 (1994).
+        
+        .. [#] D. Williams, IEEE Microw. Mag. 14, 38 (2013).
+        
+        '''        
+        return s2s_active(self.s, a)
+
+    def z_active(self, a):
+        '''
+        Returns the active Z-parameters of the network for a defined wave excitation a.
+        
+        The active Z-parameters are defined by:
+            
+        .. math::
+                    
+            \mathrm{active}(z)_{m} = z_{0,m} \frac{1 + \mathrm{active}(s)_m}{1 - \mathrm{active}(s)_m}
+            
+        where :math:`z_{0,m}` is the characteristic impedance and
+        :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.
+        
+        Parameters
+        ----------
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude
+    
+        Returns
+        ----------
+        z_act : complex array of shape (nfreqs, nports)
+            active Z-parameters for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            y_active : active Y-parameters
+            vswr_active : active VSWR        
+        '''
+        return s2z_active(self.s, self.z0, a)
+
+    def y_active(self, a):
+        '''
+        Returns the active Y-parameters of the network for a defined wave excitation a.
+        
+        The active Y-parameters are defined by:
+            
+        .. math::
+                    
+            \mathrm{active}(y)_{m} = y_{0,m} \frac{1 - \mathrm{active}(s)_m}{1 + \mathrm{active}(s)_m}
+            
+        where :math:`y_{0,m}` is the characteristic admittance and
+        :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.    
+        
+        Parameters
+        ----------            
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude 
+        
+        Returns
+        ----------
+        y_act : complex array of shape (nfreqs, nports)
+            active Y-parameters for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            z_active : active Z-parameters
+            vswr_active : active VSWR       
+        '''
+        return s2y_active(self.s, self.z0, a)
+    
+    def vswr_active(self, a):
+        '''
+        Returns the active VSWR of the network for a defined wave excitation a.
+        
+        The active VSWR is defined by :
+            
+        .. math::
+                    
+            \mathrm{active}(vswr)_{m} = \frac{1 + |\mathrm{active}(s)_m|}{1 - |\mathrm{active}(s)_m|}
+    
+        where :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.
+        
+        Parameters
+        ----------       
+        a : complex array of shape (n_ports)
+            forward wave complex amplitude
+    
+        Returns
+        ----------
+        vswr_act : complex array of shape (nfreqs, nports)
+            active VSWR for the excitation a
+            
+        See Also
+        -----------
+            s_active : active S-parameters
+            z_active : active Z-parameters
+            y_active : active Y-parameters  
+        '''        
+        return s2vswr_active(self.s, a)
+    
 
 ## Functions operating on Network[s]
 def connect(ntwkA, k, ntwkB, l, num=1):
@@ -5184,3 +5318,185 @@ def two_port_reflect(ntwk1, ntwk2=None):
     except(TypeError):
         pass
     return result
+
+def s2s_active(s, a):
+    '''
+    Returns active s-parameters for a defined wave excitation a.
+    
+    The active s-parameter at a port is the reflection coefficients 
+    when other ports are excited. It is an important quantity for active
+    phased array antennas.
+    
+    Active s-parameters are defined by [#]_:
+    
+    .. math::
+                
+        \mathrm{active}(s)_{m} = \sum_{i=1}^N\left( s_{mi} a_i \right) / a_m
+
+    where :math:`s` are the scattering parameters and :math:`N` the number of ports
+
+    Parameters
+    ----------
+    s : complex array
+        scattering parameters (nfreqs, nports, nports)
+    
+    a : complex array of shape (n_ports)
+        forward wave complex amplitude (pseudowave formulation [#]_)
+    
+    Returns
+    ---------
+    s_act : complex array of shape (n_freqs, n_ports)
+        active S-parameters for the excitation a
+
+    See Also
+    -----------
+        s2z_active : active Z-parameters
+        s2y_active : active Y-parameters
+        s2vswr_active : active VSWR   
+
+    References
+    ---------- 
+    .. [#] D. M. Pozar, IEEE Trans. Antennas Propag. 42, 1176 (1994).
+    
+    .. [#] D. Williams, IEEE Microw. Mag. 14, 38 (2013).
+    
+    '''
+    # TODO : vectorize the for loop
+    nfreqs, nports, nports = s.shape
+    s_act = npy.zeros((nfreqs, nports), dtype='complex')
+    s[ s == 0 ] = 1e-12  # solve numerical singularity
+
+    for fidx in xrange(s.shape[0]):
+        s_act[fidx] = (s[fidx] @ a) / a
+    return s_act  # shape : (n_freqs, n_ports)
+
+def s2z_active(s, z0, a):
+    '''
+    Returns the active Z-parameters for a defined wave excitation a.
+    
+    The active Z-parameters are defined by:
+        
+    .. math::
+                
+        \mathrm{active}(z)_{m} = z_{0,m} \frac{1 + \mathrm{active}(s)_m}{1 - \mathrm{active}(s)_m}
+        
+    where :math:`z_{0,m}` is the characteristic impedance and
+    :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.
+    
+    Parameters
+    ----------
+    s : complex array
+        scattering parameters (nfreqs, nports, nports)
+        
+    z0 : complex array-like or number
+        port impedances.
+        
+    a : complex array of shape (n_ports)
+        forward wave complex amplitude
+
+    Returns
+    ----------
+    z_act : complex array of shape (nfreqs, nports)
+        active Z-parameters for the excitation a
+        
+    See Also
+    -----------
+        s2s_active : active S-parameters
+        s2y_active : active Y-parameters
+        s2vswr_active : active VSWR        
+        
+    '''
+    # TODO : vectorize the for loop
+    nfreqs, nports, nports = s.shape
+    z0 = fix_z0_shape(z0, nfreqs, nports)
+    z_act = npy.zeros((nfreqs, nports), dtype='complex')
+    s_act = s2s_active(s, a)
+    
+    for fidx in xrange(s.shape[0]):
+        z_act[fidx] = z0[fidx] * (1 + s_act[fidx])/(1 - s_act[fidx])
+    return z_act
+
+def s2y_active(s, z0, a):
+    '''
+    Returns the active Y-parameters for a defined wave excitation a.
+    
+    The active Y-parameters are defined by:
+        
+    .. math::
+                
+        \mathrm{active}(y)_{m} = y_{0,m} \frac{1 - \mathrm{active}(s)_m}{1 + \mathrm{active}(s)_m}
+        
+    where :math:`y_{0,m}` is the characteristic admittance and
+    :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.    
+    
+    Parameters
+    ----------
+    s : complex array
+        scattering parameters (nfreqs, nports, nports)
+        
+    z0 : complex array-like or number
+        port impedances.
+        
+    a : complex array of shape (n_ports)
+        forward wave complex amplitude 
+    
+    Returns
+    ----------
+    y_act : complex array of shape (nfreqs, nports)
+        active Y-parameters for the excitation a
+        
+    See Also
+    -----------
+        s2s_active : active S-parameters
+        s2z_active : active Z-parameters
+        s2vswr_active : active VSWR       
+    '''
+    nfreqs, nports, nports = s.shape
+    z0 = fix_z0_shape(z0, nfreqs, nports)
+    y_act = npy.zeros((nfreqs, nports), dtype='complex')
+    s_act = s2s_active(s, a)
+    
+    for fidx in xrange(s.shape[0]):
+        y_act[fidx] = 1/z0[fidx] * (1 - s_act[fidx])/(1 + s_act[fidx])
+    return y_act    
+
+def s2vswr_active(s, a):
+    '''
+    Returns the active VSWR for a defined wave excitation a..
+    
+    The active VSWR is defined by :
+        
+    .. math::
+                
+        \mathrm{active}(vswr)_{m} = \frac{1 + |\mathrm{active}(s)_m|}{1 - |\mathrm{active}(s)_m|}
+
+    where :math:`\mathrm{active}(s)_m` the active S-parameter of port :math:`m`.    
+            
+    
+    Parameters
+    ----------
+    s : complex array
+        scattering parameters (nfreqs, nports, nports)
+        
+    a : complex array of shape (n_ports)
+        forward wave complex amplitude
+
+    Returns
+    ----------
+    vswr_act : complex array of shape (nfreqs, nports)
+        active VSWR for the excitation a
+        
+    See Also
+    -----------
+        s2s_active : active S-parameters
+        s2z_active : active Z-parameters
+        s2y_active : active Y-parameters  
+    '''
+    nfreqs, nports, nports = s.shape
+    vswr_act = npy.zeros((nfreqs, nports), dtype='complex')
+    s_act = s2s_active(s, a)
+    
+    for fidx in xrange(s.shape[0]):
+        vswr_act[fidx] = (1 + npy.abs(s_act[fidx]))/(1 - npy.abs(s_act[fidx]))
+    
+    return vswr_act

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5367,7 +5367,7 @@ def s2s_active(s, a):
     s[ s == 0 ] = 1e-12  # solve numerical singularity
 
     for fidx in xrange(s.shape[0]):
-        s_act[fidx] = (s[fidx] @ a) / a
+        s_act[fidx] = npy.matmul(s[fidx], a) / a
     return s_act  # shape : (n_freqs, n_ports)
 
 def s2z_active(s, z0, a):

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -1965,7 +1965,7 @@ def signature(self, m=0, n=0, component='s_mag',
 
     return img
 
-def plot_circuit_graph(self, **kwargs):
+def plot_circuit_graph(self, ax=None, **kwargs):
     '''
     Plot the graph of the circuit using networkx drawing capabilities.
 
@@ -2014,6 +2014,7 @@ def plot_circuit_graph(self, **kwargs):
     label_shift_x = kwargs.pop('label_shift_x', 0)
     label_shift_y = kwargs.pop('label_shift_y', 0)
 
+
     
     # sort between network nodes and port nodes
     all_ntw_names = [ntw.name for ntw in self.networks_list()]
@@ -2022,9 +2023,10 @@ def plot_circuit_graph(self, **kwargs):
     # generate connectins nodes names
     int_names = ['X'+str(k) for k in range(self.connections_nb)]
 
-    fig, ax = plb.subplots(figsize=(10,8))
+    if ax is None:
+        fig, ax = plb.subplots(figsize=(10,8))    
 
-    pos = nx.spring_layout(G)
+    pos = nx.kamada_kawai_layout(G)#spring_layout(G)
 
     # draw Networks
     nx.draw_networkx_nodes(G, pos, port_names, ax=ax,

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -1965,7 +1965,7 @@ def signature(self, m=0, n=0, component='s_mag',
 
     return img
 
-def plot_circuit_graph(self, ax=None, **kwargs):
+def plot_circuit_graph(self, **kwargs):
     '''
     Plot the graph of the circuit using networkx drawing capabilities.
 
@@ -2014,7 +2014,6 @@ def plot_circuit_graph(self, ax=None, **kwargs):
     label_shift_x = kwargs.pop('label_shift_x', 0)
     label_shift_y = kwargs.pop('label_shift_y', 0)
 
-
     
     # sort between network nodes and port nodes
     all_ntw_names = [ntw.name for ntw in self.networks_list()]
@@ -2023,10 +2022,9 @@ def plot_circuit_graph(self, ax=None, **kwargs):
     # generate connectins nodes names
     int_names = ['X'+str(k) for k in range(self.connections_nb)]
 
-    if ax is None:
-        fig, ax = plb.subplots(figsize=(10,8))    
+    fig, ax = plb.subplots(figsize=(10,8))
 
-    pos = nx.kamada_kawai_layout(G)#spring_layout(G)
+    pos = nx.spring_layout(G)
 
     # draw Networks
     nx.draw_networkx_nodes(G, pos, port_names, ax=ax,

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -48,6 +48,19 @@ class CircuitTestConstructor(unittest.TestCase):
         _ntwk1.frequency = rf.Frequency(start=1, stop=1, npoints=1)
         self.assertRaises(AttributeError, rf.Circuit, connections)
 
+    def test_s_active(self):
+        '''
+        Test the active s-parameter of a 2-ports network
+        '''
+        connections = [[(self.port1, 0), (self.ntwk1, 0)],
+                       [(self.ntwk1, 1), (self.ntwk2, 0)],
+                       [(self.ntwk2, 1), (self.port2, 0)]]
+        circuit = rf.Circuit(connections)
+        # s_act should be equal to s11 if a = [1,0]
+        assert_array_almost_equal(circuit.s_active([1, 0])[:,0], circuit.s_external[:,0,0])
+        # s_act should be equal to s22 if a = [0,1]
+        assert_array_almost_equal(circuit.s_active([0, 1])[:,1], circuit.s_external[:,1,1])
+                
 
 class CircuitTestWilkinson(unittest.TestCase):
     '''
@@ -207,6 +220,17 @@ class CircuitTestWilkinson(unittest.TestCase):
 
         assert_array_almost_equal(ntw_C.s[0], designer_wilkinson.s[0], decimal=4)
 
+    def test_s_active(self):
+        '''
+        Test the active s-parameter of a 3-ports network
+        '''
+        # s_act should be equal to s11 if a = [1,0,0]
+        assert_array_almost_equal(self.C.network.s_active([1, 0, 0])[:,0], self.C.s_external[:,0,0])
+        # s_act should be equal to s22 if a = [0,1,0]
+        assert_array_almost_equal(self.C.network.s_active([0, 1, 0])[:,1], self.C.s_external[:,1,1])
+        # s_act should be equal to s33 if a = [0,0,1]
+        assert_array_almost_equal(self.C.network.s_active([0, 0, 1])[:,2], self.C.s_external[:,2,2])
+        
 class CircuitTestCascadeNetworks(unittest.TestCase):
     '''
     Build a circuit made of two Networks cascaded and compare the result

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -8,6 +8,7 @@ import skrf as rf
 from nose.plugins.skip import SkipTest
 
 from skrf import setup_pylab
+from skrf.media import CPW
 
 
 class NetworkTestCase(unittest.TestCase):
@@ -43,7 +44,7 @@ class NetworkTestCase(unittest.TestCase):
         self.ntwk2 = rf.Network(os.path.join(self.test_dir, 'ntwk2.s2p'))
         self.ntwk3 = rf.Network(os.path.join(self.test_dir, 'ntwk3.s2p'))
         self.freq = rf.Frequency(75,110,101,'ghz')
-        self.cpw =  rf.media.CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
+        self.cpw =  CPW(self.freq, w=10e-6, s=5e-6, ep_r=10.6)
         l1 = self.cpw.line(0.20, 'm', z0=50)
         l2 = self.cpw.line(0.07, 'm', z0=50)
         l3 = self.cpw.line(0.47, 'm', z0=50)
@@ -222,7 +223,7 @@ class NetworkTestCase(unittest.TestCase):
         for test_z0 in (50, 10, 90+10j, 4-100j):
             for test_ntwk in (self.ntwk1, self.ntwk2, self.ntwk3):
                 ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0)
-       
+
                 self.assertTrue((abs(rf.a2s(rf.s2a(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
                 self.assertTrue((abs(rf.z2s(rf.s2z(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
                 self.assertTrue((abs(rf.y2s(rf.s2y(ntwk.s, test_z0), test_z0)-ntwk.s) < tinyfloat).all())
@@ -429,6 +430,34 @@ class NetworkTestCase(unittest.TestCase):
         self.assertTrue(b.is_lossless(), 'This unmatched power divider is lossless.')
         return
 
+    def test_s_active(self):
+        '''
+        Test the active s-parameters of a 2-ports network
+        '''
+        s_ref = self.ntwk1.s
+        # s_act should be equal to s11 if a = [1,0]
+        npy.testing.assert_array_almost_equal(rf.s2s_active(s_ref, [1, 0])[:,0], s_ref[:,0,0])
+        # s_act should be equal to s22 if a = [0,1]
+        npy.testing.assert_array_almost_equal(rf.s2s_active(s_ref, [0, 1])[:,1], s_ref[:,1,1])
+        # s_act should be equal to s11 if a = [1,0]
+        npy.testing.assert_array_almost_equal(self.ntwk1.s_active([1, 0])[:,0], s_ref[:,0,0])
+        # s_act should be equal to s22 if a = [0,1]
+        npy.testing.assert_array_almost_equal(self.ntwk1.s_active([0, 1])[:,1], s_ref[:,1,1])        
+
+    def test_vswr_active(self):
+        '''
+        Test the active vswr-parameters of a 2-ports network
+        '''
+        s_ref = self.ntwk1.s
+        vswr_ref = self.ntwk1.s_vswr
+        # vswr_act should be equal to vswr11 if a = [1,0]
+        npy.testing.assert_array_almost_equal(rf.s2vswr_active(s_ref, [1, 0])[:,0], vswr_ref[:,0,0])
+        # vswr_act should be equal to vswr22 if a = [0,1]
+        npy.testing.assert_array_almost_equal(rf.s2vswr_active(s_ref, [0, 1])[:,1], vswr_ref[:,1,1])
+        # vswr_act should be equal to vswr11 if a = [1,0]
+        npy.testing.assert_array_almost_equal(self.ntwk1.vswr_active([1, 0])[:,0], vswr_ref[:,0,0])
+        # vswr_act should be equal to vswr22 if a = [0,1]
+        npy.testing.assert_array_almost_equal(self.ntwk1.vswr_active([0, 1])[:,1], vswr_ref[:,1,1])
 
 suite = unittest.TestLoader().loadTestsFromTestCase(NetworkTestCase)
 unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Active parameters are useful when dealing with antenna arrays. 

For a forward wave excitation array `a` at ports, active s parameters, which are defined by:

`active(s)_m = \sum_{i=1}^N ( s_{mi} a_i ) / a_m`

are a sort of reflection coefficient when other ports are excited (while s-parameters are defined for other port matched). Definition for active y/z/vswr parameters are defined from active s-parameters.

NB: I do not understand the original `network.sa()` meaning. It is not, to my knowledge, "active s-parameters" as they do not depend on any external excitation. How and when it is used ?