### PR TITLE
Speed up X property of Circuit class

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -98,7 +98,7 @@ if TYPE_CHECKING:
     from .frequency import Frequency
 
 
-class Circuit():
+class Circuit:
     """
     Creates a circuit made of a set of N-ports networks.
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -83,7 +83,6 @@ Graph representation
    Circuit.edge_labels
 
 """
-from numbers import Number
 from . network import Network, a2s
 from . media import media
 from . constants import INF, NumberLike
@@ -96,9 +95,8 @@ except ImportError as e:
     pass
 
 from itertools import chain, product
-from scipy.linalg import block_diag
 
-from typing import Iterable, List, TYPE_CHECKING, Tuple
+from typing import List, TYPE_CHECKING, Tuple
 
 
 if TYPE_CHECKING:

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -742,31 +742,15 @@ class Circuit():
         ----
         There is a numerical bottleneck in this function,
         when creating the block diagonal matrice [X] from the [X]_k matrices.
-        The difficulty comes from the fact that the shape of each [X]_k
-        matrix is `fxnxn`, so there is a loop over the frequencies
-        to create f times a block matrix [X]. I am still looking for a
-        vectorized implementation but didn't find it.
-
         """
-        # Xk = []
-        # for cnx in self.connections:
-        #     Xk.append(self._Xk(cnx))
-        # Xk = np.array(Xk)
-
-        # #X = np.zeros(len(C.frequency), )
-        # Xf = []
-        # for (idx, f) in enumerate(self.frequency):
-        #     Xf.append(block_diag(*Xk[:,idx,:]))
-        # return np.array(Xf)  # shape: (nb_frequency, nb_inter*nb_n, nb_inter*nb_n)
-
-        # Slightly faster version
         Xks = [self._Xk(cnx) for cnx in self.connections]
 
         Xf = np.zeros((len(self.frequency), self.dim, self.dim), dtype='complex')
-        # TODO: avoid this for loop which is a bottleneck for large frequencies
-        for idx in np.nditer(np.arange(len(self.frequency))):
-            mat_list = [Xk[idx,:] for Xk in Xks]
-            Xf[idx,:] = block_diag(*mat_list)  # bottleneck
+        off = np.array([0, 0])
+        for Xk in Xks:
+            Xf[:, off[0]:off[0] + Xk.shape[1], off[1]:off[1]+Xk.shape[2]] = Xk
+            off += Xk.shape[1:]
+        
         return Xf
 
     @property

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -541,7 +541,12 @@ class Circuit:
         # is not installed.
         G = self.G
 
-        return nx.algorithms.components.is_connected(G)
+        try:
+            import networkx as nx
+            return nx.algorithms.components.is_connected(G)
+        except ImportError as e:
+            raise ImportError('networkx package as not been installed and is required. ')
+
 
     @property
     def intersections_dict(self) -> dict:

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -89,11 +89,6 @@ from . constants import INF, NumberLike
 
 import numpy as np
 
-try:
-    import networkx as nx
-except ImportError as e:
-    pass
-
 from itertools import chain, product
 
 from typing import List, TYPE_CHECKING, Tuple


### PR DESCRIPTION
Do not iterate over the frequencies but over the connections, which are usually much less.
Related to #574 

I verified the performance gain with the following snippet:

``` python
from os import setgroups
import skrf as rf
import numpy as np
import perfplot
from scipy.linalg import block_diag

def X_new(self) -> np.ndarray:
    """
    Return the concatenated intersection matrix [X] of the circuit.

    It is composed of the individual intersection matrices [X]_k assembled
    by block diagonal.

    Returns
    -------
    X : :class:`numpy.ndarray`

    Note
    ----
    There is a numerical bottleneck in this function,
    when creating the block diagonal matrice [X] from the [X]_k matrices.
    """

    Xks = [self._Xk(cnx) for cnx in self.connections]

    Xf = np.zeros((len(self.frequency), self.dim, self.dim), dtype='complex')
    off = np.array([0, 0])
    for Xk in Xks:
        Xf[:, off[0]:off[0] + Xk.shape[1], off[1]:off[1]+Xk.shape[2]] = Xk
        off += Xk.shape[1:]
    
    return Xf

def X_orig(self) -> np.ndarray:
    """
    Return the concatenated intersection matrix [X] of the circuit.

    It is composed of the individual intersection matrices [X]_k assembled
    by block diagonal.

    Returns
    -------
    X : :class:`numpy.ndarray`

    Note
    ----
    There is a numerical bottleneck in this function,
    when creating the block diagonal matrice [X] from the [X]_k matrices.
    The difficulty comes from the fact that the shape of each [X]_k
    matrix is `fxnxn`, so there is a loop over the frequencies
    to create f times a block matrix [X]. I am still looking for a
    vectorized implementation but didn't find it.

    """ 
    # Xk = []
    # for cnx in self.connections:
    #     Xk.append(self._Xk(cnx))
    # Xk = np.array(Xk)

    # #X = np.zeros(len(C.frequency), )
    # Xf = []
    # for (idx, f) in enumerate(self.frequency):
    #     Xf.append(block_diag(*Xk[:,idx,:]))
    # return np.array(Xf)  # shape: (nb_frequency, nb_inter*nb_n, nb_inter*nb_n)

    # Slightly faster version
    Xks = [self._Xk(cnx) for cnx in self.connections]

    Xf = np.zeros((len(self.frequency), self.dim, self.dim), dtype='complex')
    # TODO: avoid this for loop which is a bottleneck for large frequencies
    for idx in np.nditer(np.arange(len(self.frequency))):
        mat_list = [Xk[idx,:] for Xk in Xks]
        Xf[idx,:] = block_diag(*mat_list)  # bottleneck
    return Xf


def setup(npoints: int):
    freq = rf.Frequency(start=0.1, stop=10, unit='GHz', npoints=npoints)
    tl_media = rf.DefinedGammaZ0(freq, z0=50, gamma=1j*freq.w/rf.c)
    C1 = tl_media.capacitor(3.222e-12, name='C1')
    C2 = tl_media.capacitor(82.25e-15, name='C2')
    C3 = tl_media.capacitor(3.222e-12, name='C3')
    L2 = tl_media.inductor(8.893e-9, name='L2')
    RL = tl_media.resistor(50, name='RL')
    gnd = rf.Circuit.Ground(freq, name='gnd')
    port1 = rf.Circuit.Port(freq, name='port1', z0=50)
    port2 = rf.Circuit.Port(freq, name='port2', z0=50)

    cnx = [
        [(port1, 0), (C1, 0), (L2, 0), (C2, 0)],
        [(L2, 1), (C2, 1), (C3, 0), (port2, 0)],
        [(gnd, 0), (C1, 1), (C3, 1)],
    ]
    cir = rf.Circuit(cnx)
    return cir

perfplot.show(
    setup=setup,  # or setup=np.random.rand
    kernels=[
        X_new, 
        X_orig
    ],
    labels=["new", "orig"],
    n_range=[2 ** k for k in range(18)],
    xlabel="len(a)",
    # More optional arguments with their default values:
    # logx="auto",  # set to True or False to force scaling
    # logy="auto",
    # equality_check=np.allclose,  # set to None to disable "correctness" assertion
    # show_progress=True,
    # target_time_per_measurement=1.0,
    # max_time=None,  # maximum time per measurement
    # time_unit="s",  # set to one of ("auto", "s", "ms", "us", or "ns") to force plot units
    # relative_to=1,  # plot the timings relative to one of the measurements
    # flops=lambda n: 3*n,  # FLOPS plots
)
```

Resulting in:
![perf](https://user-images.githubusercontent.com/9936788/143508212-97e6a55f-efa1-47d9-824e-777156a4edf1.png)

