### PR TITLE
Vector fitting: code reorganization + speed improvements

### DIFF
--- a/doc/source/examples/vectorfitting/vectorfitting_ex2_190ghz_active.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex2_190ghz_active.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**First attempt:** Perform the fit using 3 real poles and 4 complex-conjugate poles: (*Note*: In a previous version of this example, the order of the two attempts was reversed. Also see the [comment at the end](#comment).)"
+    "**First attempt:** Perform the fit using 4 real poles and 4 complex-conjugate poles: (*Note*: In a previous version of this example, the order of the two attempts was reversed. Also see the [comment at the end](#comment).)"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=3, n_poles_cmplx=4)"
+    "vf.vector_fit(n_poles_real=4, n_poles_cmplx=4)"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Second attempt:** Maybe an even better fit without that large dc \"spike\" can be achieved, so let's try again. Unwanted spikes at frequencies outside the fitting band are often caused by unnecessary or badly configured poles. Let's increase the number of real starting poles to 4: (*Note*: One could also reduce the real poles and/or increase the complex-conjugate poles. Also see the [comment at the end](#comment).)"
+    "**Second attempt:** Maybe an even better fit without that large dc \"spike\" can be achieved, so let's try again. Unwanted spikes at frequencies outside the fitting band are often caused by unnecessary or badly configured poles. Predictions about the fitting quality outside the fitting band are somewhat speculative and are not exactly controllable without additional samples at those frequencies. Still, let's try to decrease the number of real starting poles to 3 and see if the dc spike is removed: (*Note*: One could also reduce the real poles and/or increase the complex-conjugate poles. Also see the [comment at the end](#comment).)"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=4, n_poles_cmplx=4)\n",
+    "vf.vector_fit(n_poles_real=3, n_poles_cmplx=4)\n",
     "vf.plot_convergence()"
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 scipy
-numpy>=1.19.5
+numpy>=1.22.2
 pandas
 nbsphinx
 networkx

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -545,6 +545,8 @@ class VectorFitting:
                                                             np.hstack((freq_responses.real, freq_responses.imag)).transpose(),
                                                             rcond=None)
 
+        # align poles and residues arrays to get matching pole-residue pairs
+        poles = np.concatenate((poles[idx_poles_real], poles[idx_poles_complex]))
         residues = np.concatenate((x[idx_res_real], x[idx_res_complex_re] + 1j * x[idx_res_complex_im]), axis=0).transpose()
 
         if fit_constant:

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -251,23 +251,25 @@ class VectorFitting:
 
         logging.info('### Starting pole relocation process.\n')
 
+        # select network representation type
+        if parameter_type.lower() == 's':
+            freq_responses = self.network.s
+        elif parameter_type.lower() == 'z':
+            freq_responses = self.network.z
+        elif parameter_type.lower() == 'y':
+            freq_responses = self.network.y
+        else:
+            warnings.warn('Invalid choice of matrix parameter type (S, Z, or Y); proceeding with scattering '
+                          'representation.', UserWarning, stacklevel=2)
+            freq_responses = self.network.s
+
+        n_responses = self.network.nports ** 2
+        n_freqs = len(freqs_norm)
+
         # stack frequency responses as a single vector
         # stacking order (row-major):
         # s11, s12, s13, ..., s21, s22, s23, ...
-        freq_responses = []
-        for i in range(self.network.nports):
-            for j in range(self.network.nports):
-                if parameter_type.lower() == 's':
-                    freq_responses.append(self.network.s[:, i, j])
-                elif parameter_type.lower() == 'z':
-                    freq_responses.append(self.network.z[:, i, j])
-                elif parameter_type.lower() == 'y':
-                    freq_responses.append(self.network.y[:, i, j])
-                else:
-                    warnings.warn('Invalid choice of matrix parameter type (S, Z, or Y); proceeding with scattering '
-                                  'representation.', UserWarning, stacklevel=2)
-                    freq_responses.append(self.network.s[:, i, j])
-        freq_responses = np.array(freq_responses)
+        freq_responses = np.reshape(np.transpose(freq_responses), (n_responses, n_freqs))
 
         # ITERATIVE FITTING OF POLES to the provided frequency responses
         # initial set of poles will be replaced with new poles after every iteration

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -436,24 +436,21 @@ class VectorFitting:
 
             # build test matrix H, which will hold the new poles as eigenvalues
             H = np.zeros((len(c_res), len(c_res)))
-            i = 0
-            for i_pole in range(len(poles)):
-                # fill diagonal with previous poles
-                pole_re = poles.real[i_pole]
-                pole_im = poles.imag[i_pole]
-                if pole_im == 0.0:
-                    # one row for a real pole
-                    H[i, i] = pole_re
-                    H[i] -= c_res / d_res
-                    i += 1
-                else:
-                    # two rows for a complex pole of a conjugated pair
-                    H[i, i] = pole_re
-                    H[i, i + 1] = pole_im
-                    H[i + 1, i] = -1 * pole_im
-                    H[i + 1, i + 1] = pole_re
-                    H[i] -= 2 * c_res / d_res
-                    i += 2
+
+            A_sub_real_idx = self._get_pole_idx(poles, real=True)
+            A_sub_cplx_idx = self._get_pole_idx(poles, real=False)
+            poles_real = poles[np.nonzero(poles.imag == 0)]
+            poles_cplx = poles[np.nonzero(poles.imag != 0)]
+
+            H[A_sub_real_idx, A_sub_real_idx] = poles_real.real
+            H[A_sub_real_idx] -= c_res / d_res
+
+            H[A_sub_cplx_idx, A_sub_cplx_idx] = poles_cplx.real
+            H[A_sub_cplx_idx + 1, A_sub_cplx_idx + 1] = poles_cplx.real
+            H[A_sub_cplx_idx, A_sub_cplx_idx + 1] = poles_cplx.imag
+            H[A_sub_cplx_idx + 1, A_sub_cplx_idx] = -1 * poles_cplx.imag
+            H[A_sub_cplx_idx] -= 2 * c_res / d_res
+
             poles_new = np.linalg.eigvals(H)
 
             # replace poles for next iteration

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -386,18 +386,8 @@ class VectorFitting:
                     
                 A_row_extra[-1] = len(freqs_norm)
 
-                # (view) View complex array (rows,cols) as float (rows,cols * 2)
-                # (reshape) Put complex tuples in an own dimension (rows,cols,2)
-                # (transpose) Swap last two dimensions (rows, 2, cols)
-                # (reshape) Merge rows and second dimension (rows * 2, cols)
-                # This results in rows with alternating real/imaginary content
-                A_ri = A_sub.view(np.float64) \
-                    .reshape(-1, A_sub.shape[1], 2) \
-                    .transpose(0,2,1) \
-                    .reshape((-1, A_sub.shape[1]))
-
                 # QR decomposition
-                R = np.linalg.qr(A_ri, 'r')
+                R = np.linalg.qr(np.vstack((A_sub.real, A_sub.imag)), 'r')
 
                 # only R22 is required to solve for c_res and d_res
                 R22 = R[n_cols_unused:, n_cols_unused:]

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -385,7 +385,6 @@ class VectorFitting:
 
             # assemble compressed coefficient matrix A_fast by row-stacking individual upper triangular matrices R22
             A_fast = np.empty((n_responses * n_cols_used + 1, n_cols_used))
-            #A_fast[:-1, :] = np.hstack(np.vsplit(R22, n_responses))
             A_fast[:-1, :] = np.reshape(R22, (n_responses * n_cols_used, n_cols_used))
 
             # extra equations to avoid trivial solution (one for each frequency response)
@@ -428,12 +427,6 @@ class VectorFitting:
 
             poles_real = poles[np.nonzero(real_mask)]
             poles_cplx = poles[np.nonzero(~real_mask)]
-
-            n_real = len(poles_real)
-            n_cmplx = len(poles_cplx)
-            idx_res_real = np.arange(n_real)
-            idx_res_complex_re = n_real + 2 * np.arange(n_cmplx)
-            idx_res_complex_im = idx_res_complex_re + 1
 
             H[idx_res_real, idx_res_real] = poles_real.real
             H[idx_res_real] -= c_res / d_res


### PR DESCRIPTION
This PR implements some of the open ideas left in PR #605 for further improvements of the `VectorFitting` module and includes a bug fix:
- Replaces remaining loop for poles relocation in `VectorFitting.vector_fit()` with numpy vectorization and broadcasting (efficient storage of coefficient matrix; use of vectorized QR decomposition and stacked least-squares solving)
- Requires numpy>=v1.22.0 for stacked matrices as input for `np.linalg.qr()`
- QR decomposition in numpy v1.22.0 became slower than in v1.19.5 (at least on my setup). I have reported the issue in https://github.com/numpy/numpy/issues/21158
- Fixes a bug in the "relaxation" of the pole relocation: until now it probably was never "relaxed" due to a minor mistake in the coefficient matrix. The algorithm now converges slightly differently, but the effect is often negligible

Fitting benchmarks on my machine:
- Example1 (3+0): master (numpy v1.19.5): ?; master (numpy v1.22.0): **0.008 s**; 00f463bc (numpy v1.22.0): **0.004 s**
- Example2 (4+4): master (numpy v1.19.5): **0.2 s**; master (numpy v1.22.0): **0.33 s**; 00f463bc (numpy v1.22.0): **0.25 s**
- Example2 (3+4): master (numpy v1.19.5): **0.11 s**; master (numpy v1.22.0): **0.14 s**; 00f463bc (numpy v1.22.0): **0.39 s**
- Example3 (1+26): master (numpy v1.19.5): **0.79 s**; master (numpy v1.22.0): **1.85 s**; 00f463bc (numpy v1.22.0): **1.55 s**
- Example3 (1+25): master (numpy v1.19.5): **0.6 s**; master (numpy v1.22.0): **1.44 s**; 00f463bc (numpy v1.22.0): **0.87 s**
- Nasty 4-port (0+200): master (numpy v1.19.5): **176 s**; master (numpy v1.22.0): **315 s**; 00f463bc (numpy v1.22.0): **254 s**
