### PR TITLE
Allow terminating a 2N-port network with a N-port network

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2165,7 +2165,7 @@ class Network(object):
             mag = npy.abs(x)
             interp_rad = interp1d(f, rad, axis=0, fill_value='extrapolate')
             interp_mag = interp1d(f, mag, axis=0, fill_value='extrapolate')
-            dc_sparam = interp_mag(0) * npy.exp(1j * interp_rad(0)).real
+            dc_sparam = interp_mag(0) * npy.exp(1j * interp_rad(0))
         else:
             #Make numpy array if argument was list
             dc_sparam = npy.array(dc_sparam)
@@ -3088,14 +3088,14 @@ def connect(ntwkA, k, ntwkB, l, num=1):
         ntwkC = innerconnect(ntwkC, k, ntwkA.nports - 1 + l, num - 1)
 
     # if ntwkB is a 2port, then keep port indices where you expect.
-    #if ntwkB.nports == 2 and ntwkA.nports > 2:
-    #    from_ports = list(range(ntwkC.nports))
-    #    to_ports = list(range(ntwkC.nports))
-    #    to_ports.pop(k);
-    #    to_ports.append(k)
+    if ntwkB.nports == 2 and ntwkA.nports > 2 and num == 1:
+        from_ports = list(range(ntwkC.nports))
+        to_ports = list(range(ntwkC.nports))
+        to_ports.pop(k);
+        to_ports.append(k)
 
-    #    ntwkC.renumber(from_ports=from_ports,
-    #                   to_ports=to_ports)
+        ntwkC.renumber(from_ports=from_ports,
+                       to_ports=to_ports)
 
     return ntwkC
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3088,14 +3088,14 @@ def connect(ntwkA, k, ntwkB, l, num=1):
         ntwkC = innerconnect(ntwkC, k, ntwkA.nports - 1 + l, num - 1)
 
     # if ntwkB is a 2port, then keep port indices where you expect.
-    if ntwkB.nports == 2 and ntwkA.nports > 2:
-        from_ports = list(range(ntwkC.nports))
-        to_ports = list(range(ntwkC.nports))
-        to_ports.pop(k);
-        to_ports.append(k)
+    #if ntwkB.nports == 2 and ntwkA.nports > 2:
+    #    from_ports = list(range(ntwkC.nports))
+    #    to_ports = list(range(ntwkC.nports))
+    #    to_ports.pop(k);
+    #    to_ports.append(k)
 
-        ntwkC.renumber(from_ports=from_ports,
-                       to_ports=to_ports)
+    #    ntwkC.renumber(from_ports=from_ports,
+    #                   to_ports=to_ports)
 
     return ntwkC
 
@@ -3303,8 +3303,12 @@ def cascade(ntwkA, ntwkB):
         # which port on self to use is ambiguous. choose N
         return connect(ntwkA, N, ntwkB, 0)
 
-    elif ntwkA.nports %2 == 0 and ntwkA.nports == ntwkB.nports:
-        # we have 2N port balanced networks
+    elif ntwkA.nports % 2 == 0 and ntwkA.nports == ntwkB.nports:
+        # we have two 2N-port balanced networks
+        return connect(ntwkA, N, ntwkB, 0, num=N)
+    
+    elif ntwkA.nports % 2 == 0 and ntwkA.nports == 2 * ntwkB.nports:
+        # we have a 2N-port balanced network terminated by a N-port network
         return connect(ntwkA, N, ntwkB, 0, num=N)
 
     else:


### PR DESCRIPTION
There is something strange renumbering done in connect(A, k, B, l) when B is 2-port and A is N-port with N>2. 
This cause 2-port failing to cascade with 4-port balanced network.
This is commented out for testing purpose, but a better solution has to be found.