### PR TITLE
Zipped touchstone fix

### DIFF
--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -70,7 +70,6 @@ import pickle
 from pickle import UnpicklingError
 import sys
 import warnings
-import zipfile
 
 import numpy as npy
 

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -26,6 +26,7 @@ Functions related to reading/writing touchstones.
 """
 import re
 import os
+import typing
 import zipfile
 import numpy
 import numpy as npy
@@ -50,7 +51,7 @@ class Touchstone:
     .. [#] https://ibis.org/interconnect_wip/touchstone_spec2_draft.pdf
     .. [#] https://ibis.org/touchstone_ver2.0/touchstone_ver2_0.pdf
     """
-    def __init__(self, file):
+    def __init__(self, file: typing.Union[str, typing.TextIO]):
         """
         constructor
 
@@ -103,7 +104,7 @@ class Touchstone:
         ## Store port names in a list if they exist in the file
         self.port_names = None
 
-        self.comment_variables=None
+        self.comment_variables = None
         self.load_file(fid)
 
         self.gamma = []
@@ -114,7 +115,7 @@ class Touchstone:
 
         fid.close()
 
-    def load_file(self, fid):
+    def load_file(self, fid: typing.TextIO):
         """
         Load the touchstone file into the internal data structures.
 
@@ -124,7 +125,7 @@ class Touchstone:
 
         """
 
-        filename=self.filename
+        filename = self.filename
 
         # Check the filename extension. 
         # Should be .sNp for Touchstone format V1.0, and .ts for V2
@@ -147,7 +148,7 @@ class Touchstone:
             if not line:
                 break
             # store comments if they precede the option line
-            line = line.split('!',1)
+            line = line.split('!', 1)
             if len(line) == 2:
                 if not self.parameter:
                     if self.comments == None:
@@ -668,7 +669,7 @@ def hfss_touchstone_2_network(filename, f_unit='ghz'):
     return(my_network)
 
 
-def read_zipped_touchstones(ziparchive, dir=""):
+def read_zipped_touchstones(ziparchive: zipfile.ZipFile, dir: str = "") -> typing.Dict[str, Network]:
     """
     similar to skrf.io.read_all_networks, which works for directories but only for Touchstones in ziparchives.
 
@@ -682,6 +683,8 @@ def read_zipped_touchstones(ziparchive, dir=""):
     Returns
     -------
     dict
+        keys are touchstone filenames without extensions
+        values are network objects created from the touchstone files
     """
     networks = dict()
     for fname in ziparchive.namelist():  # type: str

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2007,9 +2007,12 @@ class Network(object):
             Network from the Touchstone file
 
         """
-        with io.TextIOWrapper(archive.open(filename)) as touchstone_file:
-            ntwk = cls()
-            ntwk.read_touchstone(touchstone_file)
+        # Touchstone requires file objects to be seekable (for get_gamma_z0_from_fid)
+        # A ZipExtFile object is not seekable prior to Python 3.7, so use StringIO
+        # and manually add a name attribute
+        fileobj = io.StringIO(archive.open(filename).read().decode('UTF-8'))
+        fileobj.name = filename
+        ntwk = Network(fileobj)
         return ntwk
 
     def write_touchstone(self, filename: str = None, dir: str = None,

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -47,7 +47,7 @@ NetworkSet Utilities
 import zipfile
 import numpy as npy
 import typing
-from io import StringIO, BytesIO
+from io import BytesIO
 from scipy.interpolate import interp1d
 from . network import Network, Frequency, PRIMARY_PROPERTIES, COMPONENT_FUNC_DICT
 from . import mathFunctions as mf
@@ -222,18 +222,10 @@ class NetworkSet(object):
         if sort_filenames:
             filename_list.sort()
 
-
         for filename in filename_list:
             # try/except block in case not all files are touchstones
-
             try:  # Ascii files (Touchstone, etc)
-                # convert ZipExtFile to StringIO
-                # io.StringIO doesn't have an attribute called name like in
-                # file objects created with open(). So create it as it is
-                # required for the touchstone parser.
-                fileobj = StringIO(z.open(filename).read().decode('UTF-8'))
-                fileobj.name = filename
-                n = Network(fileobj)
+                n = Network.zipped_touchstone(filename, z)
                 ntwk_list.append(n)
                 continue
             except:
@@ -273,8 +265,6 @@ class NetworkSet(object):
         """
         from . io.general import read_all_networks
         return cls(read_all_networks(dir), *args, **kwargs)
-
-
 
     @classmethod
     def from_s_dict(cls, d: dict, frequency: Frequency, *args, **kwargs):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import io
 import tempfile
+import zipfile
 import sys
 import numpy as npy
 from pathlib import Path
@@ -154,6 +155,7 @@ class NetworkTestCase(unittest.TestCase):
             rf.Network(fid)
         with open(filename) as fid:
             rf.Network(fid)
+
     def test_constructor_from_stringio(self):
         filename= os.path.join(self.test_dir, 'ntwk1.s2p')
         with open(filename) as fid:
@@ -168,6 +170,11 @@ class NetworkTestCase(unittest.TestCase):
             sio = io.StringIO(data)
             sio.name = os.path.basename(filename) # hack a bug to touchstone reader
             rf.Network(sio)
+
+    def test_zipped_touchstone(self):
+        zippath = os.path.join(self.test_dir, 'ntwks.zip')
+        fname = 'ntwk1.s2p'
+        rf.Network.zipped_touchstone(fname, zipfile.ZipFile(zippath))
 
     def test_open_saved_touchstone(self):
         self.ntwk1.write_touchstone('ntwk1Saved',dir=self.test_dir)


### PR DESCRIPTION
Fix Network.zipped_touchstone() and add unit test.

This broke due to changes in Touchstone.load_file after 0.17 release.  Unit test coverage for zipped files was only present in test_networkSet.py, though NetworkSet.from_zip did not leverage Network.zipped_touchstone, so the issue escaped unit testing.