### PR TITLE
Fix coefs_8term and coefs_12term

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -131,7 +131,7 @@ coefs_list_8term = [
     'forward source match',
     'forward reflection tracking',
     'reverse directivity',
-    'reverse load match',
+    'reverse source match',
     'reverse reflection tracking',
     'forward switch term',
     'reverse switch term',
@@ -626,7 +626,7 @@ class Calibration(object):
             * forward source match
             * forward reflection tracking
             * reverse directivity
-            * reverse load match
+            * reverse source match
             * reverse reflection tracking
             * forward switch term
             * reverse switch term
@@ -649,10 +649,12 @@ class Calibration(object):
         """
 
         d = self.coefs
+        if all([k in d.keys() for k in coefs_list_3term]):
+            raise ValueError("Can't convert one port error terms to two port error terms")
 
-        for k in coefs_list_8term:
-            if k not in d and k in coefs_list_12term:
-                return convert_12term_2_8term(d)
+        # Check if we have all 12-term keys and convert to 8-term if we do.
+        if all([k in d.keys() for k in coefs_list_12term]):
+            return convert_12term_2_8term(d)
 
         return d
 
@@ -699,12 +701,14 @@ class Calibration(object):
 
         """
         d = self.coefs
+        if all([k in d.keys() for k in coefs_list_3term]):
+            raise ValueError("Can't convert one port error terms to two port error terms")
 
-        for k in coefs_list_12term:
-            if k not in d and k in coefs_list_8term:
-                return convert_8term_2_12term(d)
+        # Check if we have all 12-term keys and return the coefs if we do
+        if all([k in d.keys() for k in coefs_list_12term]):
+            return d
 
-        return d
+        return convert_8term_2_12term(d)
 
     @property
     def coefs_12term_ntwks(self):

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -474,6 +474,12 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
     def test_verify_12term(self):
         self.assertTrue(self.cal.verify_12term_ntwk.s_mag.max() < 1e-3)
 
+    def test_coefs_8term(self):
+        self.assertEqual(self.cal.coefs_8term, self.cal.coefs)
+
+    def test_coefs_12term(self):
+        self.assertEqual(self.cal.coefs_12term, rf.convert_8term_2_12term(self.cal.coefs))
+
 
 class TRLTest(EightTermTest):
     def setUp(self):
@@ -927,6 +933,12 @@ class TwelveTermTest(unittest.TestCase, CalibrationTest):
         c = self.cal.apply_cal(m)
                
         self.assertEqual(a,c)
+
+    def test_coefs_8term(self):
+        self.assertEqual(self.cal.coefs_8term, rf.convert_12term_2_8term(self.cal.coefs))
+
+    def test_coefs_12term(self):
+        self.assertEqual(self.cal.coefs_12term, self.cal.coefs)
     
 
 class TwelveTermSloppyInitTest(TwelveTermTest):


### PR DESCRIPTION
Fix the issue reported by @JAnderson419 in #572. Accessing `coefs_8term` of 8-term calibration raised an Exception. Added tests to cover this case.