### PR TITLE
Pytest instead of nose

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,10 +40,10 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     # tests suites & creates coverage report
-    - name: Test with nose
+    - name: Test with pytest
       if: ${{ always() }}    
       run: |
-        nosetests skrf --nocapture --with-coverage -c nose.cfg
+        pytest
 
     # test notebooks
     - name: Run tutorials notebooks with nbval

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ qtapps/sandbox*
 
 .vscode/
 .coverage
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
 - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
 - source activate test-environment
-- conda install numpy matplotlib scipy pandas networkx nose pip ipython openpyxl
+- conda install numpy matplotlib scipy pandas networkx pytest pip ipython openpyxl
 - pip install -r tools/travis-requirements.txt
 - python setup.py install
 script:
@@ -26,7 +26,7 @@ script:
 - python -c "import numpy; print('numpy %s' % numpy.__version__)"
 - python -c "import scipy; print('scipy %s' % scipy.__version__)"
 - python -c "import skrf; print('skrf %s' % skrf.__version__)"
-- nosetests skrf --nocapture -c nose.cfg
+- pytest
 after_success:
 - coveralls
 #deploy:

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -13,7 +13,7 @@ Contributing to scikit-rf
 
 Sponsoring the Project
 ----------------------
-It is possible to sponsor the maintainers and developpers of the scikit-rf package, using the GitHub Sponsor option ("Sponsor this project") visible in the `scikit-rf GitHub page <https://github.com/scikit-rf/scikit-rf>`_. 
+It is possible to sponsor the maintainers and developers of the scikit-rf package, using the GitHub Sponsor option ("Sponsor this project") visible in the `scikit-rf GitHub page <https://github.com/scikit-rf/scikit-rf>`_. 
 
 Sponsoring is one more way to contribute to open source: financially supporting the people who build and maintain it. Funding individuals helps them keep doing important work, expands opportunities to participate, and gives developers the recognition they deserve.
 
@@ -89,24 +89,30 @@ Tests are vital for software reliability and maintainability. Writing tests ofte
 Before making a Pull Request, we advise contributors to run the tests locally to check if nothing has been broken following their modifications. In addition, we highly recommend to provide new tests when adding new features.
 
 The structure of the testing generally follows the conventions of `numpy/scipy <https://github.com/numpy/numpy/blob/master/doc/TESTS.rst.txt>`_. Test cases live in the module, or submodule, which they are testing, and are located in a directory called `tests`. So, the tests of the media module are located at `skrf/media/tests/`. 
-Tests can be run most easily with `nosetest <http://nose.readthedocs.org/en/latest/>`_. 
+Tests can be run most easily with `pytest <https://docs.pytest.org/en/latest/index.html`_. 
 
-You probably **don't** want to run the tests for the virtual instruments ``skrf.vi`` with the rest of the tests, so to prevent this, also install `nose-exclude <https://pypi.python.org/pypi/nose-exclude>`_ via pip (``pip install nose-exclude``) or conda. 
+You probably **don't** want to run the tests for the virtual instruments ``skrf.vi`` with the rest of the tests, so these tests are excluded by default.
 
 To run all the tests (except the virtual instruments)
 
 .. code-block:: sh
 
     cd scikit-rf
-    nosetests skrf -c nose.cfg
+    pytest 
+
+Or, to run tests for every installed python installation in an isolated environment. 
+
+.. code-block:: sh
+
+    tox 
 
 Or, to run test a single module or single test, 
 
 .. code-block:: sh
 
-    nosetests media/
+    pytest skrf/media/
     # ...
-    nosetests tests/test_network.py
+    pytest skrf/tests/test_network.py
     # ...
     
 

--- a/nose.cfg
+++ b/nose.cfg
@@ -1,7 +1,0 @@
-
-[nosetests]
-exclude-dir=skrf/vi
-            skrf/src
-            
-with-coverage=1
-cover-package=skrf

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-
-# Notebooks to skip when running smoke tests with nbsmoke
-nbsmoke_skip_run = ^doc/source/examples/instrumentcontrol/.*$
-

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -4,4 +4,3 @@ numpy>=1.6
 scipy>=0.10.1
 xlwt>=0.7.4
 xlrd>=0.6.1
-nose-exclude

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,8 +4,6 @@ pyvisa
 ipython
 ipykernel
 ipywidgets
-nose
-nose-exclude
 coverage
 flake8
 pytest

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ setup(name='scikit-rf',
 			'ipywidgets',
 		],
 		'tests': [
-			'nose',
-			'nose-exclude',
 			'coverage',
 			'flake8',
 			'pytest',

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -2728,7 +2728,7 @@ class NISTMultilineTRL(EightTerm):
         Smat2 = npy.ones(shape=(fpoints, 2, 2), dtype=complex)
 
         e = npy.zeros(shape=(fpoints, 7), dtype=complex)
-        nstd = npy.zeros(shape=(fpoints), dtype=npy.float)
+        nstd = npy.zeros(shape=(fpoints), dtype=float)
 
         def t2s_single(t):
             return t2s(t[npy.newaxis,:,:])[0]

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -66,7 +66,7 @@ class Deembedding(ABC):
     """
 
     def __init__(self, dummies, name=None, *args, **kwargs):
-        """
+        r"""
         De-embedding Initializer
 
         Notes

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -2,11 +2,11 @@ import unittest
 import os
 import warnings
 import pickle
+
 import skrf as rf
 import numpy as npy
 from numpy.random  import rand, uniform
-from nose.tools import nottest
-from nose.plugins.skip import SkipTest
+import pytest
 
 from skrf.calibration import OnePort, PHN, SDDL, TRL, SOLT, UnknownThru, EightTerm, TwoPortOnePath, EnhancedResponse,TwelveTerm, SixteenTerm, LMR16, terminate, determine_line, determine_reflect, NISTMultilineTRL
 
@@ -171,7 +171,6 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
 
 class SDDLTest(OnePortTest):
     def setUp(self):
-        #raise SkipTest('Doesnt work yet')
         self.n_ports = 1
         #Exact only with a lossless waveguide
         self.wg = WG_lossless
@@ -228,15 +227,17 @@ class SDDLTest(OnePortTest):
             )
         self.cal.run()
     
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs(self):
-        raise SkipTest('not applicable ')
+        pass
+
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs_ntwks(self):
-        raise SkipTest('not applicable ')
+        pass
 
 
 class SDDLWeikle(OnePortTest):
     def setUp(self):
-        #raise SkipTest('Doesnt work yet')
         self.n_ports = 1
         #Exact only with a lossless waveguide
         self.wg = WG_lossless
@@ -265,10 +266,13 @@ class SDDLWeikle(OnePortTest):
             measured = measured,
             )
     
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs(self):
-        raise SkipTest('not applicable ')
+        pass
+
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs_ntwks(self):
-        raise SkipTest('not applicable ')
+        pass
 
 
 class SDDMTest(OnePortTest):
@@ -306,14 +310,16 @@ class SDDMTest(OnePortTest):
             measured = measured,
             )
     
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs(self):
-        raise SkipTest('not applicable ')
+        pass
     
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs_ntwks(self):
-        raise SkipTest('not applicable ')
+        pass
 
 
-@SkipTest
+@pytest.mark.skip()
 class PHNTest(OnePortTest):
     """
     """
@@ -357,10 +363,13 @@ class PHNTest(OnePortTest):
         self.assertEqual(self.actuals[0], self.cal.ideals[0])
         self.assertEqual(self.actuals[1], self.cal.ideals[1])
             
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs(self):
-        raise SkipTest('not applicable')
+        pass
+
+    @pytest.mark.skip(reason='not applicable ')
     def test_from_coefs_ntwks(self):
-        raise SkipTest('not applicable ')
+        pass
 
 
 class EightTermTest(unittest.TestCase, CalibrationTest):
@@ -723,9 +732,9 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
             self.assertTrue(all(npy.abs(self.cal.coefs[k] - self.cal_shift.coefs[k]) < 1e-9))
 
 
+@pytest.mark.skip()
 class TREightTermTest(unittest.TestCase, CalibrationTest):
     def setUp(self):
-        raise SkipTest()
         self.n_ports = 2
         self.wg = WG
         wg= self.wg
@@ -1063,10 +1072,10 @@ class TwoPortOnePathTest(TwelveTermTest):
         f = self.cal.embed(a)
         r = self.cal.embed(a.flipped())
         self.assertEqual(self.cal.apply_cal((f,r)),a)
-        
+    
+    @pytest.mark.skip(reason='measurement procedure is different so this test doesnt apply')
     def test_embed_equal_measure(self):
-        # measurement procedure is different so this test doesnt apply
-        raise SkipTest()
+        pass
 
     @suppress_warning_decorator("n_thrus is None")
     def test_from_coefs(self):
@@ -1077,23 +1086,29 @@ class TwoPortOnePathTest(TwelveTermTest):
     def test_from_coefs_ntwks(self):
         cal_from_coefs = self.cal.from_coefs_ntwks(self.cal.coefs_ntwks)
 
+    @pytest.mark.skip()
     def test_reverse_source_match_accuracy(self):
-        raise SkipTest()   
+        pass
     
+    @pytest.mark.skip()
     def test_reverse_directivity_accuracy(self):
-        raise SkipTest()      
-    
-    def test_reverse_load_match_accuracy(self):
-        raise SkipTest()  
-    
-    def test_reverse_reflection_tracking_accuracy(self):
-        raise SkipTest()  
-    
-    def test_reverse_transmission_tracking_accuracy(self):
-        raise SkipTest()  
+        pass
 
+    @pytest.mark.skip()
+    def test_reverse_load_match_accuracy(self):
+        pass  
+    
+    @pytest.mark.skip()
+    def test_reverse_reflection_tracking_accuracy(self):
+        pass  
+    
+    @pytest.mark.skip()
+    def test_reverse_transmission_tracking_accuracy(self):
+        pass  
+
+    @pytest.mark.skip()
     def test_convert_12term_2_8term_correction_accuracy(self):
-        raise SkipTest()
+        pass
 
 
 class UnknownThruTest(EightTermTest):

--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -523,7 +523,7 @@ class Frequency(object):
 
     @property
     def w(self) -> npy.ndarray:
-        """
+        r"""
         Angular frequency in radians/s.
         
         Angular frequency is defined as :math:`\omega=2\pi f` [#]_

--- a/skrf/io/csv.py
+++ b/skrf/io/csv.py
@@ -60,7 +60,7 @@ from warnings import warn
 # from pandas import Series, Index, DataFrame
 
 def read_pna_csv(filename, *args, **kwargs):
-    """
+    r"""
     Reads data from a csv file written by an Agilient PNA.
 
     This function returns a triplet containing the header, comments,
@@ -290,7 +290,7 @@ class AgilentCSV(object):
 
     """
     def __init__(self, filename, *args, **kwargs):
-        """
+        r"""
         Init.
 
         Parameters
@@ -711,7 +711,7 @@ def pna_csv_2_scalar_ntwks(filename, *args, **kwargs):
 
 
 def read_zva_dat(filename, *args, **kwargs):
-    """
+    r"""
     Reads data from a dat file written by a R&S ZVA in dB/deg or re/im format.
 
     This function returns a triplet containing header, comments and data.
@@ -854,7 +854,7 @@ def read_all_zva_dat(dir='.', contains = None):
 
 
 def read_vectorstar_csv(filename, *args, **kwargs):
-    """
+    r"""
     Reads data from a csv file written by an Anritsu VectorStar.
 
     Parameters

--- a/skrf/io/tests/test_csv.py
+++ b/skrf/io/tests/test_csv.py
@@ -1,11 +1,11 @@
 
 import unittest
+import pytest
 import os
 import numpy as npy
 
 import skrf as rf
 
-from nose.plugins.skip import SkipTest
 from skrf.util import suppress_warning_decorator
 
 class AgilentCSVTestCase(unittest.TestCase):
@@ -29,7 +29,8 @@ class AgilentCSVTestCase(unittest.TestCase):
         self.assertEqual(self.acsv.columns, ['Freq(Hz)', '"A,1"(REAL)',
                                              '"A,1"(IMAG)', '"R1,1"(REAL)',
                                              '"R1,1"(IMAG)'])
-    @SkipTest # unicode error with carrage returns for p3 vs p2
+
+    @pytest.mark.skip(reason='unicode error with carrage returns for p3 vs p2')
     def test_comments(self):
         """ 
         This tests reading of comment lines in the test file.

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -4,6 +4,7 @@ import os
 import numpy as npy
 
 import skrf as rf
+from skrf.io import Touchstone
 
 
 class IOTestCase(unittest.TestCase):
@@ -162,5 +163,5 @@ class IOTestCase(unittest.TestCase):
         """
 
         given = {'p1': ('.03', ''), 'p2': ('0.03', ''), 'p3': ('100', ''), 'p4': ('2.5', 'um')}
-        actual = rf.io.Touchstone(self.ntwk_comments_file).get_comment_variables()
+        actual = Touchstone(self.ntwk_comments_file).get_comment_variables()
         self.assertEqual(given, actual)

--- a/skrf/media/tests/README.rst
+++ b/skrf/media/tests/README.rst
@@ -4,9 +4,9 @@ skrf.media tests
 
 Running Tests
 -----------------
-These tests are most easily run using nosetests, like so ::
+These tests are most easily run using pytest, like so ::
     
-    nosetests skrf/media/tests/
+    pytest skrf/media/tests/
 
 Using QUCS for test-cases
 --------------------------

--- a/skrf/media/tests/test_all_construction.py
+++ b/skrf/media/tests/test_all_construction.py
@@ -4,8 +4,10 @@ of all general circuit components
 
 """
 import unittest
-import skrf as rf
 from scipy.constants import *
+
+import skrf as rf
+from skrf.media import Freespace, CPW, RectangularWaveguide, DistributedCircuit
 
 
 class MediaTestCase():
@@ -79,7 +81,7 @@ class MediaTestCase():
 class FreespaceTestCase(MediaTestCase, unittest.TestCase):
     def setUp(self):
         self.frequency = rf.Frequency(75,110,101,'ghz')
-        self.media = rf.media.Freespace(self.frequency)
+        self.media = Freespace(self.frequency)
 
     def test_Z0_value(self):
         self.assertEqual(round(\
@@ -89,7 +91,7 @@ class FreespaceTestCase(MediaTestCase, unittest.TestCase):
 class CPWTestCase(MediaTestCase, unittest.TestCase):
     def setUp(self):
         self.frequency = rf.Frequency(75,110,101,'ghz')
-        self.media = rf.media.CPW(\
+        self.media = CPW(\
             frequency=self.frequency,
             w=10e-6,
             s=5e-6,
@@ -101,7 +103,7 @@ class CPWTestCase(MediaTestCase, unittest.TestCase):
 class RectangularWaveguideTestCase(MediaTestCase, unittest.TestCase):
     def setUp(self):
         self.frequency = rf.Frequency(75,110,101,'ghz')
-        self.media = rf.media.RectangularWaveguide(\
+        self.media = RectangularWaveguide(\
             frequency=self.frequency,
             a=100*mil,
             )
@@ -110,7 +112,7 @@ class RectangularWaveguideTestCase(MediaTestCase, unittest.TestCase):
 class DistributedCircuitTestCase(MediaTestCase, unittest.TestCase):
     def setUp(self):
         self.frequency = rf.Frequency(75,110,101,'ghz')
-        self.media = rf.media.DistributedCircuit(\
+        self.media = DistributedCircuit(\
             frequency=self.frequency,
             L=1,C=1,R=0,G=0
             )

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3507,12 +3507,12 @@ class Network(object):
     def _P(self, p: int) -> npy.ndarray:  # (27) (28)
         n = self.nports
 
-        Pda = npy.zeros((p, 2 * n), dtype=npy.bool)
-        Pdb = npy.zeros((p, 2 * n), dtype=npy.bool)
-        Pca = npy.zeros((p, 2 * n), dtype=npy.bool)
-        Pcb = npy.zeros((p, 2 * n), dtype=npy.bool)
-        Pa = npy.zeros((n - 2 * p, 2 * n), dtype=npy.bool)
-        Pb = npy.zeros((n - 2 * p, 2 * n), dtype=npy.bool)
+        Pda = npy.zeros((p, 2 * n), dtype=bool)
+        Pdb = npy.zeros((p, 2 * n), dtype=bool)
+        Pca = npy.zeros((p, 2 * n), dtype=bool)
+        Pcb = npy.zeros((p, 2 * n), dtype=bool)
+        Pa = npy.zeros((n - 2 * p, 2 * n), dtype=bool)
+        Pb = npy.zeros((n - 2 * p, 2 * n), dtype=bool)
         for l in npy.arange(p):
             Pda[l, 4 * (l + 1) - 3 - 1] = True
             Pca[l, 4 * (l + 1) - 1 - 1] = True
@@ -3526,8 +3526,8 @@ class Network(object):
     def _Q(self) -> npy.ndarray:  # (29) error corrected
         n = self.nports
 
-        Qa = npy.zeros((n, 2 * n), dtype=npy.bool)
-        Qb = npy.zeros((n, 2 * n), dtype=npy.bool)
+        Qa = npy.zeros((n, 2 * n), dtype=bool)
+        Qb = npy.zeros((n, 2 * n), dtype=bool)
         for l in npy.arange(n):
             Qa[l, 2 * (l + 1) - 1 - 1] = True
             Qb[l, 2 * (l + 1) - 1] = True

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -943,7 +943,7 @@ class NetworkSet(object):
 
 def func_on_networks(ntwk_list, func, attribute='s',name=None, *args,\
         **kwargs):
-    """
+    r"""
     Applies a function to some attribute of a list of networks.
 
 
@@ -992,7 +992,7 @@ fon = func_on_networks
 
 
 def getset(ntwk_dict, s, *args, **kwargs):
-    """
+    r"""
     Creates a :class:`NetworkSet`, of all :class:`~skrf.network.Network`s
     objects in a dictionary that contain `s` in its key. This is useful
     for dealing with the output of

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -325,9 +325,9 @@ def smith(smithR: Number = 1, chart_type: str = 'z', draw_labels: bool = False,
 
             #Annotate 0 and inf
             if y_flip_sign == 1:  # z and zy charts
-                label_left, label_right = '0.0', '$\infty$'
+                label_left, label_right = '0.0', r'$\infty$'
             else:  # y and yz charts
-                label_left, label_right = '$\infty$', '0.0'
+                label_left, label_right = r'$\infty$', '0.0'
             ax1.annotate(label_left, xy=(-1.02, 0), xytext=(-1.02, 0),
                              ha = "right", va = "center")
             ax1.annotate(label_right, xy=(radialScaleFactor, 0), xytext=(radialScaleFactor, 0),

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -808,7 +808,7 @@ class CircuitTestGraph(unittest.TestCase):
     """
     def test_is_networkx_available(self):
         'The networkx package should be available to run these tests'
-        self.failUnless('networkx' in sys.modules)
+        self.assertTrue('networkx' in sys.modules)
 
     def setUp(self):
         """
@@ -838,15 +838,15 @@ class CircuitTestGraph(unittest.TestCase):
     def test_intersection_dict(self):
         inter_dict = self.C.intersections_dict
         # should have 3 intersections
-        self.assert_(len(inter_dict) == 3)
+        self.assertTrue(len(inter_dict) == 3)
         # All intersections should have at least 2 edges
         for it in inter_dict.items():
             k, cnx = it
-            self.assert_(len(cnx) >= 2)
+            self.assertTrue(len(cnx) >= 2)
 
     def test_edge_labels(self):
         edge_labels = self.C.edge_labels
-        self.assert_(len(edge_labels) == 7)
+        self.assertTrue(len(edge_labels) == 7)
 
 
 class CircuitTestComplexCharacteristicImpedance(unittest.TestCase):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1,3 +1,4 @@
+import pytest
 from skrf.frequency import InvalidFrequencyWarning
 import unittest
 import os
@@ -10,7 +11,6 @@ from pathlib import Path
 import pickle
 import skrf as rf
 from copy import deepcopy
-from nose.plugins.skip import SkipTest
 import warnings
 
 from skrf import setup_pylab
@@ -288,8 +288,8 @@ class NetworkTestCase(unittest.TestCase):
         d=rf.connect(a,0,b,0,3)
         self.assertTrue((d.z0==[4,13]).all())
 
+    @pytest.mark.skip(reason="not supporting this function currently ")
     def test_connect_fast(self):
-        raise SkipTest('not supporting this function currently ')
         self.assertEqual(rf.connect_fast(self.ntwk1, 1, self.ntwk2, 0) , \
             self.ntwk3)
 

--- a/skrf/tests/test_networkSet.py
+++ b/skrf/tests/test_networkSet.py
@@ -185,6 +185,7 @@ class NetworkSetTestCase(unittest.TestCase):
         # using a name        
         ns.name = 'testing'
         ns.write()  # write 'testing.ns'
+        os.remove('testing.ns')
         
     def test_write_spreadsheet(self):
         """
@@ -196,8 +197,10 @@ class NetworkSetTestCase(unittest.TestCase):
         # passing a name
         ns.name = 'testing'
         ns.write_spreadsheet()  # write 'testing.xlsx'
+        os.remove('testing.xlsx')
         # passing a filename
         ns.write_spreadsheet(file_name='testing2.xlsx')
+        os.remove('testing2.xlsx')
         
     def test_ntwk_attr_2_df(self):
         """

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1196,7 +1196,7 @@ class VectorFitting:
 
         # plot the frequency response of each singular value
         for n in range(n_ports):
-            ax.plot(freqs, singvals[n, :], label='$\sigma_{}$'.format(n + 1))
+            ax.plot(freqs, singvals[n, :], label=r'$\sigma_{}$'.format(n + 1))
         ax.set_xlabel('Frequency (Hz)')
         ax.set_ylabel('Magnitude')
         ax.legend(loc='best')

--- a/skrf/vi/tests/test_pna.py
+++ b/skrf/vi/tests/test_pna.py
@@ -1,13 +1,13 @@
 
 from numpy.testing import dec
 import unittest
-from nose.plugins.skip import SkipTest, Skip
+import pytest
 import skrf 
 
 try:
     from skrf.vi.vna import PNA
 except:
-    raise SkipTest('visa failed to import, skipping')
+    pytest.skip("visa failed to import, skipping")
 
 class PNATest(unittest.TestCase):
     def setUp(self):

--- a/skrf/vi/tests/test_sa.py
+++ b/skrf/vi/tests/test_sa.py
@@ -1,13 +1,14 @@
 
 from numpy.testing import dec
 import unittest
-from nose.plugins.skip import SkipTest, Skip
+
+import pytest
 import skrf 
 
 try:
     from skrf.vi.sa import HP8500
 except:
-    raise SkipTest('visa failed to import, skipping')
+    pytest.skip("visa failed to import, skipping")
 
 class HP8500Test(unittest.TestCase):
     def setUp(self):

--- a/skrf/vi/tests/test_vectorstar.py
+++ b/skrf/vi/tests/test_vectorstar.py
@@ -1,13 +1,13 @@
 
 from numpy.testing import dec
 import unittest
-from nose.plugins.skip import SkipTest, Skip
+import pytest
 import skrf 
 
 try:
     from skrf.vi.vna import VectorStar
 except:
-    raise SkipTest('visa failed to import, skipping')
+    pytest.skip("visa failed to import, skipping")
 
 class VectorStarTestCase(unittest.TestCase):
     def setUp(self):

--- a/tools/travis-requirements.txt
+++ b/tools/travis-requirements.txt
@@ -1,5 +1,4 @@
 
 xlwt-future>=0.8.0
 xlrd>=0.6.1
-nose-exclude
 coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py36, py37, py38, py39, py310
+
+[testenv]
+deps = 
+    pytest
+    pytest-cov
+    ipython
+
+commands =
+    pytest {posargs}
+
+[pytest]
+testpaths = 
+    skrf
+addopts = "--cov=skrf"
+norecursedirs = 
+    skrf/vi
+    skrf/src
+
+# Notebooks to skip when running smoke tests with nbsmoke
+nbsmoke_skip_run = ^doc/source/examples/instrumentcontrol/.*$
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-cov
     ipython
+    nbsmoke
 
 commands =
     pytest {posargs}


### PR DESCRIPTION
#558 mentions issues with nose and Python3.10, so this PR prepares the tests for pytest.

One could run the tests 'pytest' for one python version or simply run 'tox' for all installed versions.

@jhillairet could you double check if this is fine, especially with GH Actions?
