### PR TITLE
Fix#618 scipy.ndimage.filters namespace deprecation warning

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -176,7 +176,6 @@ from numpy.linalg import inv as npy_inv
 from numpy import fft, gradient, ndarray, reshape, shape, ones, std
 from scipy import stats, signal  # for Network.add_noise_*, and Network.windowed
 from scipy.interpolate import interp1d  # for Network.interpolate()
-from scipy.ndimage.filters import convolve1d
 import unittest  # fotr unitest.skip
 
 from . import mathFunctions as mf

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -17,7 +17,7 @@ Time domain functions
 
 """
 from .util import find_nearest_index
-from scipy.ndimage.filters import convolve1d
+from scipy.ndimage import convolve1d
 from scipy import signal
 import numpy as npy
 from numpy import fft


### PR DESCRIPTION
- removed scipy.ndimage.convolve1d from skrf.network since it was not being used
- updated skrf.time to import from scipy.ndimage