### PR TITLE
SOLT calibration example: asymmetric case

### DIFF
--- a/doc/source/examples/metrology/SOLT.ipynb
+++ b/doc/source/examples/metrology/SOLT.ipynb
@@ -189,7 +189,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have our ideal elements, let's fake the measurements:"
+    "Now that we have our ideal elements, let's fake the measurements.\n",
+    "\n",
+    "Note that the transmission lines are not symmetric in the example below, to make it as generic as possible. In such case, it is necessary to call the [flipped()](https://scikit-rf.readthedocs.io/en/latest/api/generated/skrf.network.Network.flipped.html) method to connect the ideal elements on the correct side of the `line2` object. "
    ]
   },
   {
@@ -199,8 +201,8 @@
    "outputs": [],
    "source": [
     "# left and right piece of transmission lines\n",
-    "line1 = media.line(d=20, unit='cm')\n",
-    "line2 = media.line(d=30, unit='cm')\n",
+    "line1 = media.line(d=20, unit='cm')**media.impedance_mismatch(1,2)\n",
+    "line2 = media.line(d=30, unit='cm')**media.impedance_mismatch(1,3)\n",
     "\n",
     "# add some noise to make it more realistic\n",
     "line1.add_noise_polar(.01, .1)\n",
@@ -210,9 +212,10 @@
     "measured = line1 ** dut  ** line2\n",
     "\n",
     "# fake the calibration measurements\n",
-    "open_measured = rf.two_port_reflect(line1 ** media.open(), line2 ** media.open())\n",
-    "short_measured = rf.two_port_reflect(line1 ** media.short(), line2 ** media.short())\n",
-    "load_measured = rf.two_port_reflect(line1 ** media.load(Gamma0=0), line2 ** media.load(Gamma0=0))\n",
+    "# Note the use of flipped() on line2\n",
+    "open_measured = rf.two_port_reflect(line1 ** media.open(), line2.flipped() ** media.open())\n",
+    "short_measured = rf.two_port_reflect(line1 ** media.short(), line2.flipped() ** media.short())\n",
+    "load_measured = rf.two_port_reflect(line1 ** media.load(Gamma0=0), line2.flipped() ** media.load(Gamma0=0))\n",
     "thru_measured = line1 ** line2"
    ]
   },


### PR DESCRIPTION
Make the SOLT example working with an asymmetric case.