### PR TITLE
Allow reading HFSS files from StringIO

### DIFF
--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -26,7 +26,6 @@ Functions related to reading/writing touchstones.
 """
 import re
 import os
-import io
 import zipfile
 import numpy
 import numpy as npy

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -465,6 +465,10 @@ class Touchstone:
         '''
         Extracts Z0 and Gamma comments from fid
         
+        Parameter
+        -------------
+        fid : file object
+        
         Returns
         --------
         gamma : complex numpy.ndarray

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -114,15 +114,6 @@ class Touchstone:
 
         fid.close()
 
-    def get_line(self, fid):
-        while (1):
-            line = fid.readline()
-            if not type(line) == str:
-                line = line.decode("ascii")  # for python3 zipfile compatibility
-            if not line:
-                break
-            yield line
-
     def load_file(self, fid):
         """
         Load the touchstone file into the interal data structures
@@ -146,8 +137,10 @@ class Touchstone:
             raise Exception('Filename does not have the expected Touchstone extension (.sNp or .ts)')
 
         values = []
-
-        for linenr, line in enumerate(self.get_line(fid)):
+        while True:
+            line = fid.readline()
+            if not line:
+                break
             # store comments if they precede the option line
             line = line.split('!',1)
             if len(line) == 2:
@@ -486,7 +479,10 @@ class Touchstone:
                                                 if k != ''][self.rank*-2:],
                                                 dtype='float'))
         fid.seek(0)
-        for line in self.get_line(fid):
+        while True:
+            line = fid.readline()
+            if not line:
+                break
             line = line.replace('\t', ' ')
 
             # HFSS adds gamma and z0 data in .sNp files using comments.

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -468,13 +468,6 @@ class Touchstone:
         Parameter
         -------------
         fid : file object
-        
-        Returns
-        --------
-        gamma : complex numpy.ndarray
-            complex  propagation constant
-        z0 : numpy.ndarray
-            complex port impedance    
         '''
         gamma = []
         z0 = []

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -490,11 +490,6 @@ class Touchstone:
             #  But, depending on the HFSS version, either:
             #  - up to 4 ports only. 
                 #  - up to 4 ports only. 
-            #  - up to 4 ports only. 
-                #  - up to 4 ports only. 
-            #  - up to 4 ports only. 
-                #  - up to 4 ports only. 
-            #  - up to 4 ports only. 
             #        for N > 4, gamma and z0 are given by additional lines
             #  - all gamma and z0 are given on a single line (since 2020R2)
             # In addition, some spurious '!' can remain in these lines

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -530,7 +530,7 @@ class Touchstone:
 
     def get_gamma_z0(self):
         '''
-        Extracts Z0 and Gamma comments from touchstone file (is provided)
+        Extracts Z0 and Gamma comments from touchstone file (if provided)
         
         Returns
         --------

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -143,7 +143,7 @@ class NetworkTestCase(unittest.TestCase):
             sio = io.StringIO(data)
             sio.name = os.path.basename(filename) # hack a bug to touchstone reader
             rf.Network(sio)
-
+            
         filename = os.path.join(self.test_dir, 'hfss_oneport.s1p')
         with open(filename) as fid:
             data = fid.read()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -141,7 +141,14 @@ class NetworkTestCase(unittest.TestCase):
         with open(filename) as fid:
             data = fid.read()
             sio = io.StringIO(data)
-            sio.name = filename # hack a bug to touchstone reader
+            sio.name = os.path.basename(filename) # hack a bug to touchstone reader
+            rf.Network(sio)
+
+        filename = os.path.join(self.test_dir, 'hfss_oneport.s1p')
+        with open(filename) as fid:
+            data = fid.read()
+            sio = io.StringIO(data)
+            sio.name = os.path.basename(filename) # hack a bug to touchstone reader
             rf.Network(sio)
 
     def test_open_saved_touchstone(self):


### PR DESCRIPTION
This patch fixes reading hfss files from stringio.

See #456 

The `get_gamma_z0_fid` method is now called before closing the stringIO handle, the values are stored in the Touchstone class.
The original `get_gamma_z0` returns just the previously parsed values.
