### PR TITLE
Fix/dc extrapolation array

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -2610,22 +2610,22 @@ class NISTMultilineTRL(EightTerm):
 
             Assumes TEM mode and conductance/length to be zero.
 
-            If `c0` == `z0_line` == None, the characteristic impedance is not renormalized.
+            If `c0` == `z0_line` is None, the characteristic impedance is not renormalized.
             In this case reference impedance of the calibration is characteristic
             impedance of the transmission lines.
 
         z0_ref : None, complex or list of complex
             New reference impedance for the characteristic impedance renormalizarion.
 
-            No effect if `c0` == None and `z0_line` == None.
+            No effect if `c0` is None and `z0_line` is None.
 
-            If `z0_ref` == None, no renormalization is done.
+            If `z0_ref` is None, no renormalization is done.
 
         z0_line : None, complex or list of complex
             Characteristic impedance of the transmission lines. Used for reference
             impedance renormalization.
 
-            If `z0` == `z0_line` == None, the characteristic impedance is not renormalized.
+            If `z0` == `z0_line` is None, the characteristic impedance is not renormalized.
             In this case reference impedance of the calibration is characteristic
             impedance of the transmission lines.
 
@@ -2650,7 +2650,7 @@ class NISTMultilineTRL(EightTerm):
         except TypeError:
             self.Grefls = [self.Grefls]
 
-        if self.refl_offset == None:
+        if self.refl_offset is None:
             self.refl_offset = [0]*len(self.Grefls)
 
         try:
@@ -3093,7 +3093,7 @@ class NISTMultilineTRL(EightTerm):
                         embedded = t2s_single(T1.dot(ideal).dot(g.dot(inv(T2).dot(g))))
 
                         error += npy.sum(abs(embedded - meas))
-                    if best_error == None or error < best_error:
+                    if best_error is None or error < best_error:
                         best_error = error
                         best_values = v
                 B1, B2, CoA1, CoA2 = best_values[1:]
@@ -4736,7 +4736,7 @@ class LMR16(SixteenTerm):
         T3 = []
         T4 = []
 
-        auto_sign = self.sign == None
+        auto_sign = self.sign is None
 
         for f in range(fLength):
             ma = mList[0][f] #Through
@@ -4765,7 +4765,7 @@ class LMR16(SixteenTerm):
 
             for sign_tries in [0,1,2]:
                 gt = self.sign*npy.sqrt(m*o/(n*p))
-                if self.through == None:
+                if self.through is None:
                     g = self.reflect.s[f][0,0]
                     t = g/gt
                     self._solved_through.s[f] = npy.array([[0,t],[t,0]])

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -151,7 +151,7 @@ class Touchstone:
             line = line.split('!', 1)
             if len(line) == 2:
                 if not self.parameter:
-                    if self.comments == None:
+                    if self.comments is None:
                         self.comments = ''
                     self.comments = self.comments + line[1]
                 elif line[1].startswith(' Port['):

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2733,10 +2733,10 @@ class Network(object):
         if self.frequency.f[0] == 0:
             return result
 
-        if points == None:
+        if points is None:
             fstep = self.frequency.f[1] - self.frequency.f[0]
             points = len(self) + int(round(self.frequency.f[0]/fstep))
-        if dc_sparam == None:
+        if dc_sparam is None:
             #Interpolate DC point alone first using linear interpolation, because
             #interp1d can't extrapolate with other methods.
             #TODO: Option to enforce passivity
@@ -2827,9 +2827,9 @@ class Network(object):
         cropped
 
         """
-        if f_start == None:
+        if f_start is None:
             f_start = -npy.inf
-        if f_stop == None:
+        if f_stop is None:
             f_stop = npy.inf
 
         if f_stop<f_start:
@@ -3187,7 +3187,7 @@ class Network(object):
 
         """
 
-        if center_to_dc == None:
+        if center_to_dc is None:
             center_to_dc = self.frequency.f[0] == 0
 
         if center_to_dc:
@@ -4909,7 +4909,7 @@ def three_twoports_2_threeport(ntwk_triplet: Sequence[Network], auto_order:bool 
     ntwk_list = [s11, s12, s13, s21, s22, s23, s31, s32, s33]
 
     for k in range(len(ntwk_list)):
-        if ntwk_list[k] == None:
+        if ntwk_list[k] is None:
             frequency = ntwk_triplet[0].frequency
             s = npy.zeros((len(ntwk_triplet[0]), 1, 1))
             ntwk_list[k] = Network(s=s, frequency=frequency)

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -165,7 +165,7 @@ def smith(smithR: Number = 1, chart_type: str = 'z', draw_labels: bool = False,
 
     """
     ##TODO: fix this function so it doesnt suck
-    if ax == None:
+    if ax is None:
         ax1 = plt.gca()
     else:
         ax1 = ax
@@ -1346,7 +1346,7 @@ def plot_passivity(self, port=None, label_prefix=None, *args, **kwargs):
     else:
         ports = [port]
     for k in ports:
-        if label_prefix == None:
+        if label_prefix is None:
             label = name + ', port %i' % (k + 1)
         else:
             label = label_prefix + ', port %i' % (k + 1)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -810,6 +810,11 @@ class NetworkTestCase(unittest.TestCase):
         s11 = ntwk.s11
         s11_dc = s11.extrapolate_to_dc(kind='cubic')
 
+    def test_dc_extrapolation_dc_sparam(self):
+        zeros = npy.zeros((self.ntwk1.nports, self.ntwk1.nports))
+        net_dc = self.ntwk1.extrapolate_to_dc(dc_sparam=zeros)
+        net_dc = self.ntwk1.extrapolate_to_dc(dc_sparam=zeros.tolist())
+
     def test_noise_deembed(self):
 
 


### PR DESCRIPTION
`extrapolate_to_dc` was not able to handle a numpy array for `dc_s_param`. This patch fixes the comparison against None in this case and in several other files.