### PR TITLE
Vector Fitting: Fixing RTD build timeout

### DIFF
--- a/doc/source/examples/vectorfitting/vectorfitting_Agilent_E5071B.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_Agilent_E5071B.ipynb
@@ -161,6 +161,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.8"
+  },
+  "nbsphinx": {
+   "timeout": 240
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR hopefully fixes the RTD build timeout of the new vector fitting example notebook, reported in https://github.com/scikit-rf/scikit-rf/pull/469#issuecomment-846389757.

Hesitating to disable the execution timeout entirely, I increased the maximum from 120 s to 240 s (only for this notebook).
