### PR TITLE
Fix/299

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3201,7 +3201,7 @@ class Network(object):
             w = self.windowed(window=window, normalize=False, center_to_dc=center_to_dc)
         else:
             w = self
-        return t, mf.irfft(w.s, n=n).flatten()
+        return t, mf.irfft(w.s, n=n).ravel()
 
     def step_response(self, window: str = 'hamming', n: int = None, pad: int = 1000) -> Tuple[npy.ndarray, npy.ndarray]:
         """Calculates time-domain step response of one-port.

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3190,10 +3190,9 @@ class Network(object):
 
         fstep = self.frequency.step
         if n % 2 == 0:
-            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n, endpoint=False))
+            t = npy.fft.ifftshift(npy.fft.fftfreq(n, fstep))
         else:
-            t = npy.flipud(npy.linspace(.5 / fstep, -.5 / fstep, n + 1, endpoint=False))
-            t = t[:-1]
+            t = npy.fft.ifftshift(npy.fft.fftfreq(n+1, fstep))[1:]
         if bandpass in (True, False):
             center_to_dc = not bandpass
         else:

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -92,6 +92,24 @@ class NetworkTestCase(unittest.TestCase):
             self.assertEqual(len(y), num_points)
             self.assertTrue(npy.isclose(t[1] - t[0], tps))
 
+    def test_impulse_response_dirac(self):
+        """
+        Test if the impulse response of a perfect transmission line is pure Dirac
+        """
+        f_points = 10
+        freq = rf.Frequency.from_f(npy.arange(f_points), unit='Hz')
+        s = npy.ones(10)
+        netw = rf.Network(frequency=freq, s=s)
+
+        n_lst = npy.arange(-1,2) + 2 * (f_points) - 2
+        for n in n_lst:
+            t,y = netw.impulse_response('boxcar', n=n)
+
+            y_true = npy.zeros_like(y)
+            y_true[t == 0] = 1
+            npy.testing.assert_almost_equal(y, y_true)
+
+
     def test_time_transform_nonlinear_f(self):
         netw_nonlinear_f = rf.Network(os.path.join(self.test_dir, 'ntwk_arbitrary_frequency.s2p'))
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This PR addresses #299 to avoid a time lag in impulse/step response calculation,