### PR TITLE
WIP: Implement a de-embedding class

### DIFF
--- a/skrf/calibration/__init__.py
+++ b/skrf/calibration/__init__.py
@@ -18,6 +18,8 @@ module.
 #from parametricStandard import *
 from . import calibration
 from . import calibrationSet
+from . import deembedding
 
 from .calibration import *
 from .calibrationSet import *
+from .deembedding import *

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1,0 +1,80 @@
+from ..frequency import *
+from ..network import *
+
+class Deembedding(object):
+    '''
+    Base Class for all de-embedding objects
+    '''
+    def __init__(self, dummy, name=None, *args, **kwargs):
+        '''
+        De-embedding Initializer
+
+        Notes
+        -----
+        Parameters
+        ----------
+        dummies: network objects of dummy structures used for de-embedding 
+        '''
+
+        # fill dummy with copied lists of input
+        self.dummy = [ntwk.copy() for ntwk in dummy]
+
+       # ensure all the dummy Networks' frequency's are the same
+        for dmyntwk in self.dummy:
+            if self.dummy[0].frequency != dmyntwk.frequency:
+                raise(ValueError('Dummy Networks dont have matching frequencies.')) 
+
+        # may attempt to interpolate if frequencies do not match
+
+        self.kwargs = kwargs
+        self.name = name
+
+    def __str__():
+        pass
+
+    def __repr_():
+        pass
+
+    def apply_cal(self,ntwk):
+        '''
+        Apply correction to a Network
+        '''
+        raise NotImplementedError('The Subclass must implement this')
+
+class OpenShort(Deembedding):
+    '''
+    2-step open-short de-embedding [1]_
+
+    [1] M. C. A. M. Koolen, J. A. M. Geelen and M. P. J. G. Versleijen, "An improved 
+    de-embedding technique for on-wafer high frequency characterization", 
+    IEEE 1991 Bipolar Circuits and Technology Meeting, pp. 188-191, Sep. 1991.
+    '''
+    def __init__(self, measured, *args, **kwargs):
+        '''
+        Docstring
+        '''
+        Deembedding.__init__(self, measured, *args, *kwargs)
+
+    def apply_cal(self, ntwk):
+        '''
+        Docstring
+        '''
+       
+        # first measured ntwk is open dummy
+        open = self.dummy[0].copy()
+
+        # second measured ntwk is short dummy
+        short = self.dummy[1].copy()
+        
+        # check if the frequencies match with dummy frequencies
+        if ntwk.frequency != open.frequency:
+            raise(ValueError('Network frequencies dont match dummy frequencies.')) 
+
+        caled = ntwk.copy()
+
+        # remove open parasitics
+        caled.y = ntwk.y - open.y
+        # remove short parasitics
+        caled.z = caled.z - short.z
+
+        return caled

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from ..frequency import *
 from ..network import *
 
@@ -34,7 +35,8 @@ class Deembedding(object):
 
     def __repr_():
         pass
-
+    
+    @abstractmethod
     def apply_cal(self,ntwk):
         '''
         Apply correction to a Network

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1,29 +1,33 @@
 '''
-.. module:: skrf:calibration:deembedding
+.. module:: skrf.calibration.deembedding
 
 ====================================================
 deembedding (:mod:`skrf.calibration.deembedding`)
 ====================================================
 
 This module provides objects to implement de-embedding methods
-for on-wafer applications. Each de-embedding method inherits
-from the common abstract base class :class:`Deembedding`.
+that are often used for on-wafer applications. 
+Each de-embedding method inherits from the common abstract base 
+class :class:`Deembedding`.
 
 Base Class
 ---------------
 
 .. autosummary::
-    :toctree: generated/
+   :toctree: generated/
 
-    Deembedding
+   Deembedding
 
 De-embedding Methods
 -----------------------
 
 .. autosummary::
-    :toctree: generated/
+   :toctree: generated/
 
-    OpenShort
+   OpenShort
+   Open
+   ShortOpen
+   Short
 '''
 
 from abc import ABC, abstractmethod
@@ -89,33 +93,45 @@ class Deembedding(ABC):
     @abstractmethod
     def deembed(self, ntwk):
         '''
-        Apply de-embedding orrection to a Network
+        Apply de-embedding correction to a Network
         '''
         pass
 
 class OpenShort(Deembedding):
     '''
-    A widely used de-embedding method for on-wafer applications.
+    Remove open parasitics followed by short parasitics. 
+    
+    This is a commonly used de-embedding method for on-wafer applications.
 
-    Two dummy measurements `dummy_open` and `dummy_short` are required.
-    When :func:`Deembedding.deembed` is applied, then Y-parameters
-    of the dummy_open are subtracted from the DUT measurement, followed
-    by subtraction of Z-parameters of dummy-short.
+    A deembedding object is created with two dummy measurements: `dummy_open` 
+    and `dummy_short`. When :func:`Deembedding.deembed` is applied, the 
+    Y-parameters of the dummy_open are subtracted from the DUT measurement, 
+    followed by subtraction of Z-parameters of dummy-short.
 
-    This method of de-embedding assumes the following parasitic network
+    This method is applicable only when there is a-priori knowledge of the
+    equivalent circuit model of the parasitic network to be de-embedded,
+    where the series parasitics are closest to device-under-test, 
+    followed by parallel parasitics. For more information, see [1]_
 
-                              _______
-           ------------------|_______|--------------------
-          |                                               |
-          |    _____     __________________      _____    |
-    o--------|_____|----|Device Under Test|----|_____|---------o
-         _|_            -------------------              _|_
-        |   |                  __|__                    |   |
-        |___|                 |_____|                   |___|
-          |                      |                        |
-         GND                    GND                      GND
 
-    For more information, see [1]_
+    Example
+    --------
+    >>> import skrf as rf
+    >>> from skrf.calibration import OpenShort
+
+    Create network objects for dummy structures and dut
+
+    >>> op = rf.Network('open_ckt.s2p')
+    >>> sh = rf.Network('short_ckt.s2p')
+    >>> dut = rf.Network('full_ckt.s2p')
+
+    Create de-embedding object
+
+    >>> dm = OpenShort(dummy_open = op, dummy_short = sh, name = 'test_openshort')
+        
+    Remove parasitics to get the actual device network
+        
+    >>> realdut = dm.deembed(dut)
 
     References
     ------------
@@ -142,25 +158,6 @@ class OpenShort(Deembedding):
 
         args, kwargs:
             Passed to :func:`Deembedding.__init__`
-
-        Examples
-        --------
-        >>> import skrf as rf
-        >>> import skrf.calibration import OpenShort
-
-        Create network objects for dummy structures and dut
-
-        >>> op = rf.Network('open_ckt.s2p')
-        >>> sh = rf.Network('short_ckt.s2p')
-        >>> dut = rf.Network('full_ckt.s2p')
-
-        Create de-embedding object
-
-        >>> dm = OpenShort(dummy_open = op, dummy_short = sh, name = 'test_deembed')
-        
-        Remove parasitics to get the actual device network
-        
-        >>> realdut = dm.deembed(dut)
 
         See Also
         ---------
@@ -196,5 +193,260 @@ class OpenShort(Deembedding):
         caled.y = ntwk.y - self.open.y
         # remove short parasitics
         caled.z = caled.z - self.short.z
+
+        return caled
+
+class Open(Deembedding):
+    '''
+    Remove open parasitics only.
+
+    A deembedding object is created with just one open dummy measurement,
+    `dummy_open`. When :func:`Deembedding.deembed` is applied, the 
+    Y-parameters of the open dummy are subtracted from the DUT measurement, 
+
+    This method is applicable only when there is a-priori knowledge of the
+    equivalent circuit model of the parasitic network to be de-embedded,
+    where the series parasitics are assumed to be negiligible, 
+    but parallel parasitics are unwanted. 
+
+    Example
+    --------
+    >>> import skrf as rf
+    >>> from skrf.calibration import Open
+
+    Create network objects for dummy structure and dut
+
+    >>> op = rf.Network('open_ckt.s2p')
+    >>> dut = rf.Network('full_ckt.s2p')
+
+    Create de-embedding object
+
+    >>> dm = Open(dummy_open = op, name = 'test_open')
+        
+    Remove parasitics to get the actual device network
+        
+    >>> realdut = dm.deembed(dut)
+    '''
+
+    def __init__(self, dummy_open, name=None, *args, **kwargs):
+        '''
+        Open De-embedding Initializer
+
+        Parameters
+        -----------
+
+        dummy_open : :class:`~skrf.network.Network` object
+            Measurement of the dummy open structure
+
+        name : string
+            Optional name of de-embedding object
+
+        args, kwargs:
+            Passed to :func:`Deembedding.__init__`
+
+        See Also
+        ---------
+        :func:`Deembedding.__init__`
+
+        '''
+        self.open = dummy_open.copy()
+        dummies = [self.open]
+
+        Deembedding.__init__(self, dummies, name, *args, **kwargs)
+
+    def deembed(self, ntwk):
+        '''
+        Perform the de-embedding calculation
+
+        Parameters
+        ----------
+        ntwk : :class:`~skrf.network.Network` object
+            Network data of device measurement from which
+            parasitics needs to be removed via de-embedding
+        '''
+        
+        # check if the frequencies match with dummy frequencies
+        if ntwk.frequency != self.open.frequency:
+            raise(ValueError('Network frequencies dont match dummy frequencies.')) 
+        
+        # TODO: attempt to interpolate if frequencies do not match
+
+        caled = ntwk.copy()
+
+        # remove open parasitics
+        caled.y = ntwk.y - self.open.y
+
+        return caled
+    
+class ShortOpen(Deembedding):
+    '''
+    Remove short parasitics followed by open parasitics.
+
+    A deembedding object is created with two dummy measurements: `dummy_open` 
+    and `dummy_short`. When :func:`Deembedding.deembed` is applied, the 
+    Z-parameters of the dummy_short are subtracted from the DUT measurement, 
+    followed by subtraction of Y-parameters of dummy_open.
+
+    This method is applicable only when there is a-priori knowledge of the
+    equivalent circuit model of the parasitic network to be de-embedded,
+    where the parallel parasitics are closest to device-under-test, 
+    followed by series parasitics. 
+
+    Example
+    --------
+    >>> import skrf as rf
+    >>> from skrf.calibration import ShortOpen
+
+    Create network objects for dummy structures and dut
+
+    >>> op = rf.Network('open_ckt.s2p')
+    >>> sh = rf.Network('short_ckt.s2p')
+    >>> dut = rf.Network('full_ckt.s2p')
+
+    Create de-embedding object
+
+    >>> dm = ShortOpen(dummy_short = sh, dummy_open = op, name = 'test_shortopen')
+        
+    Remove parasitics to get the actual device network
+        
+    >>> realdut = dm.deembed(dut)
+
+    '''
+    def __init__(self, dummy_short, dummy_open, name=None, *args, **kwargs):
+        '''
+        Short-Open De-embedding Initializer
+
+        Parameters
+        -----------
+
+        dummy_short : :class:`~skrf.network.Network` object
+            Measurement of the dummy short structure
+
+        dummy_open : :class:`~skrf.network.Network` object
+            Measurement of the dummy open structure
+
+        name : string
+            Optional name of de-embedding object
+
+        args, kwargs:
+            Passed to :func:`Deembedding.__init__`
+
+        See Also
+        ---------
+        :func:`Deembedding.__init__`
+
+        '''
+        self.open = dummy_open.copy()
+        self.short = dummy_short.copy()
+        dummies = [self.open, self.short]
+
+        Deembedding.__init__(self, dummies, name, *args, **kwargs)
+
+    def deembed(self, ntwk):
+        '''
+        Perform the de-embedding calculation
+
+        Parameters
+        ----------
+        ntwk : :class:`~skrf.network.Network` object
+            Network data of device measurement from which
+            parasitics needs to be removed via de-embedding
+        '''
+        
+        # check if the frequencies match with dummy frequencies
+        if ntwk.frequency != self.open.frequency:
+            raise(ValueError('Network frequencies dont match dummy frequencies.')) 
+        
+        # TODO: attempt to interpolate if frequencies do not match
+
+        caled = ntwk.copy()
+
+        # remove short parasitics
+        caled.z = ntwk.z - self.short.z
+        # remove open parasitics
+        caled.y = caled.y - self.open.y
+
+        return caled
+    
+class Short(Deembedding):
+    '''
+    Remove short parasitics only. 
+    
+    This is a useful method to remove pad contact resistances from measurement.
+
+    A deembedding object is created with just one dummy measurement: `dummy_short`.
+    When :func:`Deembedding.deembed` is applied, the 
+    Z-parameters of the dummy_short are subtracted from the DUT measurement, 
+
+    This method is applicable only when there is a-priori knowledge of the
+    equivalent circuit model of the parasitic network to be de-embedded,
+    where only series parasitics are to be removed while retaining all others. 
+
+    Example
+    --------
+    >>> import skrf as rf
+    >>> from skrf.calibration import Short
+
+    Create network objects for dummy structures and dut
+
+    >>> sh = rf.Network('short_ckt.s2p')
+    >>> dut = rf.Network('full_ckt.s2p')
+
+    Create de-embedding object
+
+    >>> dm = Short(dummy_short = sh, name = 'test_short')
+        
+    Remove parasitics to get the actual device network
+        
+    >>> realdut = dm.deembed(dut)
+
+    '''
+    def __init__(self, dummy_short, name=None, *args, **kwargs):
+        '''
+        Short De-embedding Initializer
+
+        Parameters
+        -----------
+
+        dummy_short : :class:`~skrf.network.Network` object
+            Measurement of the dummy short structure
+
+        name : string
+            Optional name of de-embedding object
+
+        args, kwargs:
+            Passed to :func:`Deembedding.__init__`
+
+        See Also
+        ---------
+        :func:`Deembedding.__init__`
+
+        '''
+        self.short = dummy_short.copy()
+        dummies = [self.short]
+
+        Deembedding.__init__(self, dummies, name, *args, **kwargs)
+
+    def deembed(self, ntwk):
+        '''
+        Perform the de-embedding calculation
+
+        Parameters
+        ----------
+        ntwk : :class:`~skrf.network.Network` object
+            Network data of device measurement from which
+            parasitics needs to be removed via de-embedding
+        '''
+        
+        # check if the frequencies match with dummy frequencies
+        if ntwk.frequency != self.open.frequency:
+            raise(ValueError('Network frequencies dont match dummy frequencies.')) 
+        
+        # TODO: attempt to interpolate if frequencies do not match
+
+        caled = ntwk.copy()
+
+        # remove short parasitics
+        caled.z = ntwk.z - self.short.z
 
         return caled

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -143,6 +143,25 @@ class OpenShort(Deembedding):
         args, kwargs:
             Passed to :func:`Deembedding.__init__`
 
+        Examples
+        --------
+        >>> import skrf as rf
+        >>> import skrf.calibration import OpenShort
+
+        Create network objects for dummy structures and dut
+
+        >>> op = rf.Network('open_ckt.s2p')
+        >>> sh = rf.Network('short_ckt.s2p')
+        >>> dut = rf.Network('full_ckt.s2p')
+
+        Create de-embedding object
+
+        >>> dm = OpenShort(dummy_open = op, dummy_short = sh, name = 'test_deembed')
+        
+        Remove parasitics to get the actual device network
+        
+        >>> realdut = dm.deembed(dut)
+
         See Also
         ---------
         :func:`Deembedding.__init__`


### PR DESCRIPTION
Hey,

I've got some preliminary code to implement a de-embedding class which was suggested in #196. I figured it was easiest to start a deembedding.py file in skrf/calibration and put in a base deembedding class, based on which other deembedding methods can be implemented. I have started with OpenShort deembedding, since that is commonly used in on-wafer measurements.

Here are some questions to get discussions started:

1. Is this a good place to develop this capability?
2. How should we go about naming the different deembedding methods to easily help the user identify it?
3. What are some of the deembedding methods that should be implemented that are most useful?

Feedback is welcome!