### PR TITLE
remove unused matplotlib imports

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -176,9 +176,9 @@ from .constants import ZERO, K_BOLTZMANN, T0
 from .constants import S_DEFINITIONS, S_DEF_DEFAULT
 
 
-from matplotlib import cm
-import matplotlib.pyplot as plt
-import matplotlib.tri as tri
+#from matplotlib import cm
+#import matplotlib.pyplot as plt
+#import matplotlib.tri as tri
 #from scipy.interpolate import interp1d
 
 


### PR DESCRIPTION
Comments out unused matplotlib imports in network.py that result in problems when users try to use skrf without matplotlib installed (see #363)