### PR TITLE
is_from_hfss(): fix TypeError when comments is None

### DIFF
--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -414,12 +414,15 @@ class Touchstone:
         status : boolean
             True if the Touchstone file has been produced by HFSS
             False otherwise
-        '''    
-        status = False
+        '''
+        if self.comments is None:
+            return False
+
         if 'exported from hfss' in str.lower(self.comments):
-            status = True
-        return status      
-    
+            return True
+
+        return False
+
     def get_gamma_z0(self):
         '''
         Extracts Z0 and Gamma comments from touchstone file (is provided)


### PR DESCRIPTION
This fixes:
[...]/skrf/io/touchstone.py in is_from_hfss(self)
    417         '''
    418         status = False
--> 419         if 'exported from hfss' in str.lower(self.comments):
    420             status = True
    421         return status

TypeError: descriptor 'lower' requires a 'str' object but received a 'NoneType'

... when comments is None. Return False instead.