### PR TITLE
Fixed a/an typo in Interpolating Network Sets

### DIFF
--- a/doc/source/examples/networksets/Interpolating Network Sets.ipynb
+++ b/doc/source/examples/networksets/Interpolating Network Sets.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, we are characterizing a old [narda phase shifter 3752](https://nardamiteq.com/docs/119-PHASESHIFTERS.PDF) at 1.5 GHz. \n",
+    "In this example, we are characterizing an old [narda phase shifter 3752](https://nardamiteq.com/docs/119-PHASESHIFTERS.PDF) at 1.5 GHz. \n",
     "![narda 3752 phase shifter](phase_shifter_measurements/Narda_3752.jpg) :\n",
     "\n",
     "In order to deduce the phase shift that one can obtain at this specific frequency, we have measured scattering parameters in the 1-2 GHz band at 19 positions of the phase knob (from 0 to 180). These measurements are loaded into a [NetworkSets](../../tutorials/NetworkSet.ipynb) object:"


### PR DESCRIPTION
`Interpolating Network Sets.ipynb` had the following typo:

a old -> an old