### PR TITLE
Matplotlib backend reconfiguration

### DIFF
--- a/skrf/data/skrf.mplstyle
+++ b/skrf/data/skrf.mplstyle
@@ -57,4 +57,4 @@ path.simplify       : True
 
 savefig.dpi         : 120      
 
-interactive :True
+#interactive :True

--- a/skrf/data/skrf2.mplstyle
+++ b/skrf/data/skrf2.mplstyle
@@ -58,4 +58,4 @@ path.simplify       : True
 
 savefig.dpi         : 120
 
-interactive :True
+#interactive :True

--- a/skrf/data/skrf2_wide.mplstyle
+++ b/skrf/data/skrf2_wide.mplstyle
@@ -58,4 +58,4 @@ path.simplify       : True
 
 savefig.dpi         : 120
 
-interactive :True
+#interactive :True

--- a/skrf/data/skrf_wide.mplstyle
+++ b/skrf/data/skrf_wide.mplstyle
@@ -57,4 +57,4 @@ path.simplify       : True
 
 savefig.dpi         : 120      
 
-interactive :True
+#interactive :True

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -57,11 +57,11 @@ Misc Functions
 import os
 
 import matplotlib as mpl
-# if running on remote mode on a linux server which does not have a display (like Docker images for CI)
-if os.name == 'posix' and not os.environ.get('DISPLAY', '') and mpl.rcParams['backend'] != 'agg': 
-    print('No display found. Using non-interactive Agg backend.') 
-    # https://matplotlib.org/faq/usage_faq.html 
-    mpl.use('Agg') 
+# # if running on remote mode on a linux server which does not have a display (like Docker images for CI)
+# if os.name == 'posix' and not os.environ.get('DISPLAY', '') and mpl.rcParams['backend'] != 'agg':
+#     print('No display found. Using non-interactive Agg backend.')
+#     # https://matplotlib.org/faq/usage_faq.html
+#     mpl.use('Agg')
 from matplotlib import ticker
 import matplotlib.pyplot as plb
 import numpy as npy

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -55,13 +55,15 @@ Misc Functions
 
 '''
 import os
+import sys
 
 import matplotlib as mpl
-# # if running on remote mode on a linux server which does not have a display (like Docker images for CI)
-# if os.name == 'posix' and not os.environ.get('DISPLAY', '') and mpl.rcParams['backend'] != 'agg':
-#     print('No display found. Using non-interactive Agg backend.')
-#     # https://matplotlib.org/faq/usage_faq.html
-#     mpl.use('Agg')
+# if running on remote mode on a linux server which does not have a display (like Docker images for CI)
+# seems to cause problems only in Python2, so let's try reconfiguring the backend only in that case
+if os.name == 'posix' and not os.environ.get('DISPLAY', '') and mpl.rcParams['backend'] != 'agg' and sys.version.startswith('2'):
+    print('No display found. Using non-interactive Agg backend.')
+    # https://matplotlib.org/faq/usage_faq.html
+    mpl.use('Agg')
 from matplotlib import ticker
 import matplotlib.pyplot as plb
 import numpy as npy


### PR DESCRIPTION
Fixes https://github.com/scikit-rf/scikit-rf/issues/419

1. Disabling the matplotlib backend reconfiguration in `plotting.py` (**Edit**: keeping it for Python2)
2. Disabling invalid parameter `interactive` from matplotlib stylesheets, which were causing warnings in `skrf.stylely()`