### PR TITLE
pre-compute scaled frequency in write_touchstone

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1634,12 +1634,14 @@ class Network(object):
             # [HZ/KHZ/MHZ/GHZ] [S/Y/Z/G/H] [MA/DB/RI] [R n]
             output.write('# {} S {} R {} \n'.format(self.frequency.unit, form, str(abs(self.z0[0, 0]))))
 
+            scaled_freq = self.frequency.f_scaled
+
             if self.number_of_ports == 1:
                 # write comment line for users (optional)
                 output.write('!freq {labelA}S11 {labelB}S11\n'.format(**formatDic))
                 # write out data
                 for f in range(len(self.f)):
-                    output.write(format_spec_freq.format(self.frequency.f_scaled[f]) + ' ' \
+                    output.write(format_spec_freq.format(scaled_freq[f]) + ' ' \
                                  + c2str_A(self.s[f, 0, 0]) + ' ' \
                                  + c2str_B(self.s[f, 0, 0]) + '\n')
                     # write out the z0 following hfss's convention if desired
@@ -1660,7 +1662,7 @@ class Network(object):
                         **formatDic))
                 # write out data
                 for f in range(len(self.f)):
-                    output.write(format_spec_freq.format(self.frequency.f_scaled[f]) + ' ' \
+                    output.write(format_spec_freq.format(scaled_freq[f]) + ' ' \
                                  + c2str_A(self.s[f, 0, 0]) + ' ' \
                                  + c2str_B(self.s[f, 0, 0]) + ' ' \
                                  + c2str_A(self.s[f, 1, 0]) + ' ' \
@@ -1688,7 +1690,7 @@ class Network(object):
                 output.write('\n')
                 # write out data
                 for f in range(len(self.f)):
-                    output.write(format_spec_freq.format(self.frequency.f_scaled[f]))
+                    output.write(format_spec_freq.format(scaled_freq[f]))
                     for m in range(3):
                         for n in range(3):
                             output.write(' ' + c2str_A(self.s[f, m, n]) + ' ' \
@@ -1720,7 +1722,7 @@ class Network(object):
                 output.write('\n')
                 # write out data
                 for f in range(len(self.f)):
-                    output.write(format_spec_freq.format(self.frequency.f_scaled[f]))
+                    output.write(format_spec_freq.format(scaled_freq[f]))
                     for m in range(self.number_of_ports):
                         for n in range(self.number_of_ports):
                             if (n > 0 and (n % 4) == 0):


### PR DESCRIPTION
write_touchstone called f_scaled a number of times equal to len(network.f). This presented a large bottleneck for my Dash program, which has to write data back to touchstone to serialize it and pass it between callbacks (don't want to use pickling for a webapp with untrusted data).

The following is profiling of my code importing and writing to touchstone the same five snp files, which have 20001 frequency data points each. Before the edit, write_touchstone was 90% of the 90s compute time with almost all of that being f_scaled. After the edit, compute time is more than halved and write_touchstone is only 60% of total compute time with c2str_A and c2str_B being the main performance bottlenecks.

Before Edit:
=============

> Thu May 16 11:35:37 2019    debug\skrf_improvement\POST._dash-update-component.89097ms.1558020937.prof
>          13906347 function calls (13906326 primitive calls) in **89.096 seconds**
>    Ordered by: internal time, call count
>    List reduced from 344 to 30 due to restriction <30>
**>    ncalls  tottime  percall  cumtime  percall filename:lineno(function)**
>    **100015   71.764    0.001   71.846    0.001 .\SNaP\venv\lib\site-packages\skrf\frequency.py:415(f_scaled)
>         5    5.912    1.182   79.608   15.922 .\SNaP\venv\lib\site-packages\skrf\network.py:1451(write_touchstone)**
>         1    3.502    3.502    3.502    3.502 {method 'compress' of 'zlib.Compress' objects}
>         5    1.807    0.361    4.026    0.805 .\SNaP\venv\lib\site-packages\skrf\io\touchstone.py:106(load_file)
>    400020    1.318    0.000    1.318    0.000 .\SNaP\venv\lib\site-packages\skrf\io\touchstone.py:224(<listcomp>)
>         3    0.573    0.191    0.573    0.191 C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python36_64\lib\json\encoder.py:204(iterencode)
>   3700275    0.408    0.000    0.408    0.000 .\SNaP\venv\lib\site-packages\skrf\network.py:763(s)
>   1600080    0.397    0.000    0.397    0.000 .\SNaP\venv\lib\site-packages\numpy\lib\type_check.py:124(real)
>        21    0.380    0.018    0.380    0.018 {method 'recv_into' of '_socket.socket' objects}
>   1600080    0.363    0.000    0.363    0.000 .\SNaP\venv\lib\site-packages\numpy\lib\type_check.py:170(imag)
>    500105    0.342    0.000    0.431    0.000 .\SNaP\venv\lib\site-packages\skrf\network.py:1144(number_of_ports)
>    800233    0.328    0.000    0.328    0.000 {method 'split' of 'str' objects}
>   2100185    0.302    0.000    0.302    0.000 {method 'write' of '_io.StringIO' objects}
>         2    0.301    0.151    0.301    0.151 C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python36_64\lib\json\decoder.py:345(raw_decode)
>    400027    0.170    0.000    0.170    0.000 {method 'extend' of 'list' objects}
>        85    0.163    0.002    0.163    0.002 {built-in method numpy.array}
>         5    0.150    0.030    0.150    0.030 {built-in method binascii.a2b_base64}
>    400150    0.125    0.000    0.125    0.000 {method 'decode' of 'bytes' objects}
>    400145    0.071    0.000    0.071    0.000 {method 'readline' of '_io.BytesIO' objects}
>         5    0.058    0.012    0.058    0.012 .\SNaP\venv\lib\site-packages\skrf\io\touchstone.py:363(get_sparameter_arrays)
>        12    0.058    0.005    0.058    0.005 {method 'encode' of 'str' objects}
>    800647    0.058    0.000    0.058    0.000 {built-in method builtins.len}
>    400236    0.056    0.000    0.056    0.000 {method 'lower' of 'str' objects}
>         1    0.050    0.050   84.306   84.306 .\SNaP\snap\apps\app_viewer.py:155(update_s_output)
>    100055    0.049    0.000    0.049    0.000 .\SNaP\venv\lib\site-packages\skrf\frequency.py:491(multiplier)
>    400146    0.048    0.000    0.048    0.000 {method 'strip' of 'str' objects}
>         2    0.041    0.021    0.041    0.021 {built-in method zlib.crc32}
>    100030    0.033    0.000    0.033    0.000 .\SNaP\venv\lib\site-packages\skrf\frequency.py:388(f)
>         5    0.030    0.006    0.030    0.006 {method 'getvalue' of '_io.StringIO' objects}
>         5    0.029    0.006    0.227    0.045 C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python36_64\lib\base64.py:65(b64decode)

![before](https://user-images.githubusercontent.com/916439/57882502-d8d25f00-77f1-11e9-8245-08b3b49bd6a2.png)

After Edit
===========
		

> Thu May 16 15:06:59 2019    debug\skrf_improvement\POST._dash-update-component.39611ms.1558033619.prof
>          20006717 function calls (20006696 primitive calls) in **39.611 seconds**
>    Ordered by: internal time, call count
>    List reduced from 347 to 30 due to restriction <30>
>    **ncalls  tottime  percall  cumtime  percall filename:lineno(function)
>         5    7.651    1.530   24.460    4.892 .\SNaP\skrf\network.py:1517(write_touchstone)**
>         5    5.062    1.012    9.194    1.839 .\SNaP\skrf\io\touchstone.py:106(load_file)
>   1600080    4.525    0.000    7.268    0.000 .\SNaP\skrf\network.py:1601(c2str_A)
>   1600080    4.147    0.000    6.799    0.000 .\SNaP\skrf\network.py:1605(c2str_B)
>   3300329    3.138    0.000    3.138    0.000 {method 'format' of 'str' objects}
>         1    3.124    3.124    3.124    3.124 {method 'compress' of 'zlib.Compress' objects}
>    400020    3.087    0.000    3.087    0.000 .\SNaP\skrf\io\touchstone.py:224(<listcomp>)
>   3700275    1.841    0.000    1.841    0.000 .\SNaP\skrf\network.py:764(s)
>   1600080    1.194    0.000    1.194    0.000 .\SNaP\venv\lib\site-packages\numpy\lib\type_check.py:124(real)
>   1600080    1.131    0.000    1.131    0.000 .\SNaP\venv\lib\site-packages\numpy\lib\type_check.py:170(imag)
>         3    0.708    0.236    0.709    0.236 C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python36_64\lib\json\encoder.py:204(iterencode)
>    500105    0.489    0.000    0.777    0.000 .\SNaP\skrf\network.py:1145(number_of_ports)
>        29    0.452    0.016    0.452    0.016 {method 'recv_into' of '_socket.socket' objects}
>         2    0.367    0.183    0.367    0.183 C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python36_64\lib\json\decoder.py:345(raw_decode)
>    800233    0.364    0.000    0.364    0.000 {method 'split' of 'str' objects}
>        85    0.323    0.004    0.323    0.004 {built-in method numpy.array}
>   2100185    0.275    0.000    0.275    0.000 {method 'write' of '_io.StringIO' objects}
>         5    0.209    0.042    0.209    0.042 .\SNaP\skrf\io\touchstone.py:363(get_sparameter_arrays)
>    400027    0.184    0.000    0.184    0.000 {method 'extend' of 'list' objects}
>         5    0.168    0.034    0.168    0.034 {built-in method binascii.a2b_base64}
>    400150    0.137    0.000    0.137    0.000 {method 'decode' of 'bytes' objects}
>    400145    0.078    0.000    0.078    0.000 {method 'readline' of '_io.BytesIO' objects}
>        20    0.072    0.004    0.101    0.005 .\SNaP\skrf\network.py:980(z0)
>        10    0.069    0.007    0.195    0.019 .\SNaP\skrf\frequency.py:216(from_f)
>    800647    0.068    0.000    0.068    0.000 {built-in method builtins.len}
>        10    0.068    0.007    0.206    0.021 .\SNaP\venv\lib\site-packages\numpy\core\numeric.py:469(asarray)
>        12    0.067    0.006    0.067    0.006 {method 'encode' of 'str' objects}
>        15    0.063    0.004    0.063    0.004 .\SNaP\skrf\frequency.py:415(f_scaled)
>    400236    0.058    0.000    0.058    0.000 {method 'lower' of 'str' objects}
>    400146    0.052    0.000    0.052    0.000 {method 'strip' of 'str' objects}

![after](https://user-images.githubusercontent.com/916439/57882504-d8d25f00-77f1-11e9-88f7-d0c4d52565a0.png)

Signed-off-by: Jackson Anderson <jda4923@rit.edu>