### PR TITLE
LRRM, MTRL doc fixes

### DIFF
--- a/doc/source/examples/metrology/LRRM.ipynb
+++ b/doc/source/examples/metrology/LRRM.ipynb
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##  LRRM example with synthetic data"
+    "## LRRM example with synthetic data"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## LRRM calibration"
+    "### LRRM calibration"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing the solved standards"
+    "### Visualizing the solved standards"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Calibrating DUT"
+    "### Calibrating DUT"
    ]
   },
   {
@@ -265,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Calibration verification using reflect |S11|\n",
+    "### Calibration verification using reflect |S11|\n",
     "\n",
     "During the calibration the second reflect |S11| is assumed to be known (|S11| = 1 in this case), but when a single inductance is fitted to the match standard this assumption can be broken. If the real match is not modeled well as known resistance in series with inductance it causes the reflect standard losslessness to be violated. By plotting the absolute value of the reflect we can get an idea on how good the calibration assumptions are.\n",
     "\n",
@@ -287,7 +287,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Calibration with capacitive match\n",
+    "### Calibration with capacitive match\n",
     "\n",
     "The LRRM calibration model of the match is a resistance in series with an inductor. If the match also has parallel capacitance it won't be solved correctly and there will be errors in the corrected measurements.\n",
     "\n",
@@ -382,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DUT measurement with incorrectly modeled match"
+    "### DUT measurement with incorrectly modeled match"
    ]
   },
   {
@@ -412,7 +412,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Match fit with inductance and capacitance\n",
+    "### Match fit with inductance and capacitance\n",
+    "\n",
     "LRRM has an option to use a match model with parallel capacitance which allows fitting the above match. The additional requirement for this fitting method is that the second reflect is open with some unknown capacitance. The open capacitance is fitted first assuming match is perfectly resistive weighting low frequencies where the assumption is likely to hold better. When the open capacitance is known match capacitance and inductance are fitted. The open and match fitting is iterated few times to refine the open and match guesses. This fitting method can be used by passing `match_fit = 'lc'` to the calibration method."
    ]
   },
@@ -485,7 +486,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Comparison with SOLT calibration"
+    "## Comparison with SOLT calibration"
    ]
   },
   {

--- a/doc/source/examples/metrology/Multiline TRL.ipynb
+++ b/doc/source/examples/metrology/Multiline TRL.ipynb
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Calculate effective complex relative permittivity of transmission lines used in the calibration\n",
+    "## Calculate effective complex relative permittivity of transmission lines used in the calibration\n",
     "\n",
     "Effective complex relative permittivity $\\epsilon_{r,eff}$ of a transmission line is related to the propagation constant $\\gamma$ as:\n",
     "\n",
@@ -300,7 +300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Plot the phase of the solved reflection coefficient"
+    "## Plot the phase of the solved reflection coefficient"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Reference plane shift\n",
+    "## Reference plane shift\n",
     "\n",
     "Because propagation constant of the media is solved during the calibration it's possible to shift the reference plane by a specified distance.\n",
     "\n",
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Calibration reference impedance renormalization\n",
+    "## Calibration reference impedance renormalization\n",
     "\n",
     "The reference impedance of the calibration is by default the transmission line characteristic impedance. If we know the actual characteristic impedance of the lines we can give it to the calibration routine with the `z0_line` argument to renormalize the measured S-parameters to a fixed reference `z0_ref`.\n",
     "\n",

--- a/doc/source/examples/networktheory/Time domain reflectometry, measurement vs simulation.ipynb
+++ b/doc/source/examples/networktheory/Time domain reflectometry, measurement vs simulation.ipynb
@@ -550,35 +550,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# extract connector characteristic\n",
-    "# note: a half thru line is embedded in connector network\n",
-    "coefs = cal.coefs\n",
-    "r = skrf.mf.sqrt_phase_unwrap(coefs['forward reflection tracking'])\n",
-    "s1 = np.array([[coefs['forward directivity'],r],\n",
-    "        [r, coefs['forward source match']]]).transpose()\n",
-    "\n",
-    "conn_and_half_thru = line100mm.copy()\n",
-    "conn_and_half_thru.s = s1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A half thru line is embedded in the extracted network, we remove it with de-embedding."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# half thru model, with already determined dielectric permittivity and tand.\n",
-    "half = m.line(50e-3, 'm', embed=True, z0=m.Z0_f)\n",
-    "\n",
-    "conn = conn_and_half_thru ** half.inv\n",
-    "conn.name = 'Connector'"
+    "# extract connector characteristic from port 1 error coefficients\n",
+    "conn = skrf.error_dict_2_network(cal.coefs, cal.frequency, is_reciprocal=True)[0]"
    ]
   },
   {
@@ -645,9 +618,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comparison of connector model characteristics against calibration results shows a reasonable agreement. Calibration results exhibit some glitches that do not correspond to the awaited physical behavior and may be related to singularities in the computations. It could possibly be enhanced by feeding more distinct lines to the algorithm, but these are not manufactured yet.\n",
-    "\n",
-    "The results look good enough to be used."
+    "Comparison of connector model characteristics against calibration results shows a reasonable agreement. Calibration results exhibit some glitches that do not correspond to the expected physical behavior. They are caused by the calibration being close to singular due to the thru and line phase being a multiple of 180 degrees. Accuracy could be enhanced by feeding more distinct lines to the algorithm, but these are not manufactured yet."
    ]
   },
   {
@@ -901,7 +872,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -915,9 +886,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Fixes the headers (`#` to `##` in markdown) in LRRM and MTRL examples.

Another fix in "Time domain reflectometry, measurement vs simulation" example due to PR #533.

Before the PR, the error box parameters were a mix of error box parameters with zero and non-zero length thrus. The transmission phase was from the zero length thru case. After the fix the phase is calculated correctly and no correction is needed that was there before.