### PR TITLE
Change kilo unit prefix from lowercase k to capital K. Though this is…

### DIFF
--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -55,7 +55,7 @@ except ImportError as e:
 
 #from matplotlib.lines import Line2D            # for drawing smith chart
 
-SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
+SI_PREFIXES_ASCII = 'yzafpnum KMGTPEZY'
 SI_CONVERSION = dict([(key, 10**((8-i)*3)) for i, key in enumerate(SI_PREFIXES_ASCII)])
 
 


### PR DESCRIPTION
… technically incorrect from the SI standpoint, the documentation states that the units are not case sensitive, so the user will see no change.

Fixes Issue #338  