### PR TITLE
change ifft to fft in gate frequency domain calculation

### DIFF
--- a/skrf/time.py
+++ b/skrf/time.py
@@ -262,8 +262,8 @@ def time_gate(ntwk, start=None, stop=None, center=None, span=None,
                            window,
                            npy.zeros(len(t) - stop_idx)]
 
-    #IFFT the gate, so we have it's frequency response, aka kernel
-    kernel=fft.fftshift(fft.ifft(fft.ifftshift(gate, axes=0), axis=0))
+    #FFT the gate, so we have it's frequency response, aka kernel
+    kernel=fft.ifftshift(fft.fft(fft.fftshift(gate, axes=0), axis=0))
     kernel =abs(kernel).flatten() # take mag and flatten
     kernel=kernel/sum(kernel) # normalize kernel
     


### PR DESCRIPTION
To address #390 , changed
`kernel=fft.fftshift(fft.ifft(fft.ifftshift(gate, axes=0), axis=0))`
to
`kernel2=fft.ifftshift(fft.fft(fft.fftshift(gate, axes=0), axis=0))`

While it produces a different mathematical result (for example due to the different iFFT/FFT normalization, see fft doc), the final result is the same as only the normalized magnitude is kept after:

```
kernel =abs(kernel).flatten() # take mag and flatten
kernel=kernel/sum(kernel) # normalize kernel
```