### PR TITLE
Modified `connect` and `__getitem__` to allow networks with frequency subsets

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3293,7 +3293,7 @@ def connect(ntwkA, k, ntwkB, l, num=1):
         else:
             ntwkA = ntwkA[common_freq[1]]
             ntwkB = ntwkB[common_freq[2]]
-            print("Using a frequency subset:\n" + str(ntwkA.frequency))
+            warnings.warn("Using a frequency subset:\n" + str(ntwkA.frequency))
 
     if (k + num - 1 > ntwkA.nports - 1):
         raise IndexError('Port `k` out of range')

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -681,8 +681,16 @@ class Network(object):
                 return ntwk
             else:
                 raise ValueError("Don't understand index: {0}".format(key))
-        sliced_frequency = self.frequency[key]
-        return self.interpolate(sliced_frequency)
+            sliced_frequency = self.frequency[key]
+            return self.interpolate(sliced_frequency)
+        if isinstance(key, str):
+            sliced_frequency = self.frequency[key]
+            return self.interpolate(sliced_frequency)
+        if isinstance(key, Frequency):
+            return self.interpolate(key)
+        # The following avoids interpolation when the slice is done directly with indices
+        ntwk = self.copy_subset(key)
+        return ntwk
 
     def __str__(self):
         """
@@ -1571,6 +1579,38 @@ class Network(object):
         '''
         for attr in ['_s', 'frequency', '_z0', 'name']:
             self.__setattr__(attr, copy(other.__getattribute__(attr)))
+
+    def copy_subset(self, key):
+        '''
+        Returns a copy of a frequency subset of this Network
+
+        Needed to allow pass-by-value for a subset Network instead of
+        pass-by-reference
+        
+        Parameters
+        -----------
+        key : numpy array
+            the array indices of the frequencies to take
+        '''
+        ntwk = Network(s=self.s[key,:],
+                       frequency=self.frequency[key].copy(),
+                       z0=self.z0[key,:],
+                       )
+
+        if isinstance(self.name, str):
+            ntwk.name = self.name + '_subset'
+        else:
+            ntwk.name = self.name
+
+        if self.noise is not None and self.noise_freq is not None:
+            ntwk.noise = npy.copy(self.noise[key,:])
+            ntwk.noise_freq = npy.copy(self.noise_freq[key])
+
+        try:
+            ntwk.port_names = copy(self.port_names)
+        except(AttributeError):
+            ntwk.port_names = None
+        return ntwk
 
     # touchstone file IO
     def read_touchstone(self, filename):
@@ -3199,6 +3239,8 @@ def connect(ntwkA, k, ntwkB, l, num=1):
     `l` thru `l+num-1` on `ntwkB`. The resultant network has
     (ntwkA.nports+ntwkB.nports-2*num) ports. The port indices ('k','l')
     start from 0. Port impedances **are** taken into account.
+    When the two networks have overlapping frequencies, the resulting
+    network will contain only the overlapping frequencies.
 
     Parameters
     -----------
@@ -3242,7 +3284,16 @@ def connect(ntwkA, k, ntwkB, l, num=1):
 
     '''
     # some checking
-    check_frequency_equal(ntwkA, ntwkB)
+    try:
+        check_frequency_equal(ntwkA, ntwkB)
+    except IndexError as e:
+        common_freq = npy.intersect1d(ntwkA.frequency.f, ntwkB.frequency.f, return_indices=True)
+        if common_freq[0].size is 0:
+            raise e
+        else:
+            ntwkA = ntwkA[common_freq[1]]
+            ntwkB = ntwkB[common_freq[2]]
+            print("Using a frequency subset:\n" + str(ntwkA.frequency))
 
     if (k + num - 1 > ntwkA.nports - 1):
         raise IndexError('Port `k` out of range')


### PR DESCRIPTION
In this pull request (originally #300, reopened on a different branch on my repo, and linked to issue #297):

-  Modified `connect` to allow networks with frequency subsets
- Changed the `__getitem__` to avoid interpolation with explicit frequency indices.
- Updated the `__getitem__` to allow slicing using Frequency objects.
- Updated the subset slice to use a `copy_subset` function

---
Examples:

```python
#!python3
# coding: utf-8

import skrf as rf
import numpy as np

ntwkA = rf.Network(name='Network A')
ntwkA.frequency.f = [11,22,33,44,55]
ntwkA.frequency.unit = 'Hz'
ntwkA.s = np.repeat(np.array([[0.9, 0.1], [0.1, 0.9]])[np.newaxis, :], 5, 0)

ntwkB = rf.Network(name='Network B')
ntwkB.frequency.f = [55, 66]
ntwkA.frequency.unit = 'Hz'
ntwkB.s = np.repeat(np.array([[0.9, 0.1], [0.1, 0.9]])[np.newaxis, :], 3, 0)

print("\nTrying to cascade the networks with partially overlapped frequencies")
ntwkC = ntwkA**ntwkB
print(ntwkA)
print(ntwkB)
print(ntwkC)

print("\nTrying to slice using a frequency object: this should maintain the old behaviour")
a = rf.Frequency(unit='Hz')
a.f = [33, 44]
print(ntwkA[a])

print("\nTrying to cascade the networks with fully overlapped frequencies")
ntwkB = ntwkA[2:4]
ntwkC = ntwkA**ntwkB
print(ntwkA)
print(ntwkB)
print(ntwkC)

print("\nTrying to calibrate a network with a subset of calkit frequencies")
ideal = rf.load_all_touchstones('mytest/calkit')
cal_meas = rf.load_all_touchstones('mytest/calibration_full_freq')
cal = rf.calibration.OnePort(cal_meas, ideal, sloppy_input=True)

s11 = 0.5 / 1
network = rf.Network()
network.frequency.f = [200195.3125]
network.frequency.unit = 'hz'
network.s = [s11]
network = cal.apply_cal(network)
```
```bash
Trying to cascade the networks with partially overlapped frequencies
Using a frequency subset:
55.0-55.0 Hz, 1 pts
2-Port Network: 'Network A',  11.0-55.0 Hz, 5 pts, z0=[50.+0.j 50.+0.j]
2-Port Network: 'Network B',  5.5e-08-6.6e-08 GHz, 2 pts, z0=[50.+0.j 50.+0.j]
2-Port Network: 'Network A_subset',  55.0-55.0 Hz, 1 pts, z0=[50.+0.j 50.+0.j]

Trying to slice using a frequency object: this should maintain the old behaviour
2-Port Network: 'Network A',  33.0-44.0 Hz, 2 pts, z0=[50.+0.j 50.+0.j]

Trying to cascade the networks with fully overlapped frequencies
Using a frequency subset:
33.0-44.0 Hz, 2 pts
2-Port Network: 'Network A',  11.0-55.0 Hz, 5 pts, z0=[50.+0.j 50.+0.j]
2-Port Network: 'Network A_subset',  33.0-44.0 Hz, 2 pts, z0=[50.+0.j 50.+0.j]
2-Port Network: 'Network A_subset',  33.0-44.0 Hz, 2 pts, z0=[50.+0.j 50.+0.j]

Trying to calibrate a network with a subset of calkit frequencies
Warning: Frequency information doesn't match on ideals[0], attempting to interpolate the ideal[0] Network ..
Success
Warning: Frequency information doesn't match on ideals[1], attempting to interpolate the ideal[1] Network ..
Success
Warning: Frequency information doesn't match on ideals[2], attempting to interpolate the ideal[2] Network ..
Success
/home/alex/git/github-personal/scikit-rf/skrf/calibration/calibration.py:1062: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.
To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.
  abcTmp, residualsTmp = npy.linalg.lstsq(Q,m)[0:2]
Using a frequency subset:
200195.3125-200195.3125 Hz, 1 pts
```
Download the required calibration files from [calfiles.zip](https://github.com/scikit-rf/scikit-rf/files/4053383/calfiles.zip)
