### PR TITLE
Add analyzer_keysight_n9918a.py for usage in data_grabber.py

### DIFF
--- a/qtapps/skrf_qtwidgets/analyzers/analyzer_keysight_n9918a.py
+++ b/qtapps/skrf_qtwidgets/analyzers/analyzer_keysight_n9918a.py
@@ -1,0 +1,9 @@
+from skrf.vi.vna import keysight_fieldfox
+
+
+class Analyzer(keysight_fieldfox.FieldFox):
+    DEFAULT_VISA_ADDRESS = "TCPIP0::192.168.1.50::5025::SOCKET"
+    NAME = "Keysight N9918A"
+    NPORTS = 2
+    NCHANNELS = 1
+    SCPI_VERSION_TESTED = 'A.02.06.00'


### PR DESCRIPTION
I added a file so that a Keysight FieldFox could be used in conjunction with data_grabber.py. However, I have not yet been able to test it since my development environment (Ubuntu 18.04) is not directly compatible with NI VISA.

I wonder if there's any incentive to move away from using NI VISA to communicate with these devices. I have been able to communicate with these Keysight devices without needing the VISA binaries setup on my computer. So perhaps we could make a fallback case for when a user doesn't have the proper VISA libraries installed?

I know it's possible, according to https://lightlab.readthedocs.io/en/master/_static/installation/sysadmin.html#ubuntu-installation, but do we expect users to go through this?