### PR TITLE
Docstring fixes after PR #504

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,7 +7,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: "3.8"
   install:
     - requirements: requirements.txt
     - requirements: requirements_dev.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ flake8
 pytest
 pytest-cov
 nbval
+sphinx>=4.0

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -14,7 +14,7 @@ The results are returned in :class:`~skrf.circuit.Circuit` object.
 
 
 Building a Circuit
-==================
+------------------
 .. autosummary::
    :toctree: generated/
 
@@ -23,14 +23,14 @@ Building a Circuit
    Circuit.Ground
 
 Representing a Circuit
-=======================
+----------------------
 .. autosummary::
    :toctree: generated/
 
    Circuit.plot_graph
 
 Network Representations
-========================
+-----------------------
 .. autosummary::
    :toctree: generated/
 
@@ -44,7 +44,7 @@ Network Representations
    Circuit.port_z0
 
 Voltages and Currents
-=====================
+---------------------
 .. autosummary::
    :toctree: generated/
 
@@ -54,7 +54,7 @@ Voltages and Currents
    Circuit.currents_external
 
 Circuit internals
-==================
+------------------
 .. autosummary::
    :toctree: generated/
 
@@ -70,7 +70,7 @@ Circuit internals
    Circuit.X
 
 Graph representation
-========================
+--------------------
 .. autosummary::
    :toctree: generated/
 

--- a/skrf/mathFunctions.py
+++ b/skrf/mathFunctions.py
@@ -1,7 +1,4 @@
 """
-.. currentmodule:: skrf.mathFunctions
-
-=============================================
 mathFunctions (:mod:`skrf.mathFunctions`)
 =============================================
 
@@ -10,12 +7,7 @@ Provides commonly used mathematical functions.
 
 Mathematical Constants
 ----------------------
-.. autosummary::
-    :toctree: generated/
-
-    INF
-    ALMOST_ZERO
-    LOG_OF_NEG
+Some convenient constants are defined in the :mod:`skrf.constants` module.
 
 Complex Component Conversion
 ---------------------------------


### PR DESCRIPTION
Some missed things during PR #504 :
- fixing the level of the sections in circuit.py
- removing the description of the constants in `mathFunction` and linking to `skrf.constants` where they are documented.