### PR TITLE
Warn users about future change of 'extrapolate_to_dc' default value from rational to cubic

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2671,8 +2671,9 @@ class Network(object):
         # freq = Frequency.from_f(f,**kwargs)
         # self.interpolate_self(freq, **interp_kwargs)
 
-    def extrapolate_to_dc(self, points: int = None, dc_sparam: NumberLike = None, kind: str = 'rational',
-            coords: str = 'cart', **kwargs) -> 'Network':
+    def extrapolate_to_dc(self, points: int = None, dc_sparam: NumberLike = None, 
+                          kind: str = 'warn', coords: str = 'cart',
+                          **kwargs) -> 'Network':
         """
         Extrapolate S-parameters down to 0 Hz and interpolate to uniform spacing.
 
@@ -2691,7 +2692,7 @@ class Network(object):
         dc_sparam : class:`npy.ndarray` or None
             NxN S-parameters matrix at 0 Hz.
             If None S-parameters at 0 Hz are determined by linear extrapolation.
-        kind : str or int
+        kind : str or int, default is 'rational'
             Specifies the kind of interpolation as a string ('linear',
             'nearest', 'zero', 'slinear', 'quadratic, 'cubic') or
             as an integer specifying the order of the spline
@@ -2717,6 +2718,13 @@ class Network(object):
         impulse_response
         step_response
         """
+        if kind == 'warn':
+            warnings.warn("The default `kind` parameter will change "
+                          "from `rational` to `cubic` in future version."
+                          "Use `kind='rational'` to keep the old default."
+                          "To silent this warning, explitly define `kind`.")
+            kind = 'rational'
+        
         result = self.copy()
 
         if self.frequency.f[0] == 0:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2720,9 +2720,10 @@ class Network(object):
         """
         if kind == 'warn':
             warnings.warn("The default `kind` parameter will change "
-                          "from `rational` to `cubic` in future version."
+                          "from `rational` to `cubic` in future versions."
                           "Use `kind='rational'` to keep the old default."
-                          "To silent this warning, explitly define `kind`.")
+                          "To silent this warning, explitly define `kind`.",
+                          category=DeprecationWarning, stacklevel=2)
             kind = 'rational'
         
         result = self.copy()

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2693,6 +2693,7 @@ class Network(object):
             NxN S-parameters matrix at 0 Hz.
             If None S-parameters at 0 Hz are determined by linear extrapolation.
         kind : str or int, default is 'rational'
+            Default value will be changed to 'cubic' in future version.
             Specifies the kind of interpolation as a string ('linear',
             'nearest', 'zero', 'slinear', 'quadratic, 'cubic') or
             as an integer specifying the order of the spline


### PR DESCRIPTION
Fixes #522. 

Keep the default value to `rational`, but warns users this choice is now considered as deprecated and will be changed to `cubic` by default in future versions.