### PR TITLE
fixing connect indexing issue

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3248,8 +3248,8 @@ def connect(ntwkA, k, ntwkB, l, num=1):
     if ntwkB.nports == 2 and ntwkA.nports > 2 and num == 1:
         from_ports = list(range(ntwkC.nports))
         to_ports = list(range(ntwkC.nports))
-        to_ports.pop(k);
-        to_ports.append(k)
+        to_ports.pop(k-1);
+        to_ports.append(k-1)
 
         ntwkC.renumber(from_ports=from_ports,
                        to_ports=to_ports)


### PR DESCRIPTION
ntwkA is 4 port device: [0,1,2,3]
ntwkB is 2 port device: [0,1]
I would like to connect port 3 &4 of ntwkA along with port 1 & 2 of ntwkB using

> rf.connect(ntwkA_4p, 2, ntwkB_2p, 0, 2)


**here k=2, l=0, num=2. Thus, ntwkC has (4 + 2 - 2*2) 2 ports.**
Then I get following error:

---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-3-1c96e8e9708a> in <module>
      8 ntwkB_2p = ntwkB_2p.interpolate_from_f(freq)
      9 
---> 10 ntwkC_2p = rf.connect(ntwkA_4p,2,ntwkB_2p,0,2)
     11 
     12 ntwkC_2p.s21['27.5-30.64ghz'].plot_s_db()

~\AppData\Local\Continuum\anaconda3\lib\site-packages\skrf\network.py in connect(ntwkA, k, ntwkB, l, num)
   2843         from_ports = list(range(ntwkC.nports))    # equal to 2, as ntwkC has 2 ports
   2844         to_ports = list(range(ntwkC.nports))        # equal to 2, as ntwkC has 2 ports
-> 2845         to_ports.pop(k);     **# [0, 1].pop(2) this causes pop index out of range**
   2846         to_ports.append(k)
   2847 


IndexError: pop index out of range

---------------------------------------------------------------------------
So the mitigation of this issue is to use k-1 instead of k.

After this fix, combining multi-port with two port device works without issue
