### PR TITLE
Fixes ModuleNotFound error in docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,6 +8,7 @@ build:
 
 python:
   version: 3.7
+  pip_install: true
   install:
     - requirements: requirements.txt
     - requirements: requirements_dev.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,8 +8,9 @@ build:
 
 python:
   version: 3.7
-  pip_install: true
   install:
     - requirements: requirements.txt
     - requirements: requirements_dev.txt
+    - method: pip
+      path: ./skrf
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -12,5 +12,5 @@ python:
     - requirements: requirements.txt
     - requirements: requirements_dev.txt
     - method: pip
-      path: ./skrf
+      path: .
 


### PR DESCRIPTION
skrf install in RTD environment was broken in #494. This edits the rtd yml file to reintroduce the installation of skrf and fix that oversight.