### PR TITLE
Correct image links in an example Notebook

### DIFF
--- a/doc/source/examples/circuit/Lumped Element Circuits.ipynb
+++ b/doc/source/examples/circuit/Lumped Element Circuits.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "In this section we reproduce a simple equivalent model of a capacitor $C$, as illustrated by the figure below:\n",
     "\n",
-    "![](designer_capacitor_simple.png)\n"
+    "<img src=\"designer_capacitor_simple.png\" width=700/>\n"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "source": [
     "In this section we reproduce an equivalent model of a capacitor $C$, as illustrated by the figure below:\n",
     "\n",
-    "![](designer_capacitor_adv.png)"
+    "<img src='designer_capacitor_adv.png' width=800/>"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](designer_bandpass_filter_450_550MHz.png)\n"
+    "<img src=\"designer_bandpass_filter_450_550MHz.png\" width=800/>\n"
    ]
   },
   {
@@ -305,8 +305,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (Spyder)",
-   "language": "python3",
+   "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {


### PR DESCRIPTION
Should use the html `<img src="..." />` in a notebook instead of the `![](...)` markdown, otherwise Sphinx takes only the last image into account.