### PR TITLE
Remove confusing transposes

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1095,7 +1095,7 @@ class OnePort(Calibration):
 
         s11 = self.coefs['directivity']
         s22 = self.coefs['source match']
-        er_ntwk.s = npy.array([[s11, s21],[s12,s22]]).transpose().reshape(-1,2,2)
+        er_ntwk.s = npy.array([[s11, s12],[s21,s22]]).transpose(2,0,1)
         return er_ntwk.inv**ntwk
 
     def embed(self,ntwk):
@@ -2221,23 +2221,22 @@ class EightTerm(Calibration):
         detX = Edf*Esf-Erf
         detY = Edr*Esr-Err
 
-
-        T1 = npy.array([\
-                [ -1*detX,  zero    ],\
-                [ zero,     -1*k*detY]])\
-                .transpose().reshape(-1,2,2)
-        T2 = npy.array([\
-                [ Edf,      zero ],\
-                [ zero,     k*Edr]])\
-                .transpose().reshape(-1,2,2)
-        T3 = npy.array([\
-                [ -1*Esf,   zero ],\
-                [ zero,     -1*k*Esr]])\
-                .transpose().reshape(-1,2,2)
-        T4 = npy.array([\
-                [ one,      zero ],\
-                [ zero,     k ]])\
-                .transpose().reshape(-1,2,2)
+        T1 = npy.array([
+                [ -detX, zero    ],
+                [ zero,  -k*detY ]
+                ]).transpose(2,0,1)
+        T2 = npy.array([
+                [ Edf,    zero ],
+                [ zero,  k*Edr ]
+                ]).transpose(2,0,1)
+        T3 = npy.array([
+                [ -Esf,   zero ],
+                [ zero, -k*Esr ]
+                ]).transpose(2,0,1)
+        T4 = npy.array([
+                [ one, zero ],
+                [ zero, k   ]
+                ]).transpose(2,0,1)
 
         return T1,T2,T3,T4
 
@@ -2263,15 +2262,15 @@ class EightTerm(Calibration):
         Err = self.coefs['reverse reflection tracking']
         k = self.coefs['k']
 
-        S1 = npy.array([\
-                [ Edf,  k ],\
-                [ Erf/k,     Esf ]])\
-                .transpose().reshape(-1,2,2)
+        S1 = npy.array([
+                [ Edf,  Erf/k ],
+                [ k,    Esf ]
+                ]).transpose(2,0,1)
 
-        S2 = npy.array([\
-                [ Edr,  Err ],\
-                [ one,     Esr ]])\
-                .transpose().reshape(-1,2,2)
+        S2 = npy.array([
+                [ Edr,  one ],
+                [ Err,  Esr ]
+                ]).transpose(2,0,1)
 
         #Port impedances before renormalization.
         #Only the DUT side (port 2) is renormalized.
@@ -4512,32 +4511,43 @@ class SixteenTerm(Calibration):
         return None
 
     def apply_cal(self, ntwk):
+        """Applies the calibration to the input network.
+        Inverse of `embed`.
+        Parameters
+        ----------
+        ntwk : :class:`~skrf.network.Network`
+            Uncalibrated input network.
+        Returns
+        -------
+        caled : :class:`~skrf.network.Network`
+            Calibrated network.
+        """
         caled = ntwk.copy()
-        inv = linalg.inv
 
         T1,T2,T3,T4 = self.T_matrices
 
-        ntwk = self.unterminate(ntwk)
+        caled = self.unterminate(caled)
+        caled.s = linalg.inv(-caled.s @ T3 + T1) @ (caled.s @ T4 - T2)
 
-        for f in list(range(len(ntwk.s))):
-            t1,t2,t3,t4,m = T1[f,:,:],T2[f,:,:],T3[f,:,:],\
-                            T4[f,:,:],ntwk.s[f,:,:]
-            caled.s[f,:,:] = inv(-1*m.dot(t3)+t1).dot(m.dot(t4)-t2)
         return caled
 
     def embed(self, ntwk):
-        """
+        """Applies the error boxes to the calibrated input network.
+        Inverse of `apply_cal`.
+        Parameters
+        ----------
+        ntwk : :class:`~skrf.network.Network`
+            Calibrated input network.
+        Returns
+        -------
+        embedded : :class:`~skrf.network.Network`
+            Network with error boxes applied.
         """
         embedded = ntwk.copy()
-        inv = linalg.inv
 
         T1,T2,T3,T4 = self.T_matrices
 
-        for f in list(range(len(ntwk.s))):
-            t1,t2,t3,t4,a = T1[f,:,:],T2[f,:,:],T3[f,:,:],\
-                            T4[f,:,:],ntwk.s[f,:,:]
-            embedded.s[f,:,:] = (t1.dot(a)+t2).dot(inv(t3.dot(a)+t4))
-
+        embedded.s = (T1 @ ntwk.s + T2) @ linalg.inv(T3 @ ntwk.s + T4)
         embedded = self.terminate(embedded)
 
         return embedded
@@ -4554,7 +4564,6 @@ class SixteenTerm(Calibration):
         """
         ec = self.coefs
         npoints = len(ec['forward directivity'])
-        inv = linalg.inv
 
         e100 = ec['forward directivity']
         e111 = ec['reverse directivity']
@@ -4573,55 +4582,47 @@ class SixteenTerm(Calibration):
         e401 = ec['reverse port isolation']
         e410 = ec['forward port isolation']
 
-        E1 = npy.array([\
-                [ e100 , e110], \
-                [ e101 , e111]])\
-                .transpose().reshape(-1,2,2)
-        E2 = npy.array([\
-                [ e200 , e210], \
-                [ e201 , e211]])\
-                .transpose().reshape(-1,2,2)
-        E3 = npy.array([\
-                [ e300 , e310], \
-                [ e301 , e311]])\
-                .transpose().reshape(-1,2,2)
-        E4 = npy.array([\
-                [ e400 , e410], \
-                [ e401 , e411]])\
-                .transpose().reshape(-1,2,2)
+        E1 = npy.array([
+                [ e100 , e101],
+                [ e110 , e111]
+                ]).transpose(2,0,1)
+        E2 = npy.array([
+                [ e200 , e201],
+                [ e210 , e211]
+                ]).transpose(2,0,1)
+        E3 = npy.array([
+                [ e300 , e301],
+                [ e310 , e311]
+                ]).transpose(2,0,1)
+        E4 = npy.array([
+                [ e400 , e401],
+                [ e410 , e411]
+                ]).transpose(2,0,1)
 
-        T1 = npy.zeros(E1.shape, dtype=complex)
-        T2 = T1.copy()
-        T3 = T1.copy()
-        T4 = T1.copy()
-
-        invE3 = inv(E3)
-        for i in range(npoints):
-            T1[i] = E2[i] - E1[i].dot(invE3[i]).dot(E4[i])
-            T2[i] = E1[i].dot(invE3[i])
-            T3[i] = -invE3[i].dot(E4[i])
-            T4[i] = invE3[i]
+        invE3 = linalg.inv(E3)
+        T1 = E2 - E1 @ invE3 @ E4
+        T2 = E1 @ invE3
+        T3 = -invE3 @ E4
+        T4 = invE3
 
         return T1, T2, T3, T4
 
     def E_matrices(self, T1, T2, T3, T4):
         """
         Convert solved calibration T matrices to S-parameters.
+
+        Returns
+        -------
+        E1,E2,E3,E4 : numpy ndarray
         """
 
-        inv = linalg.inv
+        invT4 = linalg.inv(npy.array(T4))
 
-        E1 = npy.zeros(T1.shape, dtype=complex)
-        E2 = npy.zeros(T2.shape, dtype=complex)
-        E3 = npy.zeros(T3.shape, dtype=complex)
-        E4 = npy.zeros(T4.shape, dtype=complex)
+        E1 = T2 @ invT4
+        E2 = T1 - T2 @ invT4 @ T3
+        E3 = invT4
+        E4 = -invT4 @ T3
 
-        invT4 = inv(npy.array(T4))
-        for i in range(len(T1)):
-            E1[i] = T2[i].dot(invT4[i])
-            E2[i] = T1[i] - T2[i].dot(invT4[i]).dot(T3[i])
-            E3[i] = invT4[i]
-            E4[i] = -invT4[i].dot(T3[i])
         return E1, E2, E3, E4
 
 
@@ -5138,7 +5139,7 @@ def determine_line(thru_m, line_m, line_approx=None):
     s12_0, s12_1 = w[:,0], w[:,1]
     s12 = find_correct_sign(s12_0, s12_1, line_approx.s[:,1,0])
     found_line = line_m.copy()
-    found_line.s = npy.array([[zero, s12],[s12,zero]]).transpose().reshape(-1,2,2)
+    found_line.s = npy.array([[zero, s12],[s12,zero]]).transpose(2,0,1)
     return found_line
 
 


### PR DESCRIPTION
Calibration used `.transpose().reshape(-1,2,2)` to generate some arrays from lists of array coefficients. The arrays had frequency as the last axis which needed to be moved to the first axis, but the problem with the previous code was that it also transposed the matrix. All the input matrices were confusingly written in transposed order to work around it. This PR replaces them with `.transpose(2,0,1)` which just moves the frequency axis from the last position to the first one without transposing the other axes.

Also includes some other cleanup such as replacing for loops with matrix products.