### PR TITLE
Don't shadow skrf's io module with the system io module.

### DIFF
--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -775,8 +775,8 @@ if sys.version_info < (3, 0):
         def __exit__(self, *args):
             self.close()
 else:
-    import io
-    StringBuffer = io.StringIO
+    from io import StringIO
+    StringBuffer = StringIO
 
 
 class TouchstoneEncoder(json.JSONEncoder):


### PR DESCRIPTION
This makes using (and investigating via ipython etc) the skrf.io module easier & clearer.
