### PR TITLE
Fix image links in documentation

### DIFF
--- a/doc/source/examples/circuit/Lumped Element Circuits.ipynb
+++ b/doc/source/examples/circuit/Lumped Element Circuits.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "In this section we reproduce a simple equivalent model of a capacitor $C$, as illustrated by the figure below:\n",
     "\n",
-    "<img src=\"designer_capacitor_simple.png\" width=700/>\n"
+    "<img src=\"designer_capacitor_simple.png\" width=\"700\">\n"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "source": [
     "In this section we reproduce an equivalent model of a capacitor $C$, as illustrated by the figure below:\n",
     "\n",
-    "<img src='designer_capacitor_adv.png' width=800/>"
+    "<img src=\"designer_capacitor_adv.png\" width=\"800\">"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"designer_bandpass_filter_450_550MHz.png\" width=800/>\n"
+    "<img src=\"designer_bandpass_filter_450_550MHz.png\" width=\"800\">\n"
    ]
   },
   {

--- a/doc/source/examples/circuit/Voltages and Currents in Circuits.ipynb
+++ b/doc/source/examples/circuit/Voltages and Currents in Circuits.ipynb
@@ -45,7 +45,7 @@
     "## A simple transmission line\n",
     "To start, let's assume a simple transmission line excited by a generator. Let's assume the generator is matched to the line ($Z_s=Z_0$) and the line connected to a matched load ($Z_0=Z_L$), all 50 Ohm. \n",
     "\n",
-    "![](circuit_vi_simple_line.svg)\n",
+    "<img src=\"circuit_vi_simple_line.svg\">\n",
     "\n",
     "What is the RF currents and voltages at the input and output of this line for a given input power (and phase)?"
    ]
@@ -452,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/circuit/Wilkinson Power Splitter.ipynb
+++ b/doc/source/examples/circuit/Wilkinson Power Splitter.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "In this notebook we create a [Wilkinson power divider](https://www.microwaves101.com/encyclopedias/wilkinson-power-splitters), which splits an input signal into two equals phase output signals. Theoritecal results about this circuit are exposed in reference [1]. Here we will reproduce the ideal circuit illustrated below and discussed in reference [2]. In this example, the circuit is designed to operate at 1 GHz.\n",
     "\n",
-    "![](wilkinson_power_divider.png)\n",
+    "<img src=\"wilkinson_power_divider.png\">\n",
     "\n",
     " - [1] P. Hallbjörner, Microw. Opt. Technol. Lett. 38, 99 (2003).\n",
     " - [2] Microwaves 101: \"Wilkinson Power Splitters\" "

--- a/doc/source/examples/matching/Impedance Matching.ipynb
+++ b/doc/source/examples/matching/Impedance Matching.ipynb
@@ -19,7 +19,7 @@
     " - reducing amplitude and phase errors\n",
     " - reducing reflected power toward generator\n",
     " \n",
-    "![general matching](figures/Impedance_matching_general.svg)\n",
+    "<img src=\"figures/Impedance_matching_general.svg\">\n",
     "\n",
     "As long as the load impedance $Z_L$ has a real positive part, a matching network can always be found. Many choices are available and the examples below only describe a few. The examples are taken from the D.Pozar book \"Microwave Engineering\", 4th edition. "
    ]
@@ -43,12 +43,12 @@
     "## Matching with Lumped Elements\n",
     "To begin, let's assume that the matching network is lossless and the feedig line characteristic impedance is $Z_0$:  \n",
     "\n",
-    "![Load matching](figures/Impedance_matching_lumped1.svg)\n",
+    "<img src=\"figures/Impedance_matching_lumped1.svg\">\n",
     "\n",
     "The simplest type of matching network is the \"L\" network, which uses two reactive elements to match an arbitrary load impedance. Two possible configuration exist and are illustrated by the figures below. In either configurations, the reactive elements can be inductive of capacitive, depending on the load impedance.\n",
     "\n",
-    "![matching with lumped components 1](figures/Impedance_matching_lumped2.svg)\n",
-    "![matching with lumped components 2](figures/Impedance_matching_lumped3.svg)"
+    "<img src=\"figures/Impedance_matching_lumped2.svg\">\n",
+    "<img src=\"figures/Impedance_matching_lumped3.svg\">"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "metadata": {},
    "source": [
     "We are searching for a L-C Network corresponding to the first configuration above:\n",
-    "![matching with lumped components LC](figures/Impedance_matching_lumped4.svg)"
+    "<img src=\"figures/Impedance_matching_lumped4.svg\">"
    ]
   },
   {
@@ -194,7 +194,7 @@
     "## Single-Stub Matching\n",
     "Matching can be made with a piece of open-ended or shorted transmission line ( _stub_ ), connected either in parallel ( _shunt_ ) or in series. In the example below, a matching network is realized from a shorted transmission line of length ($\\theta_{stub}$) connected in parallel, in association with a series transmission line ($\\theta_{line}$). Let's assume a load impedance $Z_L=60 - 80j$ connected to a 50 Ohm transmission line. \n",
     "\n",
-    "![matching with single stub](figures/Impedance_matching_stub1.svg)\n",
+    "<img src=\"figures/Impedance_matching_stub1.svg\">\n",
     "\n",
     "Let's match this load at 2 GHz: "
    ]

--- a/doc/source/examples/mixedmodeanalysis/Mixed Mode Basics.ipynb
+++ b/doc/source/examples/mixedmodeanalysis/Mixed Mode Basics.ipynb
@@ -17,7 +17,7 @@
     "parameters using a [50 ohm calibration load](https://www.formfactor.com/download/iss-map-129-246/) as an example.\n",
     "The experimental port setup consists of two differential probes as shown:\n",
     "\n",
-    "![](mixedmodebasics_files/setup.PNG)\n",
+    "<img src=\"mixedmodebasics_files/setup.PNG\">\n",
     "\n",
     "Experimental data for the 50 ohm load taken in normal \"single ended\" mode will be compared against data saved in\n",
     "a mixed mode format and taken using Keysight's integrated True Mode Stimulus, which applies true differential\n",
@@ -282,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/mixedmodeanalysis/Mixed Mode S and Impedance Transformation.ipynb
+++ b/doc/source/examples/mixedmodeanalysis/Mixed Mode S and Impedance Transformation.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Lastly, since it is desired to use this network in a cascade analysis as a 2-port block in a 50 Ω environment, the differential mode will be terminated in 100 Ω and a 50 Ω port transformed to 25 Ω will be connected to the common mode port:\n",
     "\n",
-    "![](mixedmodeSandZtransform_files/mixed_mode.png)"
+    "<img src=\"mixedmodeSandZtransform_files/mixed_mode.png\">"
    ]
   },
   {
@@ -140,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/networktheory/DC Extrapolation for Time Domain .ipynb
+++ b/doc/source/examples/networktheory/DC Extrapolation for Time Domain .ipynb
@@ -22,22 +22,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skrf\n",
+    "import skrf as rf\n",
     "from skrf.media import Coaxial\n",
     "import matplotlib.pyplot as plt\n",
     "from skrf.plotting import stylely\n",
     "stylely()\n",
-    "%matplotlib inline\n",
-    "\n",
-    "freq = skrf.F(0.11,110,1001)\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freq = rf.Frequency(0.11, 110, 1001)\n",
     "coax1mm = Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e20)\n",
     "\n",
-    "X = coax1mm.line(10, 'mm', z0=50, name='X', embed=True)\n",
-    "Y = coax1mm.line(80, 'mm', z0=75, name='Y', embed=True)\n",
+    "X = coax1mm.line(10, unit='mm', z0=50, name='X', embed=True)\n",
+    "Y = coax1mm.line(80, unit='mm', z0=75, name='Y', embed=True)\n",
     "dut = X**Y**X\n",
     "\n",
-    "dut_dc = dut.extrapolate_to_dc(dc_sparam=[[0,1],[1,0]])\n",
-    "\n",
+    "dut_dc = dut.extrapolate_to_dc(dc_sparam=[[0,1],[1,0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.figure()\n",
     "plt.title('Step')\n",
     "t, y = dut.s11.step_response(pad=2000)\n",
@@ -45,8 +59,15 @@
     "plt.plot(t*1e9, y, label='Original')\n",
     "plt.plot(t2*1e9, y2, label='Extrapolated')\n",
     "plt.legend()\n",
-    "plt.xlabel('Time (ns)')\n",
-    "\n",
+    "plt.xlabel('Time (ns)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.figure()\n",
     "plt.title('Impulse')\n",
     "t, y = dut.s11.impulse_response(pad=2000)\n",
@@ -54,9 +75,7 @@
     "plt.plot(t*1e9, y, label='Original')\n",
     "plt.plot(t2*1e9, y2, label='Extrapolated')\n",
     "plt.legend()\n",
-    "plt.xlabel('Time (ns)')\n",
-    "\n",
-    "plt.show(block=True)"
+    "plt.xlabel('Time (ns)')"
    ]
   },
   {
@@ -84,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.8"
   },
   "toc": {
    "nav_menu": {},

--- a/doc/source/examples/networktheory/Properties of Rectangular Waveguides.ipynb
+++ b/doc/source/examples/networktheory/Properties of Rectangular Waveguides.ipynb
@@ -41,22 +41,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "%matplotlib inline\n",
     "import skrf as rf \n",
     "rf.stylely()\n",
     "\n",
     "# imports \n",
-    "\n",
     "from scipy.constants import mil,c\n",
     "from skrf.media import RectangularWaveguide, Freespace\n",
     "from skrf.frequency import Frequency\n",
     "\n",
-    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "\n",
     "# plot formating\n",
-    "mpl.rcParams['lines.linewidth'] = 2\n",
-    "\n",
+    "plt.rcParams['lines.linewidth'] = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create frequency objects for standard bands\n",
     "f_wr5p1  = Frequency(140,220,1001, 'ghz')\n",
     "f_wr3p4  = Frequency(220,330,1001, 'ghz')\n",
@@ -99,15 +105,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pylab import * \n",
+    "fig, ax = plt.subplots()\n",
     "\n",
     "for wg in wg_list:\n",
-    "    wg.frequency.plot(rf.np_2_db(wg.alpha), label=wg.name )\n",
+    "    wg.frequency.plot(rf.np_2_db(wg.alpha), label=wg.name)\n",
     "\n",
-    "legend()    \n",
-    "xlabel('Frequency(GHz)')\n",
-    "ylabel('Loss (dB/m)')\n",
-    "title('Loss in Rectangular Waveguide (Au)');"
+    "ax.legend()    \n",
+    "ax.set_xlabel('Frequency(GHz)')\n",
+    "ax.set_ylabel('Loss (dB/m)')\n",
+    "ax.set_title('Loss in Rectangular Waveguide (Au)');"
    ]
   },
   {
@@ -116,17 +122,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resistivity_list = linspace(1,10,5)*1e-8 # ohm meter \n",
+    "fig, ax = plt.subplots()\n",
+    "resistivity_list = np.linspace(1,10,5)*1e-8 # ohm meter \n",
     "for rho in resistivity_list:\n",
     "    wg = RectangularWaveguide(f_wr1.copy(), a=10*mil, b=5*mil, \n",
     "                              rho = rho)\n",
     "    wg.frequency.plot(rf.np_2_db(wg.alpha),label=r'$ \\rho $=%.e$ \\Omega m$'%rho )\n",
     "\n",
-    "legend()    \n",
-    "#ylim(.0,20)\n",
-    "xlabel('Frequency(GHz)')\n",
-    "ylabel('Loss (dB/m)')\n",
-    "title('Loss vs. Resistivity in\\nWR-1.0 Rectangular Waveguide');"
+    "ax.legend()    \n",
+    "ax.set_xlabel('Frequency(GHz)')\n",
+    "ax.set_ylabel('Loss (dB/m)')\n",
+    "ax.set_title('Loss vs. Resistivity in\\nWR-1.0 Rectangular Waveguide');"
    ]
   },
   {
@@ -142,14 +148,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig, ax = plt.subplots()\n",
     "for wg in wg_list:\n",
     "    wg.frequency.plot(100*wg.v_p.real/c, label=wg.name )\n",
     "\n",
-    "legend()    \n",
-    "ylim(50,200)\n",
-    "xlabel('Frequency(GHz)')\n",
-    "ylabel('Phase Velocity (\\%c)')\n",
-    "title('Phase Velocity in Rectangular Waveguide');"
+    "ax.legend()    \n",
+    "ax.set_ylim(50,200)\n",
+    "ax.set_xlabel('Frequency(GHz)')\n",
+    "ax.set_ylabel('Phase Velocity (\\%c)')\n",
+    "ax.set_title('Phase Velocity in Rectangular Waveguide');"
    ]
   },
   {
@@ -158,16 +165,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig, ax = plt.subplots()\n",
     "for wg in wg_list:\n",
     "    plt.plot(wg.frequency.f_scaled[1:], \n",
-    "             100/c*diff(wg.frequency.w)/diff(wg.beta), \n",
+    "             100/c*np.diff(wg.frequency.w)/np.diff(wg.beta), \n",
     "             label=wg.name )\n",
     "    \n",
-    "legend()    \n",
-    "ylim(50,100)\n",
-    "xlabel('Frequency(GHz)')\n",
-    "ylabel('Group Velocity (\\%c)')\n",
-    "title('Group Velocity in Rectangular Waveguide');"
+    "ax.legend()    \n",
+    "ax.set_ylim(50,100)\n",
+    "ax.set_xlabel('Frequency(GHz)')\n",
+    "ax.set_ylabel('Group Velocity (\\%c)')\n",
+    "ax.set_title('Group Velocity in Rectangular Waveguide');"
    ]
   },
   {
@@ -183,14 +191,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig, ax = plt.subplots()\n",
     "for wg in wg_list+[freespace]:\n",
     "    wg.frequency.plot(wg.beta,   label=wg.name )\n",
     "    \n",
-    "legend()    \n",
-    "xlabel('Frequency(GHz)')\n",
-    "ylabel('Propagation Constant (rad/m)')\n",
-    "title('Propagation Constant \\nin Rectangular Waveguide');\n",
-    "semilogy();"
+    "ax.legend()    \n",
+    "ax.set_xlabel('Frequency(GHz)')\n",
+    "ax.set_ylabel('Propagation Constant (rad/m)')\n",
+    "ax.set_title('Propagation Constant \\nin Rectangular Waveguide');\n",
+    "ax.semilogy();"
    ]
   },
   {
@@ -229,7 +238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   },
   "toc": {
    "nav_menu": {},

--- a/doc/source/examples/networktheory/Transmission Line Properties and Manipulations.ipynb
+++ b/doc/source/examples/networktheory/Transmission Line Properties and Manipulations.ipynb
@@ -22,7 +22,7 @@
     "Let's consider a lossy coaxial cable of characteristic impedance $Z_0=75 \\Omega$ of length $d=12 m$. The coaxial cable has an attenuation of 0.02 Neper/m and a [velocity factor](https://en.wikipedia.org/wiki/Velocity_factor) VF=0.67 (This corresponds roughly to a [RG-6](https://en.wikipedia.org/wiki/RG-6) coaxial). The cable is loaded with a $Z_L=150 \\Omega$ impedance. The RF frequency of interest is 250 MHz. \n",
     "\n",
     "Please note that in `scikit-rf`, the line length is defined from the load, ie $z=0$ at the load and $z=d$ at the input of the transmission line:\n",
-    "![](transmission_line_properties.svg) \n",
+    "<img src=\"transmission_line_properties.svg\">\n",
     "\n",
     "\n",
     "First, let's make the necessary Python import statements:"
@@ -320,7 +320,7 @@
    "metadata": {},
    "source": [
     "Now assume that the previous circuit is excited by a source delivering a voltage $V=1 V$ associated to a source impedance $Z_s=100\\Omega$ :\n",
-    "![](transmission_line_properties_vi.svg)"
+    "<img src=\"transmission_line_properties_vi.svg\">"
    ]
   },
   {
@@ -544,7 +544,7 @@
    "source": [
     "In order to build the circuit illustrated by the figure above, all the circuit's Networks are created and then [cascaded](https://scikit-rf.readthedocs.io/en/latest/tutorials/Networks.html#Cascading-and-De-embedding) with the `**` operator: \n",
     "\n",
-    "![](transmission_line_properties_networks.svg)\n",
+    "<img src=\"transmission_line_properties_networks.svg\">\n",
     "\n",
     " * [transmission line](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.line.html) of length $d$ (from the media created above), \n",
     " * a [resistor](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.resistor.html) of impedance $Z_L$, \n",
@@ -604,7 +604,7 @@
     "## Determination of the propagation constant from the input impedance  <a class=\"anchor\" id=\"propagation_constant_from_zin\"></a>\n",
     "Let's assume the input impedance of a short‐circuited lossy transmission line of length d=1.5 m and a characteristic impedance of $Z_0=$100 Ohm has been measured to $Z_{in}=40 - 280j \\Omega$. \n",
     "\n",
-    "![](transmission_line_properties_propagation_constant.svg)\n",
+    "<img src=\"transmission_line_properties_propagation_constant.svg\">\n",
     "\n",
     "The transmission line propagation constant $\\gamma$ is unknown and researched. Let see how to deduce its value  using `scikit-rf`:"
    ]
@@ -709,7 +709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/networktheory/Transmission Lines and SWR.ipynb
+++ b/doc/source/examples/networktheory/Transmission Lines and SWR.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook is inspired from the reference: [\"Facts About SWR, Reflected Power, and Power Transfer on Real Transmission Lines with Loss\"](https://www.fars.k6ya.org/docs/Facts-about-SWR-and-Loss.pdf) by Steve Stearns given at ARRL Pacificon Antenna Seminar in 2010.\n",
     "\n",
-    "![](Impedance_matching_4.svg)\n"
+    "<img src=\"Impedance_matching_4.svg\">\n"
    ]
   },
   {
@@ -275,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/networktheory/Working with Complex Characteristic Impedances.ipynb
+++ b/doc/source/examples/networktheory/Working with Complex Characteristic Impedances.ipynb
@@ -13,7 +13,7 @@
     "## Characteristic Impedance\n",
     "The _characteristic impedance_ $Z_0$ associated to a transmission line (or any continuous media supporting the propagation of electromagnetic waves) is defined as the ratio of the (forward) voltage and current when the transmission line is infinite (i.e. SWR=1, meaning no reflection from a load and thus no backward voltage and current). It thus characterizes the property of the line to oppose a change in voltage for a change of current or vice-versa. Note that in most cases, it is _not_ an impedance which can be measured using a DC Ohmmeter [1]. \n",
     "\n",
-    "![](working_with_complex_char_impedance_def_char_imp.svg)\n",
+    "<img src=\"working_with_complex_char_impedance_def_char_imp.svg\">\n",
     "\n",
     "Voltage and current are derived quantities from the fundamental electric $E$ and magnetic fields $H$ (by mean of line integrals of those fields in the transverse section of a transmission line for given set of boundary conditions). Thus, voltage and current depends of the transmission line geometry and materials and in general their ratio may not be equal to the ratio of $E/H$. For transmission line supporting other modes than TEM, the definition of voltage and current may even be not unique (like for rectangular waveguides). For completness, sometime the ratio of the electric field to the magnetic field is called the _intrinsic impedance_ (like in free space).\n",
     "\n",
@@ -240,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Should use the html `<img src="..." >` in a notebook instead of the `![](...)` markdown, otherwise Sphinx takes only the last image into account. (Another solution is to use `![xxx](...)` in markdown, where xxx is different for all images)