### PR TITLE
Don't initialize z0 from str

### DIFF
--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -257,7 +257,7 @@ class Touchstone:
                 self.frequency_unit = toks[0]
                 self.parameter = toks[1]
                 self.format = toks[2]
-                self.resistance = toks[4]
+                self.resistance = complex(toks[4])
                 if self.frequency_unit not in ['hz', 'khz', 'mhz', 'ghz']:
                     print('ERROR: illegal frequency_unit [%s]',  self.frequency_unit)
                     # TODO: Raise


### PR DESCRIPTION
On my primary PC the current code works fine, but I had error below in touchstone loading on a Linux machine with numpy version 1.17.4. The issue seems to be that the `npy.array` is initialized with a string, casting to it complex before initialization works.

```
skrf/io/tests/test_touchstone.py:8: in <module>
    import skrf as rf
skrf/__init__.py:16: in <module>
    from . import media
skrf/media/__init__.py:41: in <module>
    from .freespace import Freespace
skrf/media/freespace.py:21: in <module>
    from ..data import materials
skrf/data/__init__.py:33: in <module>
    ntwk1 = Network(os.path.join(pwd, 'ntwk1.s2p'))
skrf/network.py:451: in __init__
    self.read_touchstone(filename, self.encoding)
skrf/network.py:1941: in read_touchstone
    touchstoneFile = touchstone.Touchstone(filename, encoding=encoding)
skrf/io/touchstone.py:153: in __init__
    self.get_gamma_z0_from_fid(fid)
skrf/io/touchstone.py:584: in get_gamma_z0_from_fid
    z0 = npy.array(self.resistance, dtype=complex)
E   TypeError: must be real number, not str
```