### PR TITLE
Vector Fitting: Docstring improvements, type hints and bugfix

### DIFF
--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -8,11 +8,12 @@ Vector Fitting (:mod:`skrf.vectorFitting`)
 
 """
 
+from __future__ import annotations  # according to PEP 563 (will become default in Python 3.11)
+
 import numpy as np
 import os
 
 # imports for type hinting
-from __future__ import annotations  # according to PEP 563 (will become default in Python 3.11)
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .network import Network

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -120,7 +120,7 @@ class VectorFitting:
         self.history_max_sigma = []
 
     def vector_fit(self, n_poles_real: int = 2, n_poles_cmplx: int = 2, init_pole_spacing: str = 'lin',
-                   parameter_type: str = 'S', fit_constant: bool = True, fit_proportional: bool = False) -> None:
+                   parameter_type: str = 's', fit_constant: bool = True, fit_proportional: bool = False) -> None:
         """
         Main work routine performing the vector fit. The results will be stored in the class variables
         :attr:`poles`, :attr:`zeros`, :attr:`proportional_coeff` and :attr:`constant_coeff`.
@@ -654,7 +654,7 @@ class VectorFitting:
         stsp_S += D + 2j * np.pi * freq * E
         return stsp_S
 
-    def passivity_test(self, parameter_type: str = 'S') -> np.ndarray:
+    def passivity_test(self, parameter_type: str = 's') -> np.ndarray:
         """
         Evaluates the passivity of reciprocal vector fitted models by means of a half-size test matrix [#]_. Any
         existing frequency bands of passivity violations will be returned as a sorted list.
@@ -760,7 +760,7 @@ class VectorFitting:
 
         return np.array(violation_bands)
 
-    def is_passive(self, parameter_type: str = 'S') -> bool:
+    def is_passive(self, parameter_type: str = 's') -> bool:
         """
         Returns the passivity status of the model as a boolean value.
 
@@ -788,7 +788,7 @@ class VectorFitting:
         else:
             return False
 
-    def passivity_enforce(self, n_samples: int = 100, parameter_type: str = 'S') -> None:
+    def passivity_enforce(self, n_samples: int = 100, parameter_type: str = 's') -> None:
         """
         Enforces the passivity of the vector fitted model, if required. This is an implementation of the method
         presented in [#]_.

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1,12 +1,10 @@
 """
-=========================================
-VectorFitting (:mod:`skrf.vectorFitting`)
-=========================================
+Vector Fitting (:mod:`skrf.vectorFitting`)
+==========================================
 
 .. autoclass:: VectorFitting
     :members:
     :member-order: groupwise
-    :special-members: __init__
 
 """
 
@@ -45,32 +43,46 @@ def check_plotting(func):
 
 class VectorFitting:
     """
-    =========================================================
-    VectorFitting (:class:`skrf.vectorFitting.VectorFitting`)
-    =========================================================
-
     This class provides a Python implementation of the Vector Fitting algorithm and various functions for the fit
     analysis, passivity evaluation and enforcement, and export of SPICE equivalent circuits.
 
+    Parameters
+    ----------
+    network : :class:`skrf.network.Network`
+            Network instance of the :math:`N`-port holding the frequency responses to be fitted, for example a
+            scattering, impedance or admittance matrix.
+
+    Examples
+    --------
+    Load the `Network`, create a `VectorFitting` instance, perform the fit with a given number of real and
+    complex-conjugate starting poles:
+
+    >>> nw_3port = skrf.Network('my3port.s3p')
+    >>> vf = skrf.VectorFitting(nw_3port)
+    >>> vf.vector_fit(n_poles_real=1, n_poles_cmplx=4)
+
     Notes
     -----
-    The fitting code is based on the original algorithm [1]_ and on two improvements for relaxed pole relocation [2]_
-    and efficient (fast) solving [3]_. See also the Vector Fitting website [4]_ for further information and download of
-    the papers listed below. A Matlab implementation is also available there for reference.
+    The fitting code is based on the original algorithm [#Gustavsen_vectfit]_ and on two improvements for relaxed pole
+    relocation [#Gustavsen_relaxed]_ and efficient (fast) solving [#Deschrijver_fast]_. See also the Vector Fitting
+    website [#vectfit_website]_ for further information and download of the papers listed below. A Matlab implementation
+    is also available there for reference.
 
     References
     ----------
-    .. [1] B. Gustavsen, A. Semlyen, "Rational Approximation of Frequency Domain Responses by Vector Fitting", IEEE
-        Transactions on Power Delivery, vol. 14, no. 3, pp. 1052-1061, July 1999, DOI: https://doi.org/10.1109/61.772353
+    .. [#Gustavsen_vectfit] B. Gustavsen, A. Semlyen, "Rational Approximation of Frequency Domain Responses by Vector
+        Fitting", IEEE Transactions on Power Delivery, vol. 14, no. 3, pp. 1052-1061, July 1999,
+        DOI: https://doi.org/10.1109/61.772353
 
-    .. [2] B. Gustavsen, "Improving the Pole Relocating Properties of Vector Fitting", IEEE Transactions on Power
-        Delivery, vol. 21, no. 3, pp. 1587-1592, July 2006, DOI: https://doi.org/10.1109/TPWRD.2005.860281
+    .. [#Gustavsen_relaxed] B. Gustavsen, "Improving the Pole Relocating Properties of Vector Fitting", IEEE
+        Transactions on Power Delivery, vol. 21, no. 3, pp. 1587-1592, July 2006,
+        DOI: https://doi.org/10.1109/TPWRD.2005.860281
 
-    .. [3] D. Deschrijver, M. Mrozowski, T. Dhaene, D. De Zutter, "Marcomodeling of Multiport Systems Using a Fast
-        Implementation of the Vector Fitting Method", IEEE Microwave and Wireless Components Letters, vol. 18, no. 6,
-        pp. 383-385, June 2008, DOI: https://doi.org/10.1109/LMWC.2008.922585
+    .. [#Deschrijver_fast] D. Deschrijver, M. Mrozowski, T. Dhaene, D. De Zutter, "Marcomodeling of Multiport Systems
+        Using a Fast Implementation of the Vector Fitting Method", IEEE Microwave and Wireless Components Letters,
+        vol. 18, no. 6, pp. 383-385, June 2008, DOI: https://doi.org/10.1109/LMWC.2008.922585
 
-    .. [4] Vector Fitting website: https://www.sintef.no/projectweb/vectorfitting/
+    .. [#vectfit_website] Vector Fitting website: https://www.sintef.no/projectweb/vectorfitting/
     """
 
     def __init__(self, network):
@@ -146,6 +158,7 @@ class VectorFitting:
         Returns
         -------
         None
+            No return value.
 
         Notes
         -----
@@ -500,7 +513,7 @@ class VectorFitting:
         """
         Private method.
         Returns the real-valued system matrices of the state-space representation of the current rational model, as
-        defined in [8]_.
+        defined in [#]_.
 
         Returns
         -------
@@ -518,7 +531,7 @@ class VectorFitting:
 
         References
         ----------
-        .. [8] B. Gustavsen and A. Semlyen, "Fast Passivity Assessment for S-Parameter Rational Models Via a Half-Size
+        .. [#] B. Gustavsen and A. Semlyen, "Fast Passivity Assessment for S-Parameter Rational Models Via a Half-Size
             Test Matrix," in IEEE Transactions on Microwave Theory and Techniques, vol. 56, no. 12, pp. 2701-2708,
             Dec. 2008, DOI: 10.1109/TMTT.2008.2007319.
         """
@@ -646,7 +659,7 @@ class VectorFitting:
 
     def passivity_test(self, parameter_type='S'):
         """
-        Evaluates the passivity of reciprocal vector fitted models by means of a half-size test matrix [6]_. Any
+        Evaluates the passivity of reciprocal vector fitted models by means of a half-size test matrix [#]_. Any
         existing frequency bands of passivity violations will be returned as a sorted list.
 
         Parameters
@@ -658,17 +671,18 @@ class VectorFitting:
 
         Returns
         -------
-        ndarray
+        violation_bands : ndarray
             NumPy array with frequency bands of passivity violation:
-            [[f_start_1, f_stop_1], [f_start_2, f_stop_2], ...].
+            `[[f_start_1, f_stop_1], [f_start_2, f_stop_2], ...]`.
 
         See Also
         --------
         is_passive : Query the model passivity as a boolean value.
+        passivity_enforce : Enforces the passivity of the vector fitted model, if required.
 
         References
         ----------
-        .. [6] B. Gustavsen and A. Semlyen, "Fast Passivity Assessment for S-Parameter Rational Models Via a Half-Size
+        .. [#] B. Gustavsen and A. Semlyen, "Fast Passivity Assessment for S-Parameter Rational Models Via a Half-Size
             Test Matrix," in IEEE Transactions on Microwave Theory and Techniques, vol. 56, no. 12, pp. 2701-2708,
             Dec. 2008, DOI: 10.1109/TMTT.2008.2007319.
         """
@@ -755,9 +769,15 @@ class VectorFitting:
 
         Returns
         -------
-        bool
+        passivity : bool
             :attr:`True` if model is passive, else :attr:`False`.
+
+        See Also
+        --------
+        passivity_test : Verbose passivity evaluation routine.
+        passivity_enforce : Enforces the passivity of the vector fitted model, if required.
         """
+
         viol_bands = self.passivity_test(parameter_type)
         if len(viol_bands) == 0:
             return True
@@ -767,7 +787,7 @@ class VectorFitting:
     def passivity_enforce(self, n_samples=100, parameter_type='S'):
         """
         Enforces the passivity of the vector fitted model, if required. This is an implementation of the method
-        presented in [7]_.
+        presented in [#]_.
 
         Parameters
         ----------
@@ -785,12 +805,13 @@ class VectorFitting:
 
         See Also
         --------
-        passivity_test : More verbose passivity evaluation routine.
+        is_passive : Returns the passivity status of the model as a boolean value.
+        passivity_test : Verbose passivity evaluation routine.
         plot_passivation : Convergence plot for passivity enforcement iterations.
 
         References
         ----------
-        .. [7] T. Dhaene, D. Deschrijver and N. Stevens, "Efficient Algorithm for Passivity Enforcement of S-Parameter-
+        .. [#] T. Dhaene, D. Deschrijver and N. Stevens, "Efficient Algorithm for Passivity Enforcement of S-Parameter-
             Based Macromodels," in IEEE Transactions on Microwave Theory and Techniques, vol. 57, no. 2, pp. 415-420,
             Feb. 2009, DOI: 10.1109/TMTT.2008.2011201.
         """
@@ -992,15 +1013,15 @@ class VectorFitting:
 
     def get_model_response(self, i, j, freqs=None):
         """
-        Returns the frequency response of the fitted model.
+        Returns one of the frequency responses :math:`H_{i+1,j+1}` of the fitted model :math:`H`.
 
         Parameters
         ----------
         i : int
-            Row index of the response.
+            Row index of the response in the response matrix.
 
         j : int
-            Column index of the response.
+            Column index of the response in the response matrix.
 
         freqs : list of float or ndarray or None, optional
             List of frequencies for the response plot. If None, the sample frequencies of the fitted network in
@@ -1008,8 +1029,8 @@ class VectorFitting:
 
         Returns
         -------
-        ndarray
-            Model response at the frequencies specified in freqs (complex-valued ndarray).
+        response : ndarray
+            Model response :math:`H_{i+1,j+1}` at the frequencies specified in `freqs` (complex-valued Numpy array).
         """
 
         if self.poles is None:
@@ -1045,7 +1066,7 @@ class VectorFitting:
     @check_plotting
     def plot_s_db(self, i, j, freqs=None, ax=None):
         """
-        Plots the magnitude in dB of the response **S_(i+1,j+1)** in the fit.
+        Plots the magnitude in dB of the scattering parameter response :math:`S_{i+1,j+1}` in the fit.
 
         Parameters
         ----------
@@ -1060,7 +1081,7 @@ class VectorFitting:
             :attr:`network` are used.
 
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1086,7 +1107,7 @@ class VectorFitting:
     @check_plotting
     def plot_s_mag(self, i, j, freqs=None, ax=None):
         """
-        Plots the magnitude in linear scale of the response **S_(i+1,j+1)** in the fit.
+        Plots the magnitude in linear scale of the scattering parameter response :math:`S_{i+1,j+1}` in the fit.
 
         Parameters
         ----------
@@ -1101,7 +1122,7 @@ class VectorFitting:
             :attr:`network` are used.
 
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1136,7 +1157,7 @@ class VectorFitting:
             :attr:`network` are used.
 
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1173,7 +1194,7 @@ class VectorFitting:
     @check_plotting
     def plot_pz(self, i, j, ax=None):
         """
-        Plots a pole-zero diagram of the fit of the response **S_(i+1,j+1)**.
+        Plots a pole-zero diagram of the fit of the model response :math:`H_{i+1,j+1}`.
 
         Parameters
         ----------
@@ -1184,7 +1205,7 @@ class VectorFitting:
             Column index of the response.
 
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1220,7 +1241,7 @@ class VectorFitting:
         Parameters
         ----------
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1250,7 +1271,7 @@ class VectorFitting:
         Parameters
         ----------
         ax : :class:`matplotlib.axes.AxesSubplot` object or None
-            matplotlib axes to draw on. If None, the current axes is fetched with gca().
+            matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
@@ -1284,11 +1305,11 @@ class VectorFitting:
         -----
         In the SPICE subcircuit, all ports will share a common reference node (global SPICE ground on node 0). The
         equivalent circuit uses linear dependent current sources on all ports, which are controlled by the currents
-        through equivalent admittances modelling the parameters from a vector fit. This approach is based on [5]_.
+        through equivalent admittances modelling the parameters from a vector fit. This approach is based on [#]_.
 
         References
         ----------
-        .. [5] G. Antonini, "SPICE Equivalent Circuits of Frequency-Domain Responses", IEEE Transactions on
+        .. [#] G. Antonini, "SPICE Equivalent Circuits of Frequency-Domain Responses", IEEE Transactions on
             Electromagnetic Compatibility, vol. 45, no. 3, pp. 502-512, August 2003,
             DOI: https://doi.org/10.1109/TEMC.2003.815528
         """

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -10,7 +10,7 @@ Vector Fitting (:mod:`skrf.vectorFitting`)
 
 import numpy as np
 import os
-from network import Network
+from .network import Network
 from typing import Any
 from functools import wraps
 try:
@@ -1326,7 +1326,7 @@ class VectorFitting:
             return subcircuits[-1]
 
         # use engineering notation for the numbers in the SPICE file (1000 --> 1k)
-        formatter = EngFormatter(sep="", places=3)
+        formatter = EngFormatter(sep="", places=3, usetex=False)
         # replace "micron" sign by "u" and "mega" sign by "meg"
         letters_dict = formatter.ENG_PREFIXES
         letters_dict.update({-6: 'u', 6: 'meg'})
@@ -1373,9 +1373,9 @@ class VectorFitting:
                     # control current is measured by the dummy voltage source at the transfer network Y_nj
                     # the scattered current is injected into the port (source positive connected to ground)
                     f.write('F{}{} 0 a{} V{}{} {}\n'.format(n + 1, j + 1, n + 1, n + 1, j + 1,
-                                                            1 / np.real(self.network.z0[0, n])))
+                                                            formatter(1 / np.real(self.network.z0[0, n]))))
                     f.write('F{}{}_inv a{} 0 V{}{}_inv {}\n'.format(n + 1, j + 1, n + 1, n + 1, j + 1,
-                                                                    1 / np.real(self.network.z0[0, n])))
+                                                                    formatter(1 / np.real(self.network.z0[0, n]))))
 
                     # add dummy voltage source (V=0) in series with Y_nj to measure current through transfer admittance
                     f.write('V{}{} nt{} nt{}{} 0\n'.format(n + 1, j + 1, j + 1, n + 1, j + 1))

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -10,6 +10,8 @@ Vector Fitting (:mod:`skrf.vectorFitting`)
 
 import numpy as np
 import os
+from network import Network
+from typing import Any
 from functools import wraps
 try:
     from . import plotting    # will perform the correct setup for matplotlib before it is called below
@@ -85,7 +87,7 @@ class VectorFitting:
     .. [#vectfit_website] Vector Fitting website: https://www.sintef.no/projectweb/vectorfitting/
     """
 
-    def __init__(self, network):
+    def __init__(self, network: Network):
         """
         Creates a VectorFitting instance based on a supplied :class:`skrf.network.Network` containing the frequency
         responses of the N-port.
@@ -124,8 +126,8 @@ class VectorFitting:
         self.delta_max_history = []
         self.history_max_sigma = []
 
-    def vector_fit(self, n_poles_real=2, n_poles_cmplx=2, init_pole_spacing='lin', parameter_type='S',
-                   fit_constant=True, fit_proportional=False):
+    def vector_fit(self, n_poles_real: int = 2, n_poles_cmplx: int = 2, init_pole_spacing: str = 'lin',
+                   parameter_type: str = 'S', fit_constant: bool = True, fit_proportional: bool = False) -> None:
         """
         Main work routine performing the vector fit. The results will be stored in the class variables
         :attr:`poles`, :attr:`zeros`, :attr:`proportional_coeff` and :attr:`constant_coeff`.
@@ -509,7 +511,7 @@ class VectorFitting:
 
         logging.info('\n### Vector fitting finished.\n')
 
-    def _get_ABCDE(self):
+    def _get_ABCDE(self) -> np.ndarray:
         """
         Private method.
         Returns the real-valued system matrices of the state-space representation of the current rational model, as
@@ -629,7 +631,8 @@ class VectorFitting:
         return A, B, C, D, E
 
     @staticmethod
-    def _get_s_from_ABCDE(freq, A, B, C, D, E):
+    def _get_s_from_ABCDE(freq: float,
+                          A: np.ndarray, B: np.ndarray, C: np.ndarray, D: np.ndarray, E: np.ndarray) -> np.ndarray:
         """
         Private method.
         Returns the S-matrix of the vector fitted model calculated from the real-valued system matrices of the state-
@@ -657,7 +660,7 @@ class VectorFitting:
         stsp_S += D + 2j * np.pi * freq * E
         return stsp_S
 
-    def passivity_test(self, parameter_type='S'):
+    def passivity_test(self, parameter_type: str = 'S') -> np.ndarray:
         """
         Evaluates the passivity of reciprocal vector fitted models by means of a half-size test matrix [#]_. Any
         existing frequency bands of passivity violations will be returned as a sorted list.
@@ -756,7 +759,7 @@ class VectorFitting:
 
         return np.array(violation_bands)
 
-    def is_passive(self, parameter_type='S'):
+    def is_passive(self, parameter_type: str = 'S') -> bool:
         """
         Returns the passivity status of the model as a boolean value.
 
@@ -784,7 +787,7 @@ class VectorFitting:
         else:
             return False
 
-    def passivity_enforce(self, n_samples=100, parameter_type='S'):
+    def passivity_enforce(self, n_samples: int = 100, parameter_type: str = 'S') -> None:
         """
         Enforces the passivity of the vector fitted model, if required. This is an implementation of the method
         presented in [#]_.
@@ -930,7 +933,7 @@ class VectorFitting:
                         k += 2
                     z += 1
 
-    def write_npz(self, path):
+    def write_npz(self, path: str) -> None:
         """
         Writes the model parameters in :attr:`poles`, :attr:`zeros`,
         :attr:`proportional_coeff` and :attr:`constant_coeff` to a labeled NumPy .npz file.
@@ -970,7 +973,7 @@ class VectorFitting:
                             poles=self.poles, zeros=self.zeros, proportionals=self.proportional_coeff,
                             constants=self.constant_coeff)
 
-    def read_npz(self, file):
+    def read_npz(self, file: str) -> None:
         """
         Reads all model parameters :attr:`poles`, :attr:`zeros`, :attr:`proportional_coeff` and :attr:`constant_coeff`
         from a labeled NumPy .npz file.
@@ -1011,7 +1014,7 @@ class VectorFitting:
             else:
                 logging.error('Length of the provided parameters does not match the network size.')
 
-    def get_model_response(self, i, j, freqs=None):
+    def get_model_response(self, i: int, j: int, freqs: Any = None) -> np.ndarray:
         """
         Returns one of the frequency responses :math:`H_{i+1,j+1}` of the fitted model :math:`H`.
 
@@ -1064,7 +1067,7 @@ class VectorFitting:
         return resp
 
     @check_plotting
-    def plot_s_db(self, i, j, freqs=None, ax=None):
+    def plot_s_db(self, i: int, j: int, freqs: Any = None, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the magnitude in dB of the scattering parameter response :math:`S_{i+1,j+1}` in the fit.
 
@@ -1080,12 +1083,12 @@ class VectorFitting:
             List of frequencies for the response plot. If None, the sample frequencies of the fitted network in
             :attr:`network` are used.
 
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1105,7 +1108,7 @@ class VectorFitting:
         return ax
 
     @check_plotting
-    def plot_s_mag(self, i, j, freqs=None, ax=None):
+    def plot_s_mag(self, i: int, j: int, freqs: Any = None, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the magnitude in linear scale of the scattering parameter response :math:`S_{i+1,j+1}` in the fit.
 
@@ -1121,12 +1124,12 @@ class VectorFitting:
             List of frequencies for the response plot. If None, the sample frequencies of the fitted network in
             :attr:`network` are used.
 
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1146,7 +1149,7 @@ class VectorFitting:
         return ax
 
     @check_plotting
-    def plot_s_singular(self, freqs=None, ax=None):
+    def plot_s_singular(self, freqs: Any = None, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the singular values of the vector fitted S-matrix in linear scale.
 
@@ -1156,12 +1159,12 @@ class VectorFitting:
             List of frequencies for the response plot. If None, the sample frequencies of the fitted network in
             :attr:`network` are used.
 
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1192,7 +1195,7 @@ class VectorFitting:
         return ax
 
     @check_plotting
-    def plot_pz(self, i, j, ax=None):
+    def plot_pz(self, i: int, j: int, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots a pole-zero diagram of the fit of the model response :math:`H_{i+1,j+1}`.
 
@@ -1204,12 +1207,12 @@ class VectorFitting:
         j : int
             Column index of the response.
 
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1232,7 +1235,7 @@ class VectorFitting:
         return ax
 
     @check_plotting
-    def plot_convergence(self, ax=None):
+    def plot_convergence(self, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the history of the model residue parameter **d_res** during the iterative pole relocation process of the
         vector fitting, which should eventually converge to a fixed value. Additionally, the relative change of the
@@ -1240,12 +1243,12 @@ class VectorFitting:
 
         Parameters
         ----------
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1262,7 +1265,7 @@ class VectorFitting:
         return ax
 
     @check_plotting
-    def plot_passivation(self, ax=None):
+    def plot_passivation(self, ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the history of the greatest singular value during the iterative passivity enforcement process, which
         should eventually converge to a value slightly lower than 1.0 or stop after exceeding the maximum number of
@@ -1270,12 +1273,12 @@ class VectorFitting:
 
         Parameters
         ----------
-        ax : :class:`matplotlib.axes.AxesSubplot` object or None
+        ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
 
         Returns
         -------
-        :class:`matplotlib.axes.AxesSubplot`
+        :class:`matplotlib.Axes`
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
@@ -1288,7 +1291,7 @@ class VectorFitting:
         ax.set_ylabel('Max. singular value')
         return ax
 
-    def write_spice_subcircuit_s(self, file):
+    def write_spice_subcircuit_s(self, file: str) -> None:
         """
         Creates an equivalent N-port SPICE subcircuit based on its vector fitted S parameter responses.
 

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -10,8 +10,13 @@ Vector Fitting (:mod:`skrf.vectorFitting`)
 
 import numpy as np
 import os
-from .network import Network
-from typing import Any
+
+# imports for type hinting
+from __future__ import annotations  # according to PEP 563 (will become default in Python 3.11)
+from typing import Any, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .network import Network
+
 from functools import wraps
 try:
     from . import plotting    # will perform the correct setup for matplotlib before it is called below

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -178,7 +178,7 @@ class VectorFitting:
         # create initial poles and space them across the frequencies in the provided Touchstone file
         # use normalized frequencies during the iterations (seems to be more stable during least-squares fit)
         norm = np.average(self.network.f)
-        freqs_norm = self.network.f / norm
+        freqs_norm = np.array(self.network.f) / norm
 
         fmin = np.amin(freqs_norm)
         fmax = np.amax(freqs_norm)

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -91,16 +91,6 @@ class VectorFitting:
     """
 
     def __init__(self, network: 'Network'):
-        """
-        Creates a VectorFitting instance based on a supplied :class:`skrf.network.Network` containing the frequency
-        responses of the N-port.
-
-        Parameters
-        ----------
-        network : :class:`skrf.network.Network`
-            Network instance of the N-port holding the S-matrix to be fitted.
-        """
-
         self.network = network
         self.initial_poles = None
 


### PR DESCRIPTION
In the spirit of PR #504 and issue #449 this PR improves the docstrings for the `VectorFitting` class and adds type hints for its methods.
A tiny bug in the number formatting in `write_spice_subcircuit_s()` is also fixed.