### PR TITLE
SOLT.ipynb example: suggests using nports=2.

### DIFF
--- a/doc/source/examples/metrology/SOLT.ipynb
+++ b/doc/source/examples/metrology/SOLT.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "The ideal component Networks are obtained from your calibration kit manufacturers or from modelling.\n",
     "\n",
-    "In this example, we simulate ideal components from transmission line theory. We create a lossy and noisy transmission line (for the sake of the example) and the ideal components (Short, Open and Load):   "
+    "In this example, we simulate ideal components from transmission line theory. We create a lossy and noisy transmission line (for the sake of the example)."
    ]
   },
   {
@@ -157,20 +157,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "media = rf.DefinedGammaZ0(frequency=dut.frequency, gamma=0.5 + 1j)\n",
-    "\n",
-    "# ideal 1-port Networks\n",
-    "short_ideal = media.short()\n",
-    "open_ideal = media.open()\n",
-    "load_ideal = media.match()  # could also be: media.load(Gamma0=0)\n",
-    "thru_ideal = media.thru()"
+    "media = rf.DefinedGammaZ0(frequency=dut.frequency, gamma=0.5 + 1j)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `SOLT` class expect a list of two ports Network, so it is needed to forge them using `two_port_reflect`:"
+    "Then we create the ideal components: Short, Open and Load, and Through. By default, the methods `media.short()`, `media.open()`, and `media.match()` return a one-port network, the SOLT class expects a list of two-port Network, so `two_port_reflect()` is needed to forge a two-port network from two one-port networks (`media.thru()` returns a two-port network and no adjustment is needed).\n",
+    "\n",
+    "Alternatively, the argument `nports=2` can be used as a shorthand for this task."
    ]
   },
   {
@@ -179,10 +175,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# generate ideal 2-ports, as required by the scikit-rf SOLT calibration Class \n",
+    "# ideal 1-port Networks\n",
+    "short_ideal = media.short()\n",
+    "open_ideal = media.open()\n",
+    "load_ideal = media.match()  # could also be: media.load(Gamma0=0)\n",
+    "thru_ideal = media.thru()\n",
+    "\n",
+    "# forge a two-port network from two one-port networks\n",
     "short_ideal_2p = rf.two_port_reflect(short_ideal, short_ideal)\n",
     "open_ideal_2p = rf.two_port_reflect(open_ideal, open_ideal)\n",
-    "load_ideal_2p = rf.two_port_reflect(load_ideal, load_ideal)"
+    "load_ideal_2p = rf.two_port_reflect(load_ideal, load_ideal)\n",
+    "\n",
+    "# alternatively, the \"nport=2\" argument can be used as a shorthand\n",
+    "# short_ideal_2p = media.short(nports=2)\n",
+    "# open_ideal_2p = media.open(nports=2)\n",
+    "# load_ideal_2p = media.match(nports=2)  "
    ]
   },
   {
@@ -223,7 +230,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now create the lists of Network that the `SOLT` class expect:"
+    "We can now create the lists of Network that the `SOLT` class expects:"
    ]
   },
   {
@@ -333,7 +340,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -347,7 +354,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The current example for creating Short, Open, Load ideal components uses `two_port_reflect()`, which is cumbersome. Suggest using the more convenient `nports=2` argument in the tutorial.