### PR TITLE
se2gmm z0 broadcasting, docstring and tests

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3414,7 +3414,6 @@ class Network(object):
             `f x 2*p x 2*p` matrix of mixed mode impedances, optional
             if input is None, 2 * z0 Ohms differential and z0 / 2 Ohms common mode
             reference impedance is used.
-            Pseudowave definition is used.
 
             If None and differential pair z0 is not identical, average of pair
             z0 is used for mixed mode z0 calculation.
@@ -3495,7 +3494,6 @@ class Network(object):
         z0_se: Numpy array
             `f x 2*p x 2*p` matrix of single ended impedances, optional
             if input is None, extract the reference impedance from the differential network.
-            Pseudowave definition is used.
 
             if None, z0 is calculated as 0.5 * (0.5 * z0_diff + 2 * z0_comm) for each differential port.
         s_def : str -> s_def :  can be: 'power' or 'pseudo'

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -979,11 +979,10 @@ class NetworkTestCase(unittest.TestCase):
         # Test that se2gmm renormalization is compatible with network renormalization
 
         # Single-ended ports
-        for s_def in ['power', 'pseudo']:
+        for s_def in rf.S_DEFINITIONS:
             for ports in range(2, 10):
                 # Number of differential pairs to convert
                 for p in range(0, ports//2 + 1):
-                    print(s_def, ports, p)
                     # Create a random network, z0=50
                     s_random = npy.random.uniform(-1, 1, (1, ports, ports)) +\
                                 1j * npy.random.uniform(-1, 1, (1, ports, ports))
@@ -1014,7 +1013,6 @@ class NetworkTestCase(unittest.TestCase):
                     # Renormalize net_renorm to the random z0
                     # net and net_renorm should match after this
                     # Single-ended ports stay 50 ohms
-                    # se2gmm uses pseudo wave definition
                     full_z0 = 50 * npy.ones(ports, dtype=complex)
                     full_z0[:2*p] = z0
                     net_renorm.renormalize(z_new=full_z0, s_def=s_def)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -386,6 +386,30 @@ class NetworkTestCase(unittest.TestCase):
                 npy.testing.assert_allclose(rf.t2s(rf.s2t(ntwk.s)), ntwk.s)
         npy.testing.assert_allclose(rf.t2s(rf.s2t(self.Fix.s)), self.Fix.s)
 
+    def test_multiport_conversions(self):
+        #Converting to other format and back to S-parameters should return the original network
+        for ports in range(3, 6):
+            s_random = npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports)) + 1j * npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports))
+            ntwk_random = rf.Network(s=s_random, frequency=self.freq)
+            for test_z0 in (50, 20+60j, 90-50j):
+                for test_ntwk in (self.ntwk1, self.ntwk2, self.ntwk3, ntwk_random):
+                    ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0)
+                    npy.testing.assert_allclose(rf.z2s(rf.s2z(ntwk.s, test_z0), test_z0), ntwk.s)
+                    npy.testing.assert_allclose(rf.y2s(rf.s2y(ntwk.s, test_z0), test_z0), ntwk.s)
+
+    def test_sparam_renormalize(self):
+        #Converting to other format and back to S-parameters should return the original network
+        for ports in range(2, 6):
+            s_random = npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports)) + 1j * npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports))
+            test_ntwk = rf.Network(s=s_random, frequency=self.freq)
+            for test_z0 in (50, 20+60j, 70-30j):
+                for method in rf.S_DEFINITIONS:
+                    ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=50)
+                    ntwk_renorm = ntwk.copy()
+                    ntwk_renorm.renormalize(test_z0, method)
+                    ntwk_renorm.renormalize(50, method)
+                    npy.testing.assert_allclose(ntwk_renorm.s, ntwk.s)
+
     def test_setters(self):
         s_random = npy.random.uniform(-10, 10, (self.freq.npoints, 2, 2)) + 1j * npy.random.uniform(-10, 10, (self.freq.npoints, 2, 2))
         ntwk = rf.Network(s=s_random, frequency=self.freq)
@@ -926,14 +950,58 @@ class NetworkTestCase(unittest.TestCase):
         se[:,0,2] = 1
         se[:,3,1] = 1
         se[:,1,3] = 1
-        net = rf.Network(s=se, f=[1])
+        net = rf.Network(s=se, f=[1], z0=50)
         gmm = npy.zeros((1,4,4), dtype=complex)
         gmm[:,0,1] = 1
         gmm[:,1,0] = 1
         gmm[:,2,3] = 1
         gmm[:,3,2] = 1
         net.se2gmm(p=2)
+        self.assertTrue(npy.allclose(net.z0, npy.array([[100,100,25,25]])))
         self.assertTrue(npy.allclose(net.s, gmm))
+
+    def test_se2gmm_3port(self):
+        # Test mixed mode conversion of ideal balun
+        se = npy.zeros((1,3,3), dtype=complex)
+        se[:,2,0] =  1/2**0.5
+        se[:,0,2] =  1/2**0.5
+        se[:,2,1] = -1/2**0.5
+        se[:,1,2] = -1/2**0.5
+        net = rf.Network(s=se, f=[1], z0=50)
+        gmm = npy.zeros((1,3,3), dtype=complex)
+        gmm[:,0,2] = 1
+        gmm[:,2,0] = 1
+        net.se2gmm(p=1)
+        self.assertTrue(npy.allclose(net.z0, npy.array([[100,25,50]])))
+        self.assertTrue(npy.allclose(net.s, gmm))
+
+    def test_se2gmm_renorm(self):
+        # Test that se2gmm renormalization is compatible with network renormalization
+        s_random = npy.random.uniform(-1, 1, (1, 4, 4)) + 1j * npy.random.uniform(-1, 1, (1, 4, 4))
+        net = rf.Network(s=s_random, frequency=[1], z0=50)
+        net_original = net.copy()
+        net_renorm = net.copy()
+
+        z0 = npy.random.uniform(1, 100, 4) + 1j * npy.random.uniform(-100, 100, 4)
+
+        # net and net_renorm have different z0
+        net.se2gmm(p=2, z0_mm=z0)
+        net_renorm.se2gmm(p=2, z0_mm=[100,100,25,25])
+        # S-parameters should be different
+        self.assertFalse(npy.allclose(net.s, net_renorm.s))
+
+        # Renormalize to the random z0
+        # se2gmm uses pseudo wave definition
+        net_renorm.renormalize(z_new=z0, s_def='pseudo')
+
+        # Nets should match now
+        self.assertTrue(npy.allclose(net.z0, net_renorm.z0))
+        self.assertTrue(npy.allclose(net.s, net_renorm.s))
+
+        # Test that we get the original network back
+        net.gmm2se(p=2, z0_se=50)
+        self.assertTrue(npy.allclose(net.z0, net_original.z0))
+        self.assertTrue(npy.allclose(net.s, net_original.s))
 
 
     def test_s_active(self):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -977,31 +977,54 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_se2gmm_renorm(self):
         # Test that se2gmm renormalization is compatible with network renormalization
-        s_random = npy.random.uniform(-1, 1, (1, 4, 4)) + 1j * npy.random.uniform(-1, 1, (1, 4, 4))
-        net = rf.Network(s=s_random, frequency=[1], z0=50)
-        net_original = net.copy()
-        net_renorm = net.copy()
 
-        z0 = npy.random.uniform(1, 100, 4) + 1j * npy.random.uniform(-100, 100, 4)
+        # Single-ended ports
+        for ports in range(2, 10):
+            # Number of differential pairs to convert
+            for p in range(0, ports//2 + 1):
+                # Create a random network, z0=50
+                s_random = npy.random.uniform(-1, 1, (1, ports, ports)) +\
+                            1j * npy.random.uniform(-1, 1, (1, ports, ports))
+                net = rf.Network(s=s_random, frequency=[1], z0=50)
+                net_original = net.copy()
+                net_renorm = net.copy()
 
-        # net and net_renorm have different z0
-        net.se2gmm(p=2, z0_mm=z0)
-        net_renorm.se2gmm(p=2, z0_mm=[100,100,25,25])
-        # S-parameters should be different
-        self.assertFalse(npy.allclose(net.s, net_renorm.s))
+                # Random z0 for mixed mode ports
+                z0 = npy.random.uniform(1, 100, 2*p) +\
+                        1j * npy.random.uniform(-100, 100, 2*p)
 
-        # Renormalize to the random z0
-        # se2gmm uses pseudo wave definition
-        net_renorm.renormalize(z_new=z0, s_def='pseudo')
+                # Convert net to mixed mode with random z0
+                net.se2gmm(p=p, z0_mm=z0)
 
-        # Nets should match now
-        self.assertTrue(npy.allclose(net.z0, net_renorm.z0))
-        self.assertTrue(npy.allclose(net.s, net_renorm.s))
+                # Convert net_renorm to mixed mode with different z0
+                z0_mm = npy.zeros(2*p, dtype=complex)
+                z0_mm[:p] = 100
+                z0_mm[p:] = 25
+                net_renorm.se2gmm(p=p, z0_mm=z0_mm)
 
-        # Test that we get the original network back
-        net.gmm2se(p=2, z0_se=50)
-        self.assertTrue(npy.allclose(net.z0, net_original.z0))
-        self.assertTrue(npy.allclose(net.s, net_original.s))
+                if p > 0:
+                    # S-parameters should be different
+                    self.assertFalse(npy.allclose(net.s, net_renorm.s))
+                else:
+                    # Same if no differential ports
+                    self.assertTrue(npy.allclose(net.s, net_renorm.s))
+
+                # Renormalize net_renorm to the random z0
+                # net and net_renorm should match after this
+                # Single-ended ports stay 50 ohms
+                # se2gmm uses pseudo wave definition
+                full_z0 = 50 * npy.ones(ports, dtype=complex)
+                full_z0[:2*p] = z0
+                net_renorm.renormalize(z_new=full_z0, s_def='pseudo')
+
+                # Nets should match now
+                self.assertTrue(npy.allclose(net.z0, net_renorm.z0))
+                self.assertTrue(npy.allclose(net.s, net_renorm.s))
+
+                # Test that we get the original network back
+                net.gmm2se(p=p, z0_se=50)
+                self.assertTrue(npy.allclose(net.z0, net_original.z0))
+                self.assertTrue(npy.allclose(net.s, net_original.s))
 
 
     def test_s_active(self):


### PR DESCRIPTION
* If se2gmm input network ports have unequal z0, calculate the mixed mode z0 from average of differential pair z0. This should make more sense than the previous code which didn't handle different port z0s too well. No change in the common case where all ports have the same z0.
* Allow broadcasting in z0 argument. Makes it possible to for example just give `z0_se=50` in `gmm2se` to make all ports 50 ohms instead of needing to make numpy array with the correct shape.
* Some slight docstring fixes. For complex z0 mention that pseudowave definition is used and add test that se2gmm renormalization matches the network class pseudowave renormalization.
* Add some more tests, no functional changes to the converstion mathematics.