### PR TITLE
Fix DefinedAEpTandZ0 example

### DIFF
--- a/doc/source/examples/networktheory/DefinedAEpTandZ0 media example.ipynb
+++ b/doc/source/examples/networktheory/DefinedAEpTandZ0 media example.ipynb
@@ -119,15 +119,17 @@
    "outputs": [],
    "source": [
     "#Make the missing reflect measurement\n",
-    "#Reflect only affects sign of the corrected\n",
+    "#This is possible because we already have existing calibration\n",
+    "#and know what the open measurement would look like at the reference plane\n",
+    "#'refl_offset' needs to be set to -half_thru - connector_length.\n",
     "reflect = TL100.copy()\n",
     "reflect.s[:,0,0] = 1\n",
     "reflect.s[:,1,1] = 1\n",
     "reflect.s[:,1,0] = 0\n",
     "reflect.s[:,0,1] = 0\n",
     "\n",
-    "# Perform NISTMultilineTRL algorithm\n",
-    "cal = rf.NISTMultilineTRL([TL100, reflect, TL200], [1], [100e-3, 200e-3], er_est=3.0, refl_offset=[0])\n",
+    "# Perform NISTMultilineTRL algorithm. Reference plane is at the center of the thru.\n",
+    "cal = rf.NISTMultilineTRL([TL100, reflect, TL200], [1], [0, 100e-3], er_est=3.0, refl_offset=[-56e-3])\n",
     "\n",
     "plt.figure()\n",
     "plt.title('Corrected lines')\n",
@@ -271,7 +273,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Connector + thru plots shows a reasonable agreement between calibration results and model. There is a phase jump in the calibration results."
+    "Connector + thru plots shows a reasonable agreement between calibration results and model."
    ]
   },
   {
@@ -335,7 +337,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -349,9 +351,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This example had a same problem as the one I fixed in PR #555 caused by PR #553. Explicitly set the TRL reference plane to center of thru to match the existing behaviour. Also fix the phase offset in calibration by setting the correct reflect offset.