### PR TITLE
ZVA: add missing single quotation mark for CONV name

### DIFF
--- a/skrf/vi/vna/rs_zva_scpi.py
+++ b/skrf/vi/vna/rs_zva_scpi.py
@@ -173,7 +173,7 @@ class SCPI(object):
          |-----------|--------------------|
      
         """
-        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME {:}", cnum, TYPE)
+        scpi_command = scpi_preprocess(":SENS{:}:FREQ:CONV:DEV:NAME '{:}'", cnum, TYPE)
         self.write(scpi_command)
 
     def set_corr_connection(self, cnum=1, pnum=1, CONN=""):

--- a/skrf/vi/vna/rs_zva_scpi.yaml
+++ b/skrf/vi/vna/rs_zva_scpi.yaml
@@ -308,7 +308,7 @@ COMMAND_TREE:
             \t\t\tPorts 5 and 6: Converter LO
             \n\t"
           }
-          NAME: {name: converter_name, set: "<TYPE>", query: "",
+          NAME: {name: converter_name, set: "'<TYPE>'", query: "",
             help: "Selects the frequency converter type for enhanced frequency-converting measurements\n\n
             \t(with option ZVA-K8, Converter Control).\n\n
             \tThe preset configuration will be reset to Instrument scope (SYSTem:PRESet:SCOPe ALL)\n


### PR DESCRIPTION
The command did not set the name for the frequency extender without the
single quotation mark. Works now:

```python
In [1]: from skrf.vi.vna import ZVA
In [2]: vna = ZVA(address='192.168.1.83', visa_library='@py', interface='SOCKET')
In [3]: vna.echo = 1
In [4]: vna.scpi.query_converter_name()
:SENS1:FREQ:CONV:DEV:NAME?
Out[4]: 'ZC220'
In [5]: vna.scpi.set_converter_name(1, 'ZC330')
:SENS1:FREQ:CONV:DEV:NAME 'ZC330'
In [6]: vna.scpi.query_converter_name()
:SENS1:FREQ:CONV:DEV:NAME?
Out[6]: 'ZC330'
```