### PR TITLE
Switch nbsmoke to nbval for notebook testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
         pip install flake8 pytest
         sudo apt-get install xvfb
         pip install coverage
-        pip install nbsmoke
+        pip install nbval
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     # code quality check (linting)
@@ -38,14 +38,16 @@ jobs:
     - name: Test with nose
       run: |
         nosetests skrf --nocapture --with-coverage -c nose.cfg
-    - name: Run examples notebooks with nbsmoke
+        
+    - name: Run examples notebooks with nbval
       if: ${{ always() }}
       run: |
-        pytest --nbsmoke-run -k ".ipynb" doc/source/examples
-    - name: Run tutorials notebooks with nbsmoke
+        pytest --nbval-lax --current-env -p no:python --ignore=doc/source/examples/instrumentcontrol/ doc/source/examples/
+        
+    - name: Run tutorials notebooks with nbval
       if: ${{ always() }}
       run: |
-        pytest --nbsmoke-run -k ".ipynb" doc/source/tutorials
+        pytest --nbval-lax --current-env -p no:python doc/source/tutorials/
 
     # Upload coverage data to coveralls.io
     - name: Upload coverage data to coveralls.io


### PR DESCRIPTION
Since I didn't manage to make nbsmoke working without installing scikit-rf from git. By doing so, changes in PR are not seen during the notebooks evaluation.

Some note concerning the options used:
- `--nbval-lax`, which runs notebooks and checks for errors, but only compares the outputs of cells which include a `#NBVAL_CHECK_OUTPUT` marker comment.
- By default, each .ipynb file will be executed using the kernel specified in its metadata, a behaviour overridden by passing either `--current-env` to use a kernel in the same environment in which pytest itself was launched.
- Specify `-p no:python` if you would like to execute notebooks only. 
- ignore instrumentcontrol notebooks