### PR TITLE
Fix Python 2 tests with Github Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,6 +28,6 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with nose
-      run: sudo apt-get install xvfb  
       run: |
+        sudo apt-get install xvfb  
         nosetests skrf --nocapture -c nose.cfg

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,5 +28,6 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with nose
+      run: sudo apt-get install xvfb  
       run: |
         nosetests skrf --nocapture -c nose.cfg


### PR DESCRIPTION
Install xvfb before running the tests, so that the call to matplotlib plot() do not fail on Python 2. 