### PR TITLE
Add citation to the IEEE journal article

### DIFF
--- a/doc/source/citations_ack/index.rst
+++ b/doc/source/citations_ack/index.rst
@@ -20,6 +20,24 @@ If you use `scikit-rf <http://scikit-rf.org>`_ for work/research presented in a 
 
 You can also include a link to `<www.scikit-rf.org>`_ (if the journal allows this) in addition to the above text.
 
+For academic citations, please cite the `IEEE Microwave Magazine article <https://ieeexplore.ieee.org/document/9632487>`_ that some of the community members wrote.
+The IEEE-style citation for this paper is
+
+``A. Arsenovic et al., "scikit-rf: An Open Source Python Package for Microwave Network Creation, Analysis, and Calibration [Speaker’s Corner]," in IEEE Microwave Magazine, vol. 23, no. 1, pp. 98-105, Jan. 2022, doi: 10.1109/MMM.2021.3117139.``
+
+and in BibTex format
+
+.. code-block:: latex
+
+   @ARTICLE{9632487,
+  author={Arsenovic, Alexander and Hillairet, Julien and Anderson, Jackson and Forstén, Henrik and Rieß, Vincent and Eller, Michael and Sauber, Noah and Weikle, Robert and Barnhart, William and Forstmayr, Franz},
+  journal={IEEE Microwave Magazine}, 
+  title={scikit-rf: An Open Source Python Package for Microwave Network Creation, Analysis, and Calibration [Speaker’s Corner]}, 
+  year={2022},
+  volume={23},
+  number={1},
+  pages={98-105},
+  doi={10.1109/MMM.2021.3117139}}
 
 In Presentations or Apps
 -------------------------


### PR DESCRIPTION
Some of the community members wrote an IEEE Microwave Magazine article <https://ieeexplore.ieee.org/document/9632487>. This adds links and example citations.