### PR TITLE
LRRM calibration

### DIFF
--- a/doc/source/examples/metrology/LRRM.ipynb
+++ b/doc/source/examples/metrology/LRRM.ipynb
@@ -1,0 +1,555 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LRRM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example demonstrates how to use `skrf`'s LRRM calibration. LRRM stands for Line-Reflect-Reflect-Match which are the calibration standards needed for the calibration. There are few different implementations of the LRRM that use slightly different assumptions and match model. `skrf`'s LRRM calibration uses the following assumptions:\n",
+    "\n",
+    " * Line standard needs to be known exactly.\n",
+    " * First reflect's phase needs to be known within 90 degrees. It can be lossy and it's assumed to be identical on both ports.\n",
+    " * Second reflect's |S11| is assumed to be known, it's phase also needs to be known within 90 degrees and it's assumed to be identical on both ports. The two reflects need to be different and their phase difference should be 180 degrees for the best accuracy.\n",
+    " * Match is assumed to be a known resistance in series with unknown inductance. Match only needs to be measured on the first port.\n",
+    " \n",
+    "The calibration standards and measurements need to be given in the above order to the calibration routine. If the above assumptions are followed the calibration can solve the reflects, match and calibration parameters exactly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  LRRM example with synthetic data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import skrf\n",
+    "from skrf.media import Coaxial\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "skrf.stylely()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Generate example data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first generate some synthetic error boxes and calibration standards. We will have two sets of the calibration standards. The real standards used for calibration that have parasitics and the approximate standards without parasitics that we will give to the calibration algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freq = skrf.F(1,100,100)\n",
+    "\n",
+    "# 1.0 mm coaxial media for calibration error boxes\n",
+    "coax = Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e8)\n",
+    "\n",
+    "# Generate random error boxes\n",
+    "X = coax.random(n_ports=2, name='X')\n",
+    "Y = coax.random(n_ports=2, name='Y')\n",
+    "\n",
+    "# Random switch terms\n",
+    "gamma_f = coax.random(n_ports=1, name='gamma_f')\n",
+    "gamma_r = coax.random(n_ports=1, name='gamma_r')\n",
+    "\n",
+    "# Our guess of the standards. We assume they don't have any parasitics.\n",
+    "oo_i = coax.open(nports=2, name='open')\n",
+    "ss_i = coax.short(nports=2, name='short')\n",
+    "# Match is only measured on one port. Resistance can be different from 50 ohms.\n",
+    "m_i = coax.resistor(R=50, name='r') ** coax.short(nports=1)\n",
+    "# Thru must be known exactly\n",
+    "thru = coax.line(d=100, unit='um', name='thru')\n",
+    "\n",
+    "# Actual reflects with parasitics. They must be identical in both ports.\n",
+    "# Short is slightly lossy.\n",
+    "ss = coax.line(d=200, unit='um') ** coax.load(-0.98,nports=2, name='short') ** coax.line(d=200, unit='um')\n",
+    "oo = coax.shunt_capacitor(10e-15) ** coax.open(nports=2, name='open') ** coax.shunt_capacitor(10e-15)\n",
+    "\n",
+    "# Match standard has inductance in series.\n",
+    "match_l = 40e-12\n",
+    "l = coax.inductor(L=match_l)\n",
+    "m = l**m_i\n",
+    "\n",
+    "# Make two-port of the match with open on the second port.\n",
+    "mm = skrf.two_port_reflect(m, coax.open(nports=1))\n",
+    "# Make two-port for the match standard\n",
+    "mm_i = coax.match(nports=2, name='load')\n",
+    "\n",
+    "# These are our guesses of the calibration standards.\n",
+    "approx_ideals = [\n",
+    "    thru,\n",
+    "    ss_i,\n",
+    "    oo_i,\n",
+    "    mm_i\n",
+    "    ]\n",
+    "\n",
+    "# These are the actual standards with parasitics.\n",
+    "ideals = [\n",
+    "    thru,\n",
+    "    ss,\n",
+    "    oo,\n",
+    "    mm\n",
+    "    ]\n",
+    "\n",
+    "# Make measurement of the standards using the random error boxes and switch terms.\n",
+    "measured = [skrf.terminate(X**k**Y, gamma_f, gamma_r) for k in ideals]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualize the standards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "oo.plot_s_smith(m=0, n=0, label='Open')\n",
+    "ss.plot_s_smith(m=0, n=0, label='Short')\n",
+    "mm.plot_s_smith(m=0, n=0, label='Match')\n",
+    "\n",
+    "plt.figure()\n",
+    "oo.plot_s_db(m=0, n=0, label='Open')\n",
+    "ss.plot_s_db(m=0, n=0, label='Short')\n",
+    "mm.plot_s_db(m=0, n=0, label='Match')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LRRM calibration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We pretend to not know the actual standards with parasitics and give only our approximations of the standards without parasitics and the measurements of the standard with parasitics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " cal = skrf.LRRM(\n",
+    "    ideals = approx_ideals,\n",
+    "    measured = measured,\n",
+    "    switch_terms = [gamma_f, gamma_r])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualizing the solved standards"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "LRRM calibration solves for the real standards. We can get the solved standards from the `cal` object. The solved standards should match the actual standards above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "cal.solved_r2.plot_s_smith(m=0, n=0, label='Open')\n",
+    "cal.solved_r1.plot_s_smith(m=0, n=0, label='Short')\n",
+    "cal.solved_m.plot_s_smith(m=0, n=0, label='Match')\n",
+    "\n",
+    "plt.figure()\n",
+    "cal.solved_r2.plot_s_db(m=0, n=0, label='Open')\n",
+    "cal.solved_r1.plot_s_db(m=0, n=0, label='Short')\n",
+    "cal.solved_m.plot_s_db(m=0, n=0, label='Match')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "The solved inductance of the match is also given as calibration output. It's given as an array but with the default options a single inductance is fitted over all frequencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solved_match_l = cal.solved_l[0]\n",
+    "print('Solved inductance {:.1f} pH, actual inductance {:.1f} pH'.format(1e12*solved_match_l, 1e12*match_l))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calibrating DUT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Measured DUT can be calibrated using the `apply_cal` method. The S-parameters should match exactly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's generate a DUT: 5 mm long 75 ohm line.\n",
+    "dut = coax.line(d=5, unit='mm', z0=75, embed=True)\n",
+    "\n",
+    "dut_measured = skrf.terminate(X**dut**Y, gamma_f, gamma_r)\n",
+    "dut_cal = cal.apply_cal(dut_measured)\n",
+    "\n",
+    "plt.figure()\n",
+    "dut.plot_s_db(m=0, n=0, label='Actual S11')\n",
+    "dut.plot_s_db(m=1, n=0, label='Actual S21')\n",
+    "dut_cal.plot_s_db(m=0, n=0, label='Calibrated S11')\n",
+    "dut_cal.plot_s_db(m=1, n=0, label='Calibrated S21')\n",
+    "plt.ylim([-20, 5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calibration verification using reflect |S11|\n",
+    "\n",
+    "During the calibration the second reflect |S11| is assumed to be known (|S11| = 1 in this case), but when a single inductance is fitted to the match standard this assumption can be broken. If the real match is not modeled well as known resistance in series with inductance it causes the reflect standard losslessness to be violated. By plotting the absolute value of the reflect we can get an idea on how good the calibration assumptions are.\n",
+    "\n",
+    "Let's first plot the open |S11| in the previous calibration. It should be exactly 0 dB if everything worked correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "cal.solved_r2.plot_s_db(m=0, n=0, label='Solved open')\n",
+    "plt.ylim([-0.01, 0.01])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration with capacitive match\n",
+    "\n",
+    "The LRRM calibration model of the match is a resistance in series with an inductor. If the match also has parallel capacitance it won't be solved correctly and there will be errors in the corrected measurements.\n",
+    "\n",
+    "Let's define a new match standard and redo the calibration using it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Match standard with series inductance and parallel capacitance. \n",
+    "match_c = 20e-15\n",
+    "match_l = 20e-12\n",
+    "l = coax.inductor(L=match_l)\n",
+    "c = coax.shunt_capacitor(match_c)\n",
+    "m = c**l**m_i\n",
+    "\n",
+    "# Make two-port of the match with open on the second port.\n",
+    "mm = skrf.two_port_reflect(m, coax.open(nports=1))\n",
+    "\n",
+    "# Redo the match measurement\n",
+    "ideals[3] = mm\n",
+    "measured[3] = skrf.terminate(X**mm**Y, gamma_f, gamma_r)\n",
+    "\n",
+    "# Redo the calibration\n",
+    "cal = skrf.LRRM(\n",
+    "    ideals = approx_ideals,\n",
+    "    measured = measured,\n",
+    "    switch_terms = [gamma_f, gamma_r]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualize the capacitive match and the solved match"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calibration tries to fit the inductance to the match as best as it can but it can't model the match exactly with an inductor. The closest fit is a negative valued inductor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "mm.plot_s_smith(m=0, n=0, label='Actual')\n",
+    "cal.solved_m.plot_s_smith(m=0, n=0, label='Solved')\n",
+    "\n",
+    "plt.figure()\n",
+    "mm.plot_s_db(m=0, n=0, label='Actual')\n",
+    "cal.solved_m.plot_s_db(m=0, n=0, label='Solved')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solved_match_l = cal.solved_l[0]\n",
+    "print('Solved inductance {:.1f} pH'.format(1e12*solved_match_l))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting the |S11| of the open reveals that the solved open is not lossless indicating that some of the calibration assumptions were violated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "cal.solved_r2.plot_s_db(m=0, n=0, label='Solved open')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DUT measurement with incorrectly modeled match"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The incorrect match causes errors in the calibration parameters. The error increases at higher frequencies where the match modeling error is bigger."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dut_cal2 = cal.apply_cal(dut_measured)\n",
+    "\n",
+    "plt.figure()\n",
+    "dut.plot_s_db(m=0, n=0, label='Actual S11')\n",
+    "dut.plot_s_db(m=1, n=0, label='Actual S21')\n",
+    "dut_cal2.plot_s_db(m=0, n=0, label='Calibrated S11')\n",
+    "dut_cal2.plot_s_db(m=1, n=0, label='Calibrated S21')\n",
+    "plt.ylim([-20, 5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Match fit with inductance and capacitance\n",
+    "LRRM has an option to use a match model with parallel capacitance which allows fitting the above match. The additional requirement for this fitting method is that the second reflect is open with some unknown capacitance. The open capacitance is fitted first assuming match is perfectly resistive weighting low frequencies where the assumption is likely to hold better. When the open capacitance is known match capacitance and inductance are fitted. The open and match fitting is iterated few times to refine the open and match guesses. This fitting method can be used by passing `match_fit = 'lc'` to the calibration method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Redo the calibration using LC match model\n",
+    "cal = skrf.LRRM(\n",
+    "    ideals = approx_ideals,\n",
+    "    measured = measured,\n",
+    "    match_fit = 'lc',\n",
+    "    switch_terms = [gamma_f, gamma_r]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "mm.plot_s_smith(m=0, n=0, label='Actual')\n",
+    "cal.solved_m.plot_s_smith(m=0, n=0, label='Solved')\n",
+    "\n",
+    "plt.figure()\n",
+    "mm.plot_s_db(m=0, n=0, label='Actual')\n",
+    "cal.solved_m.plot_s_db(m=0, n=0, label='Solved')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solved_match_l = cal.solved_l[0]\n",
+    "solved_match_c = cal.solved_c[0]\n",
+    "print('Solved inductance {:.1f} pH, actual inductance {:.1f} pH'.format(1e12*solved_match_l, 1e12*match_l))\n",
+    "print('Solved capacitance {:.1f} fF, actual capacitance {:.1f} fF'.format(1e15*solved_match_c, 1e15*match_c))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Applying the calibration now to the measurements should give a close fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dut_cal3 = cal.apply_cal(dut_measured)\n",
+    "\n",
+    "plt.figure()\n",
+    "dut.plot_s_db(m=0, n=0, label='Actual S11')\n",
+    "dut.plot_s_db(m=1, n=0, label='Actual S21')\n",
+    "dut_cal3.plot_s_db(m=0, n=0, label='Calibrated S11')\n",
+    "dut_cal3.plot_s_db(m=1, n=0, label='Calibrated S21')\n",
+    "plt.ylim([-20, 5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparison with SOLT calibration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The normal overdetermined two-port SOLT calibration assumes that all standards are known accurately. We can compare how it would perform with the same measurements with the same approximately known standards. Match needs to be also measured on the second port for SOLT, we assume it's identical to the first port. The randomly generated error boxes make the calibration especially difficult."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SOLT requires match measurement on both ports.\n",
+    "mm = skrf.two_port_reflect(m, m)\n",
+    "measured[3] = skrf.terminate(X**mm**Y, gamma_f, gamma_r)\n",
+    "\n",
+    "# TwelveTerm assumes that thru is last\n",
+    "cal12 = skrf.TwelveTerm(\n",
+    "    ideals = list(reversed(approx_ideals)),\n",
+    "    measured = list(reversed(measured)),\n",
+    "    n_thrus = 1,\n",
+    "    )\n",
+    "\n",
+    "dut_cal12 = cal12.apply_cal(dut_measured)\n",
+    "\n",
+    "plt.figure()\n",
+    "dut.plot_s_db(m=0, n=0, label='Actual S11')\n",
+    "dut.plot_s_db(m=1, n=0, label='Actual S21')\n",
+    "dut_cal12.plot_s_db(m=0, n=0, label='Calibrated S11')\n",
+    "dut_cal12.plot_s_db(m=1, n=0, label='Calibrated S21')\n",
+    "plt.ylim([-20, 5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -77,6 +77,7 @@ import numpy as npy
 from numpy import linalg
 from numpy.linalg import det
 from numpy import mean, std, angle, real, imag, exp, ones, zeros, poly1d, invert, einsum, sqrt, unwrap,log,log10
+from scipy.optimize import least_squares
 import json
 from numbers import Number
 from collections import OrderedDict
@@ -3512,6 +3513,374 @@ class UnknownThru(EightTerm):
         coefs.update({'k':k_})
 
         self.coefs = coefs
+
+class LRRM(EightTerm):
+    '''
+    Line-Reflect-Reflect-Match self-calibration.
+
+    The required calibration standards are:
+
+        Line: Fully known.
+        Reflect: Unknown reflect, phase needs to be known within 90 degrees.
+        Reflect: Lossless reflect, phase needs to be known within 90 degrees.
+                 Different from the other reflect.
+        Match: Match with known resistance in series with unknown inductance.
+
+    Reflects are assumed to be identical on both ports. Note that the first
+    reflect doesn't need to be lossless, but the second one does. Match needs to
+    be only measured on the first port, the second port of match measurement is
+    not used during the calibration.
+
+    Implementation is based on papers [1] and [2].
+
+    [1] Zhao, W.; Liu, S.; Wang, H.; Liu, Y.; Zhang, S.; Cheng, C.; Feng,
+        K.; Ocket, I.; Schreurs, D.; Nauwelaers, B.; Qin, H.; Yang, X.
+        A Unified Approach for Reformulations of LRM/LRMM/LRRM Calibration
+        Algorithms Based on the T-Matrix Representation. Appl. Sci. 2017, 7,
+        866. https://doi.org/10.3390/app7090866
+
+    [2] F. Purroy and L. Pradell, "New theoretical analysis of the LRRM
+        calibration technique for vector network analyzers," in IEEE
+        Transactions on Instrumentation and Measurement, vol. 50, no. 5,
+        pp. 1307-1314, Oct. 2001.
+    '''
+
+    family = 'EightTerm'
+    def __init__(self, measured, ideals, switch_terms=None, isolation=None,
+            z0=50, match_fit='l', *args, **kwargs):
+        '''
+        Parameters
+        --------------
+        measured : list of :class:`~skrf.network.Network` objects
+            Raw measurements of the calibration standards. The order
+            must be line, reflect, reflect, match and must align with the
+            `ideals` parameter
+
+        ideals : list of :class:`~skrf.network.Network` objects
+            Predicted ideal response of the calibration standards.
+            The order must align with `measured` list
+
+        switch_terms : tuple of :class:`~skrf.network.Network` objects
+            the pair of switch terms in the order (forward, reverse)
+
+        isolation : :class:`~skrf.network.Network` object
+            Measurement with loads on both ports with a perfect isolation
+            between the ports. Used for determining the isolation error terms.
+            If no measurement is given leakage is assumed to be zero.
+
+        z0 : int
+            Calibration reference impedance. Only affects the solved match
+            inductance. Has no effect to the solved calibration parameters.
+
+        match_fit : string or None
+            Match model. Valid choices are 'l' to fit a single inductance over
+            all frequencies. 'none' to not fit inductance and let it be
+            different for each frequency. Fitting is recommended as individual
+            inductance estimates can be noisy.
+        '''
+
+        self.z0 = z0
+        # TODO: Second port not implemented.
+        self.match_port = 0
+
+        self.match_fit = match_fit
+
+        if self.match_port not in [0, 1]:
+            raise ValueError('match_port must be either 0 or 1.')
+
+        super().__init__(
+            measured = measured,
+            ideals = ideals,
+            switch_terms = switch_terms,
+            isolation = isolation,
+            *args, **kwargs)
+
+    def run(self):
+        mList = [k for k in self.measured_unterminated]
+        lm = mList[0]
+        r1m = mList[1]
+        r2m = mList[2]
+        mm = mList[3]
+
+        inv = npy.linalg.inv
+
+        tl = self.ideals[0].t
+
+        fpoints = len(mList[0])
+
+        r11 = r1m.s[:,0,0]
+        r12 = r1m.s[:,1,1]
+        r21 = r2m.s[:,0,0]
+        r22 = r2m.s[:,1,1]
+
+        lm11 = lm.s[:,0,0]
+        lm12 = lm.s[:,0,1]
+        lm21 = lm.s[:,1,0]
+        lm22 = lm.s[:,1,1]
+
+        mm1 = mm.s[:,0,0]
+
+        thru_s21 = self.ideals[0].s[:,1,0]
+
+        ones = npy.ones(fpoints, dtype=npy.complex)
+        zeros = npy.zeros(fpoints, dtype=npy.complex)
+
+        wlr1 = npy.transpose(npy.array([[ones, ones], [r11, r21]]), [2,0,1])
+        wll1 = npy.transpose(npy.array([[ones, zeros], [lm11, lm12]]), [2,0,1])
+        wll2 = npy.transpose(npy.array([[zeros, ones], [lm21, lm22]]), [2,0,1])
+        wlr2 = npy.transpose(npy.array([[ones, ones], [r12, r22]]), [2,0,1])
+
+        wl = inv(wlr1) @ wll1 @ inv(wll2) @ wlr2
+
+        # xyz2 == (x/y)*z**2
+        xyz2 = -npy.linalg.det(tl) / npy.linalg.det(wl)
+
+        c2 = wl[:, 0, 0]
+        c1 = -tl[:, 1, 0] - tl[:, 0, 1]
+        c0 = wl[:, 1, 1] * xyz2
+
+        z0 = -c1 + npy.sqrt(c1**2 - 4*c2*c0)/(2*c2)
+        z1 = -c1 - npy.sqrt(c1**2 - 4*c2*c0)/(2*c2)
+        zs = npy.stack([z0, z1])
+
+        # wm and solve_gr equations are different if match is on the second port.
+        assert self.match_port == 0
+        wm_t1 = inv(npy.transpose(npy.array([[ones, ones],[r11, r21]]), [2,0,1]))
+        wm_t2 = npy.transpose(npy.array([[ones], [mm1]]), [2,0,1])
+        wm = wm_t1 @ wm_t2
+        wm1 = wm[:, 0, 0]
+        wm2 = wm[:, 1, 0]
+
+        def solve_gr(gm):
+            gr1s = npy.zeros((2, fpoints), dtype=npy.complex)
+            gr2s = npy.zeros((2, fpoints), dtype=npy.complex)
+            xs = npy.zeros((2, fpoints), dtype=npy.complex)
+            er = npy.zeros((2, fpoints), dtype=npy.complex)
+            efs = npy.zeros((2, 4, fpoints), dtype=npy.complex)
+
+            for root in [0, 1]:
+                z = zs[root]
+                xyz = xyz2 / z
+
+                w11 = wl[:, 0, 0] * z
+                w21 = wl[:, 1, 0] * z
+                w12 = wl[:, 0, 1] * xyz
+                w22 = wl[:, 1, 1] * xyz
+
+                e1 = (tl[:, 1, 1]**2) * wm1
+                e0 = tl[:, 1, 1] * (tl[:, 1, 0] - w22) * wm1 + tl[:, 1, 1] * wm2 * w12
+                f1 = tl[:, 1, 1] * (w11 - tl[:, 1, 0]) * wm1 + tl[:, 1, 1] * wm2 * w12
+                f0 = (w11 - tl[:, 1, 0]) * (tl[:, 1, 0] - w22) * wm1 + wm1 * w21 * w12
+
+                gr2 = -(f0 - e0 * gm) / (f1 - e1 * gm)
+
+                x = w12 / (tl[:, 1, 0] + tl[:, 1, 1]*gr2 - w22)
+                gr1 = ((w11 - tl[:, 1, 0]) * (tl[:, 1, 0] + tl[:, 1, 1] * gr2 - w22) + w21*w12) \
+                        / (tl[:, 1, 1] * (tl[:, 1, 0] + tl[:, 1, 1] * gr2 - w22))
+
+                egr1 = npy.abs(gr1 - self.ideals[1].s[:,0,0])
+                egr2 = npy.abs(gr2 - self.ideals[2].s[:,0,0])
+
+                er[root] = egr1 + egr2
+                gr1s[root] = gr1
+                gr2s[root] = gr2
+                efs[root, 0, :] = e1
+                efs[root, 1, :] = e0
+                efs[root, 2, :] = f1
+                efs[root, 3, :] = f0
+                xs[root] = x
+
+            one_ints = npy.ones(fpoints, dtype=npy.int)
+            zero_ints = npy.zeros(fpoints, dtype=npy.int)
+            root = er[0] < er[1]
+
+            gr1 = npy.where(root, gr1s[0], gr1s[1])
+            gr2 = npy.where(root, gr2s[0], gr2s[1])
+            x = npy.where(root, xs[0], xs[1])
+            z = npy.where(root, zs[0], zs[1])
+            efs = npy.where(root, efs[0], efs[1])
+            y = x * z**2 / xyz2
+
+            return gr1, gr2, x, y, z, efs
+
+        # Solve first reflects assuming gm = 0
+        gr1, gr2, x, y, z, efs = solve_gr(zeros)
+
+        # Next solve for match inductance
+        gmi = self.ideals[3].s[:, self.match_port, self.match_port]
+        R = (self.z0 * (1 + gmi)/(1 - gmi)).real # Resistance of the match
+
+        a = 2*gr2.real + npy.abs(gr2)**2 - \
+            2*(gr2*thru_s21**(-2)).real - npy.abs(gr2*thru_s21**(-2))**2
+        b = 4*R*(gr2.imag + (gr2*thru_s21**(-2)).imag )
+        c = 4*R**2*(npy.abs(gr2)**2 - 1)
+
+        det = b**2 - 4*a*c
+        if npy.any(det < 0):
+            warnings.warn('Load inductance determination failed. Calibration might be incorrect.')
+        det[det < 0] = 0
+        wL = [None, None]
+        wL[0] = (-b+npy.sqrt(det))/(2*a)
+        wL[1] = (-b-npy.sqrt(det))/(2*a)
+
+        gm_guess = [None, None]
+        for p in [0,1]:
+            gm_guess[p] = (R + 1j*wL[p] - self.z0)/(R + 1j*wL[p] + self.z0)
+
+        # Choose the root according to which one is closer to the ideal
+        m_ideal = self.ideals[3].s[:,0,0]
+        root = (npy.abs(gm_guess[0] - m_ideal) > npy.abs(gm_guess[1] - m_ideal)).astype(npy.int)
+
+        # L from reactance
+        match_l = npy.choose(root, wL)/(2*npy.pi*self.measured[0].f)
+
+        w = 2*npy.pi*self.measured[0].f
+
+        if self.match_fit == 'l':
+
+            # Weight L estimate by frequency
+            l0 = npy.sum(w * match_l) / npy.sum(w)
+
+            e1 = efs[0, :]
+            e0 = efs[1, :]
+            f1 = efs[2, :]
+            f0 = efs[3, :]
+
+            gr2_abs = npy.abs(self.ideals[2].s[:,0,0])
+
+            def min_l(l):
+                """
+                Calculates gr2 absolute value error as a function of
+                the match inductance.
+                """
+                gm = (R + 1j*w*l - self.z0)/(R + 1j*w*l + self.z0)
+                return gr2_abs - npy.abs((f0 - e0 * gm) / (f1 - e1 * gm))
+
+            # Try some alternative initial guesses
+            init_x = npy.linspace(-10, 10, 10)
+            init_l = init_x / (w[-1])
+            init_guess = [npy.mean(min_l(l)**2) for l in init_l]
+            li = npy.argmin(init_guess)
+            best_guess = init_l[li]
+
+            # Choose the best guess for the least squares initial value
+            if init_guess[li] < npy.mean(min_l(l0)**2):
+                l0 = best_guess
+
+            sol = least_squares(min_l, l0)
+            match_l = sol.x * npy.ones(match_l.shape)
+
+        elif self.match_fit == 'none' or self.match_fit is None:
+            pass
+        else:
+            raise ValueError('Unknown match_fit {}'.format(self.match_fit))
+
+        gamma_m = (R + 1j*w*match_l - self.z0)/(R + 1j*w*match_l + self.z0)
+
+        # Solve finally reflects and calibration parameters using the solved match
+        gr1, gr2, x, y, z, _ = solve_gr(gamma_m)
+
+        self._solved_l = match_l
+        self._solved_m = Network(s=gamma_m, frequency=self.measured[0].frequency)
+        self._solved_r1 = Network(s=gr1, frequency=self.measured[0].frequency)
+        self._solved_r2 = Network(s=gr2, frequency=self.measured[0].frequency)
+
+        # Calculate error matrices
+        t10 = npy.transpose(npy.array([[ones, x], [gr1, gr2*x]]), [2,0,1]) \
+                @ inv(npy.transpose(npy.array([[ones,ones],[r11, r21]]), [2,0,1]))
+        t23 = npy.transpose((1/z)*npy.array([[ones, y], [gr1, gr2*y]]), [2,0,1]) \
+                @ inv(npy.transpose(npy.array([[ones,ones],[r12, r22]]), [2,0,1]))
+
+        Smat1 = t2s(t10)
+        Smat2 = t2s(t23)
+
+        #Convert the error coefficients to
+        #definitions used by the EightTerm class.
+        dx = linalg.det(Smat1)
+        dy = linalg.det(Smat2)
+
+        k = Smat1[:,0,1]/Smat2[:,0,1]
+
+        #Error coefficients
+        e = [Smat1[:,0,0],
+             Smat1[:,1,1],
+             dx,
+             Smat2[:,0,0],
+             Smat2[:,1,1],
+             dy,
+             k]
+
+        self._coefs = {\
+                'forward directivity':e[1],
+                'forward source match':e[0],
+                'forward reflection tracking':e[0]*e[1]-e[2],
+                'reverse directivity':e[4],
+                'reverse source match':e[3],
+                'reverse reflection tracking':e[4]*e[3]- e[5],
+                'k':e[6],
+                }
+
+        self._coefs['forward isolation'] = self.isolation.s[:,1,0].flatten()
+        self._coefs['reverse isolation'] = self.isolation.s[:,0,1].flatten()
+
+        if self.switch_terms is not None:
+            self._coefs.update({
+                'forward switch term': self.switch_terms[0].s.flatten(),
+                'reverse switch term': self.switch_terms[1].s.flatten(),
+                })
+        else:
+            self._coefs.update({
+                'forward switch term': npy.zeros(fpoints, dtype=complex),
+                'reverse switch term': npy.zeros(fpoints, dtype=complex),
+                })
+        # output is a dictionary of information
+        self._output_from_run = {
+                'error vector':e
+                }
+
+    @property
+    def solved_l(self):
+        '''
+        Solved inductance of the load
+        '''
+        try:
+            return self._solved_l
+        except(AttributeError):
+            self.run()
+            return self._solved_l
+
+    @property
+    def solved_m(self):
+        '''
+        Solved match
+        '''
+        try:
+            return self._solved_m
+        except(AttributeError):
+            self.run()
+            return self._solved_m
+
+    @property
+    def solved_r1(self):
+        '''
+        Solved reflect1
+        '''
+        try:
+            return self._solved_r1
+        except(AttributeError):
+            self.run()
+            return self._solved_r1
+
+    @property
+    def solved_r2(self):
+        '''
+        Solved reflect2
+        '''
+        try:
+            return self._solved_r2
+        except(AttributeError):
+            self.run()
+            return self._solved_r2
 
 class MRC(UnknownThru):
     '''

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -37,6 +37,7 @@ Two-port
    SOLT
    EightTerm
    UnknownThru
+   LRRM
    TRL
    MultilineTRL
    NISTMultilineTRL
@@ -3527,10 +3528,14 @@ class LRRM(EightTerm):
         Match: Match with known resistance in series with unknown inductance.
 
     Reflects are assumed to be identical on both ports. Note that the first
-    reflect can be lossy, but the second reflect's magnitude of the reflection
-    coefficient needs to be known. Match needs to be only measured on the first
-    port, the second port of match measurement is not used during the
-    calibration.
+    reflect's |S11| can be unknown, but the second reflect's magnitude of the
+    reflection coefficient needs to be known. Match needs to be only measured
+    on the first port, the second port of match measurement is not used during
+    the calibration.
+
+    If match_fit == 'lc' then the second reflect is assumed to be a lossless
+    capacitor. Measurements should then include low frequencies for accurate
+    open capacitance determination.
 
     Implementation is based on papers [1] and [2]. 'lc' match_fit based on [3].
 
@@ -3713,6 +3718,10 @@ class LRRM(EightTerm):
             return gr1, gr2, x, y, z, efs
 
         def calc_gm(R, l, c=0):
+            """
+            Calculates reflection coefficient of resistor R in series with inductance
+            l in parallel with capacitor c.
+            """
             return (self.z0 + R*(-1 + 1j*c*w*self.z0) - l*w*(1j + c*w*self.z0)) \
                  /(-self.z0 + R*(-1 - 1j*c*w*self.z0) + l*w*(-1j + c*w*self.z0))
 
@@ -3933,7 +3942,7 @@ class LRRM(EightTerm):
     def solved_c(self):
         '''
         Solved capacitance of the load.
-        Zero if lc_fit = 'l'.
+        Zero if match_fit != 'lc'.
         '''
         try:
             return self._solved_c

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -3746,11 +3746,10 @@ class LRRM(EightTerm):
 
         # L from reactance
         match_l = npy.choose(root, wL)/(2*npy.pi*self.measured[0].f)
-        match_c = -1/(npy.choose(root, wL)*2*npy.pi*self.measured[0].f)
+        match_c = zeros
 
         # Weight L estimate by frequency
         l0 = npy.sum(w * match_l) / npy.sum(w)
-        c0 = npy.sum(w * match_c) / npy.sum(w)
 
         e1 = efs[0, :]
         e0 = efs[1, :]
@@ -3798,6 +3797,9 @@ class LRRM(EightTerm):
                 warnings.warn("2nd reflect assumed to be open, but 2nd ideal ' \
                 'doesn't look like open. Calibration is likely incorrect.")
 
+            match_c = -1/(npy.choose(root, wL)*2*npy.pi*self.measured[0].f)
+            c0 = npy.sum(w * match_c) / npy.sum(w)
+
             for iteration in range(self.lc_fit_iters):
                 # Fit capacitance to gr2
                 cgr2 = (1j*(-1 + gr2))/((1 + gr2)*w*self.z0)
@@ -3816,7 +3818,7 @@ class LRRM(EightTerm):
                     r.extend(e.imag)
                     return npy.array(r)
 
-                if iteration == 0:
+                if iteration == 0 or l0 < 0 or c0 < 0:
                     # Biggest capacitance value assuming given gm matching.
                     worst_match = 0.4 # -7 dB
                     max_init_c = (2*worst_match)/(npy.sqrt(1 - worst_match**2)*w[-1]*self.z0)

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1146,6 +1146,81 @@ class UnknownThruTest(EightTermTest):
             switch_terms = [self.gamma_f, self.gamma_r]
             )
 
+class LRRMTest(EightTermTest):
+    def setUp(self):
+
+        self.n_ports = 2
+        self.wg = WG
+        wg = self.wg
+        self.X = wg.random(n_ports=2, name='X')
+        self.Y = wg.random(n_ports=2, name='Y')
+        self.If = wg.random(n_ports=1, name='If')
+        self.Ir = wg.random(n_ports=1, name='Ir')
+        self.gamma_f = wg.random(n_ports=1, name='gamma_f')
+        self.gamma_r = wg.random(n_ports=1, name='gamma_r')
+
+        # Our guess of the standards
+        o_i = wg.load(1, nports=1, name='open')
+        s_i = wg.short(nports=1, name='short')
+        m_i = wg.load(0.1, nports=1, name='load')
+        thru = wg.line(d=50, unit='um', name='thru')
+
+        # Actual reflects with parasitics
+        s = wg.inductor(5e-12) ** wg.load(-0.95, nports=1, name='short')
+        o = wg.shunt_capacitor(5e-15) ** wg.open(nports=1, name='open')
+
+        self.match_l = npy.random.uniform(1e-12, 20e-12)
+        l = wg.inductor(L=self.match_l)
+        m = l**m_i
+
+        # Make standards two-ports
+        oo = rf.two_port_reflect(o, o)
+        ss = rf.two_port_reflect(s, s)
+        mm = rf.two_port_reflect(m, o)
+
+        oo_i = rf.two_port_reflect(o_i, o_i)
+        ss_i = rf.two_port_reflect(s_i, s_i)
+        mm_i = rf.two_port_reflect(m_i, m_i)
+
+        # Store open and short for other tests.
+        self.s = s
+        self.o = o
+
+        approx_ideals = [
+            thru,
+            ss_i,
+            oo_i,
+            mm_i
+            ]
+
+        ideals = [
+            thru,
+            ss,
+            oo,
+            mm
+            ]
+
+        measured = [self.measure(k) for k in ideals]
+
+        self.cal = rf.LRRM(
+            ideals = approx_ideals,
+            measured = measured,
+            switch_terms = [self.gamma_f, self.gamma_r],
+            isolation = measured[3]
+            )
+
+    # Test the solved standards, don't use exact equality because of inductance
+    # fitting tolerance.
+    def test_solved_inductance(self):
+        solved_l = npy.mean(self.cal.solved_l)
+        self.assertTrue(npy.abs(self.match_l - solved_l) < 1e-3*self.match_l)
+
+    def test_solved_r1(self):
+        self.assertTrue(npy.abs(self.s.s - self.cal.solved_r1.s) < 1e-7)
+
+    def test_solved_r2(self):
+        self.assertTrue(npy.abs(self.o.s - self.cal.solved_r2.s) < 1e-7)
+
 
 class MRCTest(EightTermTest):
     def setUp(self):


### PR DESCRIPTION
LRRM is probably the most widely used calibration that is still missing from scikit-rf. It's often used for on-wafer calibration at mm-wave frequencies but it's usable also in other situations. This implementation combines the best parts from few different LRRM papers and the functionality looks good so far. Example notebook is included to show how to use it and what assumptions are made of the calibration standards.

Three alternatives for match determination are provided. 'none' uses independent inductance for each frequency, this doesn't currently work correctly with non-z0 match. 'l' which is the default fits a single inductance value to the match. 'lc' fits inductor and parallel capacitor assuming second reflect is open with some unknown capacitance that is the same at all frequencies. Tests are included for 'l' and 'none'. No test is included for 'lc' right now as it doesn't work too well using the waveguide media without low frequency measurements. The iterative approach it uses is also not accurate enough for the equality test of the calibration parameters. Example using it is however included in the example notebook and it should be usable with real measurements.