### PR TITLE
Return kHz when network.frequency.unit = 'khz'

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -64,7 +64,7 @@ class Frequency(object):
     '''
     unit_dict = {\
             'hz':'Hz',\
-            'khz':'KHz',\
+            'khz':'kHz',\
             'mhz':'MHz',\
             'ghz':'GHz',\
             'thz':'THz'\


### PR DESCRIPTION
See [BIPM - SI prefixes](https://www.bipm.org/en/measurement-units/prefixes.html)

Fixes Issue #338 