### PR TITLE
Allow to calculate step/impulse response from multiports

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3549,7 +3549,7 @@ class Network(object):
         return Xi_tilde[:, :n, :n], Xi_tilde[:, :n, n:], Xi_tilde[:, n:, :n], Xi_tilde[:, n:, n:]
 
     def impulse_response(self, window: str = 'hamming', n: int = None, pad: int = 1000,
-                        bandpass: bool = None) -> Tuple[npy.ndarray, npy.ndarray]:
+                        bandpass: bool = None, squeeze: bool = True) -> Tuple[npy.ndarray, npy.ndarray]:
         """Calculates time-domain impulse response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
@@ -3591,8 +3591,6 @@ class Network(object):
             step_response
             extrapolate_to_dc
         """
-        if self.nports != 1:
-            raise ValueError('Only one-ports are supported')
         if n is None:
             # Use zero-padding specification. Note that this does not allow n odd.
             n = 2 * (self.frequency.npoints + pad - 1)
@@ -3610,9 +3608,14 @@ class Network(object):
             w = self.windowed(window=window, normalize=False, center_to_dc=center_to_dc)
         else:
             w = self
-        return t, mf.irfft(w.s, n=n).ravel()
 
-    def step_response(self, window: str = 'hamming', n: int = None, pad: int = 1000) -> Tuple[npy.ndarray, npy.ndarray]:
+        ir = mf.irfft(w.s, n=n)
+        if squeeze:
+            ir = ir.squeeze()
+
+        return t, ir
+
+    def step_response(self, window: str = 'hamming', n: int = None, pad: int = 1000, squeeze: bool = True) -> Tuple[npy.ndarray, npy.ndarray]:
         """Calculates time-domain step response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
@@ -3665,8 +3668,8 @@ class Network(object):
                 RuntimeWarning
             )
 
-        t, y = self.impulse_response(window=window, n=n, pad=pad, bandpass=False)
-        return t, npy.cumsum(y)
+        t, y = self.impulse_response(window=window, n=n, pad=pad, bandpass=False, squeeze=squeeze)
+        return t, npy.cumsum(y, axis=0)
 
     # Network Active s/z/y/vswr parameters
     def s_active(self, a: npy.ndarray) -> npy.ndarray:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3578,6 +3578,11 @@ class Network(object):
                 If True full window is used and low frequencies are attenuated.
                 If None value is determined automatically based on if the
                 frequency vector begins from 0.
+        squeeze: bool
+                Squeeze impulse response to one dimension, 
+                if a oneport gets transformed.
+                Has no effect when transforming a multiport.
+                Default = True
 
         Returns
         -------
@@ -3637,6 +3642,11 @@ class Network(object):
         pad : int
                 Number of zeros to add as padding for FFT.
                 Adding more zeros improves accuracy of peaks.
+        squeeze: bool
+                Squeeze step response to one dimension, 
+                if a oneport gets transformed.
+                Has no effect when transforming a multiport.
+                Default = True
 
         Returns
         -------

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -129,7 +129,7 @@ class NetworkTestCase(unittest.TestCase):
         y1 = npy.zeros((1000, dut_dc.nports, dut_dc.nports))
 
         for (i,j) in dut_dc.port_tuples:
-            oneport = getattr(dut_dc, 's{0}{1}'.format(i+1, j+1))
+            oneport = getattr(dut_dc, f's{i+1}{j+1}')
             t1, y1[:,i,j] = oneport.step_response(n=1000)
 
         t2, y2 = dut_dc.step_response(n=1000)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1,3 +1,4 @@
+from numpy.core.fromnumeric import squeeze
 import pytest
 from skrf.frequency import InvalidFrequencyWarning
 import unittest
@@ -125,8 +126,16 @@ class NetworkTestCase(unittest.TestCase):
     def test_time_transform_multiport(self):
         dut_dc = self.ntwk1.extrapolate_to_dc()
 
-        with self.assertRaises(ValueError):
-            t, y = dut_dc.step_response()
+        y1 = npy.zeros((1000, dut_dc.nports, dut_dc.nports))
+
+        for (i,j) in dut_dc.port_tuples:
+            oneport = getattr(dut_dc, 's{0}{1}'.format(i+1, j+1))
+            t1, y1[:,i,j] = oneport.step_response(n=1000)
+
+        t2, y2 = dut_dc.step_response(n=1000)
+
+        assert npy.allclose(t1, t2)
+        assert npy.allclose(y1, y2)
 
     def test_constructor_empty(self):
         rf.Network()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -139,10 +139,10 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_time_transform_squeeze(self):
         dut_dc = self.ntwk1.extrapolate_to_dc()
-        assert dut_dc.s11.impulse_response()[1].ndim == 1
-        assert dut_dc.s11.impulse_response(squeeze=False)[1].ndim == 3
-        assert dut_dc.impulse_response()[1].ndim == 3
-        assert dut_dc.impulse_response(squeeze=False)[1].ndim == 3
+        assert dut_dc.s11.step_response()[1].ndim == 1
+        assert dut_dc.s11.step_response(squeeze=False)[1].ndim == 3
+        assert dut_dc.step_response()[1].ndim == 3
+        assert dut_dc.step_response(squeeze=False)[1].ndim == 3
 
     def test_constructor_empty(self):
         rf.Network()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -133,9 +133,9 @@ class NetworkTestCase(unittest.TestCase):
             t1, y1[:,i,j] = oneport.step_response(n=1000)
 
         t2, y2 = dut_dc.step_response(n=1000)
-
-        assert npy.allclose(t1, t2)
-        assert npy.allclose(y1, y2)
+        
+        npy.testing.assert_almost_equal(t1, t2)
+        npy.testing.assert_almost_equal(y1, y2)
 
     def test_time_transform_squeeze(self):
         dut_dc = self.ntwk1.extrapolate_to_dc()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -137,6 +137,13 @@ class NetworkTestCase(unittest.TestCase):
         assert npy.allclose(t1, t2)
         assert npy.allclose(y1, y2)
 
+    def test_time_transform_squeeze(self):
+        dut_dc = self.ntwk1.extrapolate_to_dc()
+        assert dut_dc.s11.impulse_response()[1].ndim == 1
+        assert dut_dc.s11.impulse_response(squeeze=False)[1].ndim == 3
+        assert dut_dc.impulse_response()[1].ndim == 3
+        assert dut_dc.impulse_response(squeeze=False)[1].ndim == 3
+
     def test_constructor_empty(self):
         rf.Network()
 


### PR DESCRIPTION
With this PR I want to get rid of loops when calculating the time responses of bigger networks.