### PR TITLE
add port name writing in write_touchstone (re-implementation of PR #428)

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1845,7 +1845,7 @@ class Network(object):
     def write_touchstone(self, filename=None, dir=None,
                          write_z0=False, skrf_comment=True,
                          return_string=False, to_archive=None,
-                         form='ri',format_spec_A='{}',format_spec_B='{}',
+                         form='ri', format_spec_A='{}', format_spec_B='{}',
                          format_spec_freq='{}'):
         """
         Write a contents of the :class:`Network` to a touchstone file.
@@ -1949,7 +1949,7 @@ class Network(object):
                 if self.comments:
                     for comment_line in self.comments.split('\n'):
                         commented_header += '!{}\n'.format(comment_line)
-            except(AttributeError):
+            except AttributeError:
                 pass
             if skrf_comment:
                 commented_header += '!Created with skrf (http://scikit-rf.org).\n'
@@ -1961,6 +1961,16 @@ class Network(object):
             # exactly this format, to work
             # [HZ/KHZ/MHZ/GHZ] [S/Y/Z/G/H] [MA/DB/RI] [R n]
             output.write('# {} S {} R {} \n'.format(self.frequency.unit, form, str(abs(self.z0[0, 0]))))
+
+            # write ports
+            try:
+                if self.port_names and len(self.port_names) == self.number_of_ports:
+                    ports = ''
+                    for port_idx, port_name in enumerate(self.port_names):
+                        ports += '! Port[{}] = {}\n'.format(port_idx, port_name)
+                    output.write(ports)
+            except AttributeError:
+                pass
 
             scaled_freq = self.frequency.f_scaled
 


### PR DESCRIPTION
PR #428 has been accidentally reverted due to a non-updated PR #433 based on a previous version