### PR TITLE
Separate the test of the notebooks from the test of the code 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Tests:
 
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
@@ -21,21 +21,21 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions flake8
-    
+
     # code quality check (linting)
     - name: Lint with flake8
-      if: ${{ always() }}    
+      if: ${{ always() }}
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  
-    # test code and notebooks (tutorials and examples)
+
+    # run the tests located in skrf/
     - name: Test the code, tutorials and examples
-      if: ${{ always() }}    
+      if: ${{ always() }}
       run: |
-        tox -- --nbval-lax --current-env
+        tox
 
     # Upload coverage data to coveralls.io
     - name: Upload coverage data to coveralls.io
@@ -46,9 +46,9 @@ jobs:
         COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
         COVERALLS_PARALLEL: true
       run: |
-        pip install coveralls    
+        pip install coveralls
         coveralls --service=github
-  
+
   coveralls:
     name: Indicate completion to coveralls.io (Finish)
     continue-on-error: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Code linting and testing
 on: [push, pull_request]
 
 jobs:
-  Tests:
+  Tests: 
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/testing_notebooks.yml
+++ b/.github/workflows/testing_notebooks.yml
@@ -1,0 +1,29 @@
+name: Documentation notebooks testing
+
+on: [push, pull_request]
+
+jobs:
+  Tests:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions flake8
+
+    # test code *and* notebooks (tutorials and examples)
+    - name: Test the code, tutorials and examples
+      if: ${{ always() }}
+      run: |
+        tox -- --nbval-lax --current-env

--- a/.github/workflows/testing_notebooks.yml
+++ b/.github/workflows/testing_notebooks.yml
@@ -1,11 +1,12 @@
-name: Documentation notebooks testing
+name: notebooks testing
 
 on: [push, pull_request]
 
 jobs:
-  Tests:
+  test-notebooks:
 
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         python-version: ['3.9']

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,5 @@
+# running 'tox' will run the tests located in skrf/
+# running 'tox -- --nbval-lax' will also run all the notebooks located in doc/
 [tox]
 envlist = py{36, 37, 38, 39, 310}
 
@@ -22,7 +24,7 @@ testpaths =
     skrf
     doc/source/examples
     doc/source/tutorials
-addopts = --cov=skrf --cov=doc --ignore-glob='*.ipynb_checkpoints'
+addopts = --cov=skrf --ignore-glob='*.ipynb_checkpoints'
 norecursedirs = 
     skrf/vi
     skrf/src


### PR DESCRIPTION
split notebook tests into an independent github action: 

- the code is tested against multiple python versions (as before)
- while the notebooks are tested for only one python version, and independently of the code tests, and only for non-draft PR