### PR TITLE
Change syntax of the images from Markdown to HTML in the de-embedding tutorial

### DIFF
--- a/doc/source/tutorials/Deembedding.ipynb
+++ b/doc/source/tutorials/Deembedding.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "But what is the calibration reference plane for this transistor s-parameter measurement? The effects of the cabling and probe transitions can be removed by performing a standard calibration using methods such as Thru-Reflect-Line (TRL) or Short-Open-Load-Thru (SOLT) to move the calibration reference to the probe tips, or in other words, to the GSG pads implemented on-wafer. The use of an Impedance Standard Substrates (ISS) provides a set of well-defined calibration standards that can be used to establish such a reference plane for measurement. However, there is still a substantial \"test-fixture\" involving metal interconnects that need to be removed before accessing the real terminals of the RF transistor whose measurement we actually want. **De-embedding refers to the removal of extraneous effects that a test fixture can have on the measurement of a device under test (DUT).** The figure below (obtained from [here](https://mos-ak.org/shanghai_2016/presentations/Bertrand_Ardouin_MOS-AK_Shanghai_2016.pdf)) shows an example of the \"test-fixture\" that often has to be removed in on-wafer measurement applications.\n",
     "\n",
-    "<img src=\"figures/onwafer_pads.png\" alt=\"onwafer-pads\" width=\"300\">\n",
+    "<img src=\"figures/onwafer_pads.png\" alt=\"onwafer-pads\" width=\"500\">\n",
     "\n",
     "The de-embedding process differs from calibration in that no well known standards are used either because they cannot exist in certain environments, or are not practical to implement given space and cost constraints. De-embedding uses several dummy structures that help remove unwanted test fixture effects, but does not provide enough information to deduce a complete error box network like those obtained using standard calibration techniques. Since the test fixture itself may contain various transitions and interconnects before reaching the DUT, de-embedding is useful when simple scalar port extension of the reference plane is not applicable.\n",
     "\n",
@@ -31,7 +31,7 @@
     "\n",
     "The accuracy of Open-Short de-embedding depends on the validity of assumption that the test-fixture parasitics are a combination of parallel conductances (in red) and series impedances (in orange) as shown in the figure below. The lumped element model is usually representative of an on-wafer test-fixture, because first there is the shunt pad capacitance in the GSG pads, followed by the series impedance of the interconnect lines. To move the reference plane of the measurements from the plane of calibration (the outer terminals of the network below) to the DUT, two dummy structures - Open and Short - are needed in addition to the DUT. To create an Open dummy, the DUT is simply removed from the test fixture, while the three terminals are shorted together to implement the Short dummy. With the help of these dummies, the real measurements of the DUT can be extracted. The reader is referred to [this detailed presentation](https://mos-ak.org/shanghai_2016/presentations/Bertrand_Ardouin_MOS-AK_Shanghai_2016.pdf) for intricate details regarding the design of on-wafer test structures and best practices. From here on, we will focus on explaining how the de-embedding class in scikit-rf works.\n",
     "\n",
-    "<img src=\"figures/openshort.png\" alt=\"openshort\" width=\"300\">"
+    "<img src=\"figures/openshort.png\" alt=\"openshort\" width=\"500\">"
    ]
   },
   {
@@ -42,7 +42,7 @@
     "\n",
     "In this section, let us build up a concrete example to demonstrate how de-embedding in scikit-rf works. Assume that the device under test is a 1nH inductor whose measurements we are interested in. Since this inductor must be placed in an on-wafer test-fixture, let us assume that the pad capacitance at each port is 25fF, the pad-pad capacitance is 10fF, and the resistance of interconnect lines from each pad are 2-ohms each. The resulting network whose measurements are available at the external reference plane P1-P2, is shown below. \n",
     "\n",
-    "<img src=\"figures/ind_parasitics.png\" alt=\"openshort-ckt\" width=\"300\">\n",
+    "<img src=\"figures/ind_parasitics.png\" alt=\"openshort-ckt\" width=\"500\">\n",
     "\n",
     "The goal is to accurately extract the actual 1nH inductor by removing all other extraneous parasitic circuit elements.\n",
     "\n"
@@ -96,11 +96,11 @@
    "source": [
     "To create an open dummy structure, the DUT, which is the 1nH inductor here is simply removed from the DUT test structure resulting in the circuit shown below.\n",
     "\n",
-    "<img src=\"figures/ind_open.png\" alt=\"openckt\" width=\"300\">\n",
+    "<img src=\"figures/ind_open.png\" alt=\"openckt\" width=\"500\">\n",
     "\n",
     "To create a short dummy structure, the internal terminals of the test-fixture that would otherwise connect to the DUT are shorted to ground as shown below.\n",
     "\n",
-    "<img src=\"figures/ind_short.png\" alt=\"shortckt\" width=\"300\">"
+    "<img src=\"figures/ind_short.png\" alt=\"shortckt\" width=\"500\">"
    ]
   },
   {
@@ -169,19 +169,19 @@
     "\n",
     "At higher frequencies above 10 GHz, the fringe capacitance of the open dummy and the parasitic inductance of the short dummy cause errors. For high frequencies, several methods using a through (thru) dummy have been proposed, such as `SplitPi`[[1](#ref1)], `SplitTee`[[2](#ref2)], `AdmittanceCancel`[[3](#ref3)], and `ImpedanceCancel`[[4](#ref4)]. The thru dummy is a direct connection of the left and right test pads. The example of the test device and thru dummy is shown in the figure below, where G and S indicate ground pads and signal pads.\n",
     "\n",
-    "<img src=\"figures/thru_micrograph.png\" alt=\"thru_micrograph\" width=\"300\">\n",
+    "<img src=\"figures/thru_micrograph.png\" alt=\"thru_micrograph\" width=\"500\">\n",
     "\n",
     "### Split methods\n",
     "\n",
     "Split methods are based on lumped elements assumption as well as the open or short methods. The `SplitPi` and `SplitTee` methods assume that the embedding-networks are Π-network and T-network, respectively, as shown in the figure below. The values of the left and right parasitics (i.e. Z and Y) are extracted from the thru dummy. The parasitics are removed by multiplying by the inverse of the left and right ABCD matrix. **These methods can apply to only 2-port DUTs**.\n",
     "\n",
-    "<img src=\"figures/split_methods.svg\" alt=\"split_methods\" width=\"300\">\n",
+    "<img src=\"figures/split_methods.svg\" alt=\"split_methods\" width=\"500\">\n",
     "\n",
     "### Immittance cancel methods\n",
     "\n",
     "The `AdmittanceCancel` (a.k.a Mangan's method) and `ImpedanceCancel` methods are also based on lumped elements assumption as shown in the figure below. However, unlike the split methods, they do NOT directly calculate the immittance of the left and right parasitics. These methods de-embed the DUTs by left-right mirroring operation which is called 'swapping'. The `AdmittanceCancel` method consists of two steps. First, an matrix defined as 'H' is calculated by multiplying the ABCD matrix of the test device by inverse matrix of thru dummy as shown in figure(c). Then, the de-embedded Y matrix is obtained by taking the average of the left-right mirrored and un-mirrored Y-parameters of H. Similarly, in the case of the `ImpedanceCancel` method, it takes the average of the Z-parameters. **These methods can apply to only symmetric 2-port DUTs (i.e. S11=S22 and S12=S21)**, but more accurate than the split methods in the characterization of transmission lines at mmW frequencies. A comparison between the split methods and immittance cancel methods is described in [[4]](https://ieeexplore.ieee.org/document/7377897).\n",
     "\n",
-    "<img src=\"figures/immittance_cancel.svg\" alt=\"immittance_cancel\" width=\"300\">"
+    "<img src=\"figures/immittance_cancel.svg\" alt=\"immittance_cancel\" width=\"500\">"
    ]
   },
   {

--- a/doc/source/tutorials/Deembedding.ipynb
+++ b/doc/source/tutorials/Deembedding.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "But what is the calibration reference plane for this transistor s-parameter measurement? The effects of the cabling and probe transitions can be removed by performing a standard calibration using methods such as Thru-Reflect-Line (TRL) or Short-Open-Load-Thru (SOLT) to move the calibration reference to the probe tips, or in other words, to the GSG pads implemented on-wafer. The use of an Impedance Standard Substrates (ISS) provides a set of well-defined calibration standards that can be used to establish such a reference plane for measurement. However, there is still a substantial \"test-fixture\" involving metal interconnects that need to be removed before accessing the real terminals of the RF transistor whose measurement we actually want. **De-embedding refers to the removal of extraneous effects that a test fixture can have on the measurement of a device under test (DUT).** The figure below (obtained from [here](https://mos-ak.org/shanghai_2016/presentations/Bertrand_Ardouin_MOS-AK_Shanghai_2016.pdf)) shows an example of the \"test-fixture\" that often has to be removed in on-wafer measurement applications.\n",
     "\n",
-    "![onwafer-pads](figures/onwafer_pads.png)\n",
+    "<img src=\"figures/onwafer_pads.png\" alt=\"onwafer-pads\" width=\"300\">\n",
     "\n",
     "The de-embedding process differs from calibration in that no well known standards are used either because they cannot exist in certain environments, or are not practical to implement given space and cost constraints. De-embedding uses several dummy structures that help remove unwanted test fixture effects, but does not provide enough information to deduce a complete error box network like those obtained using standard calibration techniques. Since the test fixture itself may contain various transitions and interconnects before reaching the DUT, de-embedding is useful when simple scalar port extension of the reference plane is not applicable.\n",
     "\n",
@@ -31,7 +31,7 @@
     "\n",
     "The accuracy of Open-Short de-embedding depends on the validity of assumption that the test-fixture parasitics are a combination of parallel conductances (in red) and series impedances (in orange) as shown in the figure below. The lumped element model is usually representative of an on-wafer test-fixture, because first there is the shunt pad capacitance in the GSG pads, followed by the series impedance of the interconnect lines. To move the reference plane of the measurements from the plane of calibration (the outer terminals of the network below) to the DUT, two dummy structures - Open and Short - are needed in addition to the DUT. To create an Open dummy, the DUT is simply removed from the test fixture, while the three terminals are shorted together to implement the Short dummy. With the help of these dummies, the real measurements of the DUT can be extracted. The reader is referred to [this detailed presentation](https://mos-ak.org/shanghai_2016/presentations/Bertrand_Ardouin_MOS-AK_Shanghai_2016.pdf) for intricate details regarding the design of on-wafer test structures and best practices. From here on, we will focus on explaining how the de-embedding class in scikit-rf works.\n",
     "\n",
-    "![openshort](figures/openshort.png)"
+    "<img src=\"figures/openshort.png\" alt=\"openshort\" width=\"300\">"
    ]
   },
   {
@@ -42,7 +42,7 @@
     "\n",
     "In this section, let us build up a concrete example to demonstrate how de-embedding in scikit-rf works. Assume that the device under test is a 1nH inductor whose measurements we are interested in. Since this inductor must be placed in an on-wafer test-fixture, let us assume that the pad capacitance at each port is 25fF, the pad-pad capacitance is 10fF, and the resistance of interconnect lines from each pad are 2-ohms each. The resulting network whose measurements are available at the external reference plane P1-P2, is shown below. \n",
     "\n",
-    "![openshort-ckt](figures/ind_parasitics.png)\n",
+    "<img src=\"figures/ind_parasitics.png\" alt=\"openshort-ckt\" width=\"300\">\n",
     "\n",
     "The goal is to accurately extract the actual 1nH inductor by removing all other extraneous parasitic circuit elements.\n",
     "\n"
@@ -96,11 +96,11 @@
    "source": [
     "To create an open dummy structure, the DUT, which is the 1nH inductor here is simply removed from the DUT test structure resulting in the circuit shown below.\n",
     "\n",
-    "![openckt](figures/ind_open.png)\n",
+    "<img src=\"figures/ind_open.png\" alt=\"openckt\" width=\"300\">\n",
     "\n",
     "To create a short dummy structure, the internal terminals of the test-fixture that would otherwise connect to the DUT are shorted to ground as shown below.\n",
     "\n",
-    "![shortckt](figures/ind_short.png)"
+    "<img src=\"figures/ind_short.png\" alt=\"shortckt\" width=\"300\">"
    ]
   },
   {
@@ -167,21 +167,21 @@
    "source": [
     "## Through-only de-embedding\n",
     "\n",
-    "At higher frequencies above 10 GHz, the fringe capacitance of the open dummy and the parasitic inductance of the short dummy cause errors. For high frequencies, several methods using a through (thru) dummy have been proposed, such as `SplitPi`[[1](#ref1)] , `SplitTee`[[2](#ref2)], `AdmittanceCancel`[[3](#ref3)], and `ImpedanceCancel`[[4](#ref4)]. The thru dummy is a direct connection of the left and right test pads. The example of the test device and thru dummy is shown in the figure below, where G and S indicate ground pads and signal pads.\n",
+    "At higher frequencies above 10 GHz, the fringe capacitance of the open dummy and the parasitic inductance of the short dummy cause errors. For high frequencies, several methods using a through (thru) dummy have been proposed, such as `SplitPi`[[1](#ref1)], `SplitTee`[[2](#ref2)], `AdmittanceCancel`[[3](#ref3)], and `ImpedanceCancel`[[4](#ref4)]. The thru dummy is a direct connection of the left and right test pads. The example of the test device and thru dummy is shown in the figure below, where G and S indicate ground pads and signal pads.\n",
     "\n",
-    "![thru_micrograph](figures/thru_micrograph.png)\n",
+    "<img src=\"figures/thru_micrograph.png\" alt=\"thru_micrograph\" width=\"300\">\n",
     "\n",
     "### Split methods\n",
     "\n",
     "Split methods are based on lumped elements assumption as well as the open or short methods. The `SplitPi` and `SplitTee` methods assume that the embedding-networks are Π-network and T-network, respectively, as shown in the figure below. The values of the left and right parasitics (i.e. Z and Y) are extracted from the thru dummy. The parasitics are removed by multiplying by the inverse of the left and right ABCD matrix. **These methods can apply to only 2-port DUTs**.\n",
     "\n",
-    "![split_methods](figures/split_methods.svg)\n",
+    "<img src=\"figures/split_methods.svg\" alt=\"split_methods\" width=\"300\">\n",
     "\n",
     "### Immittance cancel methods\n",
     "\n",
     "The `AdmittanceCancel` (a.k.a Mangan's method) and `ImpedanceCancel` methods are also based on lumped elements assumption as shown in the figure below. However, unlike the split methods, they do NOT directly calculate the immittance of the left and right parasitics. These methods de-embed the DUTs by left-right mirroring operation which is called 'swapping'. The `AdmittanceCancel` method consists of two steps. First, an matrix defined as 'H' is calculated by multiplying the ABCD matrix of the test device by inverse matrix of thru dummy as shown in figure(c). Then, the de-embedded Y matrix is obtained by taking the average of the left-right mirrored and un-mirrored Y-parameters of H. Similarly, in the case of the `ImpedanceCancel` method, it takes the average of the Z-parameters. **These methods can apply to only symmetric 2-port DUTs (i.e. S11=S22 and S12=S21)**, but more accurate than the split methods in the characterization of transmission lines at mmW frequencies. A comparison between the split methods and immittance cancel methods is described in [[4]](https://ieeexplore.ieee.org/document/7377897).\n",
     "\n",
-    "![immittance_cancel](figures/immittance_cancel.svg)"
+    "<img src=\"figures/immittance_cancel.svg\" alt=\"immittance_cancel\" width=\"300\">"
    ]
   },
   {
@@ -209,13 +209,6 @@
     "\n",
     "<div id=\"ref4\"></div>[4]: [S. Amakawa et al., “Comparative analysis of on-chip transmission line de-embedding techniques,” in 2015 IEEE International Symposium on Radio-Frequency Integration Technology, Aug. 2015, pp. 91–93.](https://ieeexplore.ieee.org/document/7377897)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fix #579
TODO: check the online documentation to make sure it works properly.