### PR TITLE
Feat/iac 272 read all files parameter

### DIFF
--- a/doc/source/tutorials/Networks.ipynb
+++ b/doc/source/tutorials/Networks.ipynb
@@ -683,6 +683,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Other times you know the list of files that need to be analyzed. `rf.read_all`  also accepts a files parameter. This example file list contains only files within the same directory, but you can store files however your application would benefit from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_o_ntwks_files = rf.read_all(files=[os.path.join(rf.data.pwd, test_file) for test_file in ['ntwk1.s2p', 'ntwk2.s2p']])\n",
+    "dict_o_ntwks_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Other Parameters\t\n",
     "\n",
     "This tutorial focuses on s-parameters, but other network representations are available as well. Impedance and Admittance Parameters can be accessed through the parameters `Network.z` and `Network.y`, respectively. Scalar components of complex parameters, such as  `Network.z_re`, `Network.z_im` and plotting methods are available as well.\n",

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -212,7 +212,7 @@ def write(file, obj, overwrite = True):
         pickle.dump(obj, fid, protocol=2)
         fid.close()
 
-def read_all(dir='.', contains = None, f_unit = None, obj_type=None):
+def read_all(dir='.', contains = None, f_unit = None, obj_type=None, files=None):
     '''
     Read all skrf objects in a directory
 
@@ -232,6 +232,8 @@ def read_all(dir='.', contains = None, f_unit = None, obj_type=None):
         frequencies's :attr:`~skrf.frequency.Frequency.f_unit`
     obj_type : str
         Name of skrf object types to read (ie 'Network')
+    files : list, optional
+        list of files to load, bypassed dir.
 
     Returns
     ---------
@@ -253,7 +255,10 @@ def read_all(dir='.', contains = None, f_unit = None, obj_type=None):
     {'delay_short': 1-Port Network: 'delay_short',  75-110 GHz, 201 pts, z0=[ 50.+0.j],
     'line': 2-Port Network: 'line',  75-110 GHz, 201 pts, z0=[ 50.+0.j  50.+0.j],
     'ntwk1': 2-Port Network: 'ntwk1',  1-10 GHz, 91 pts, z0=[ 50.+0.j  50.+0.j],
-    ...
+
+    >>> rf.read_all(files = ['skrf/data/delay_short.s1p', 'skrf/data/line.s2p'], obj_type = 'Network')
+    {'delay_short': 1-Port Network: 'delay_short',  75-110 GHz, 201 pts, z0=[ 50.+0.j],
+    'line': 2-Port Network: 'line',  75-110 GHz, 201 pts, z0=[ 50.+0.j  50.+0.j]}
 
     See Also
     ----------
@@ -264,11 +269,20 @@ def read_all(dir='.', contains = None, f_unit = None, obj_type=None):
     '''
 
     out={}
-    for filename in os.listdir(dir):
+    
+    filelist = files
+    if files == None:
+        filelist = os.listdir(dir)
+    
+    for filename in filelist:
         if contains is not None and contains not in filename:
             continue
-        fullname = os.path.join(dir,filename)
-        keyname = os.path.splitext(filename)[0]
+        if files == None:
+            fullname = os.path.join(dir,filename)
+            keyname = os.path.splitext(filename)[0]
+        else:
+            fullname = filename
+            keyname = os.path.splitext(os.path.basename(filename))[0]
         try:
             out[keyname] = read(fullname)
             continue

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -233,7 +233,7 @@ def read_all(dir='.', contains = None, f_unit = None, obj_type=None, files=None)
     obj_type : str
         Name of skrf object types to read (ie 'Network')
     files : list, optional
-        list of files to load, bypassed dir.
+        list of files to load, bypasses dir parameter.
 
     Returns
     ---------

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -22,6 +22,7 @@ class IOTestCase(unittest.TestCase):
         self.short = rf.Network(os.path.join(self.test_dir, 'short.s1p'))
         self.match = rf.Network(os.path.join(self.test_dir, 'match.s1p'))
         self.open = rf.Network(os.path.join(self.test_dir, 'open.s1p'))
+        self.test_files = [os.path.join(self.test_dir, test_file) for test_file in ['ntwk1.s2p', 'ntwk2.s2p']]
         self.embeding_network= rf.Network(os.path.join(self.test_dir, 'embedingNetwork.s2p'))
         self.freq = rf.F(75,110,101)
 
@@ -38,6 +39,9 @@ class IOTestCase(unittest.TestCase):
 
     def test_read_all(self):
         rf.read_all(self.test_dir)
+    
+    def test_read_all_files(self):
+        rf.read_all(files=self.test_files)
 
     def test_save_sesh(self):
         a=self.ntwk1


### PR DESCRIPTION
This implements https://github.com/scikit-rf/scikit-rf/issues/272 and allows users to pass in a files parameter, which is a list of files.  

This is helpful for situations when a directory parameter and a contains string is not the desired search mechanism for networks. Files can span multiple directories. My intended addition is for cases when the list of files is determined outside of the read_all function.  

This change is backwards compatible, as agreed.

- Updated read_all function, in a backwards compatible way, per issue https://github.com/scikit-rf/scikit-rf/issues/272 agreement
- add test case with a list of networks in test folder 
  - (intentionally not testing multiple directories as this is self contained in the data folder, but a list of absolute paths is now supported)
- Updated Networks.ipynb file showing the new function

Please let me know if there is any thing more you would need before merging.

Thank you,
Ian