### PR TITLE
Keep port_names when using subnetwork

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -346,7 +346,7 @@ class Network(object):
 
     # CONSTRUCTOR
     def __init__(self, file: str = None, name: str = None, params: dict = None,
-                 comments: str = None, f_unit: str = None, 
+                 comments: str = None, f_unit: str = None,
                  s_def: str = S_DEF_DEFAULT, **kwargs) -> None:
         r"""
         Network constructor.
@@ -360,13 +360,13 @@ class Network(object):
 
         file : str or file-object
             file to load information from. supported formats are:
-             * touchstone file (.s?p) (or .ts)  
+             * touchstone file (.s?p) (or .ts)
              * io.StringIO object (with `.name` property which contains the file extension, such as `myfile.s4p`)
              * pickled Network (.ntwk, .p) see :func:`write`
         name : str, optional
             Name of this Network. if None will try to use file, if it is a str
         params : dict, optional
-            Dictionnary of parameters associated with the Network            
+            Dictionnary of parameters associated with the Network
         comments : str, optional
             Comments associated with the Network
         s_def : str -> s_def :  can be: 'power', 'pseudo' or 'traveling'
@@ -399,9 +399,9 @@ class Network(object):
         Directly from values
 
         >>> n = rf.Network(f=[1,2,3], s=[1,2,3], z0=[1,2,3])
-        
+
         Define some parameters associated with the Network
-        
+
         >>> n = rf.Network('ntwk1.s2p', params={'temperature': 25, 'voltage':5})
 
         See Also
@@ -421,7 +421,7 @@ class Network(object):
         self.comments = comments
         self.port_names = None
         self.encoding = kwargs.pop('encoding', None)
-                
+
         self.deembed = None
         self.noise = None
         self.noise_freq = None
@@ -1871,8 +1871,8 @@ class Network(object):
         Example
         -------
 
-        The following example shows how to use the :func:`drop_non_monotonic_increasing` 
-        automatically, if invalid frequency data is detected and an 
+        The following example shows how to use the :func:`drop_non_monotonic_increasing`
+        automatically, if invalid frequency data is detected and an
         :class:`~skrf.frequency.InvalidFrequencyWarning` is thrown.
 
 
@@ -1939,8 +1939,8 @@ class Network(object):
         filename : str or file-object
             touchstone file name.
         encoding : str, optional
-            define the file encoding to use. Default value is None, 
-            meaning the encoding is guessed.            
+            define the file encoding to use. Default value is None,
+            meaning the encoding is guessed.
 
         Note
         ----
@@ -2689,7 +2689,7 @@ class Network(object):
         # freq = Frequency.from_f(f,**kwargs)
         # self.interpolate_self(freq, **interp_kwargs)
 
-    def extrapolate_to_dc(self, points: int = None, dc_sparam: NumberLike = None, 
+    def extrapolate_to_dc(self, points: int = None, dc_sparam: NumberLike = None,
                           kind: str = 'warn', coords: str = 'cart',
                           **kwargs) -> 'Network':
         """
@@ -2744,7 +2744,7 @@ class Network(object):
                           "To silent this warning, explitly define `kind`.",
                           category=DeprecationWarning, stacklevel=2)
             kind = 'rational'
-        
+
         result = self.copy()
 
         if self.frequency.f[0] == 0:
@@ -3654,7 +3654,7 @@ class Network(object):
                 If None value is determined automatically based on if the
                 frequency vector begins from 0.
         squeeze: bool
-                Squeeze impulse response to one dimension, 
+                Squeeze impulse response to one dimension,
                 if a oneport gets transformed.
                 Has no effect when transforming a multiport.
                 Default = True
@@ -3718,7 +3718,7 @@ class Network(object):
                 Number of zeros to add as padding for FFT.
                 Adding more zeros improves accuracy of peaks.
         squeeze: bool
-                Squeeze step response to one dimension, 
+                Squeeze step response to one dimension,
                 if a oneport gets transformed.
                 Has no effect when transforming a multiport.
                 Default = True
@@ -4767,6 +4767,9 @@ def subnetwork(ntwk: Network, ports: int, offby:int = 1) -> Network:
     subntwk = Network(frequency=ntwk.frequency, z0=ntwk.z0[:,ports], name=subntwk_name)
     # keep requested rows and columns of the s-matrix. ports can be not contiguous
     subntwk.s = ntwk.s[npy.ix_(npy.arange(ntwk.s.shape[0]), ports, ports)]
+    # keep port_names
+    if ntwk.port_names:
+        subntwk.port_names = [ntwk.port_names[idx] for idx in ports]
     return subntwk
 
 ## Building composit networks from sub-networks
@@ -6349,12 +6352,12 @@ def renormalize_s(s: npy.ndarray, z_old: NumberLike, z_new: NumberLike, s_def:st
      To use the pseudo-wave formulation, use s_def='pseudo'.
      However, results should be the same for real-valued characteristic impedances.
      See the [#Marks]_ and [#Anritsu]_ for more details.
-    
-    
+
+
     Note
     ----
     This just calls ::
-   
+
         z2s(s2z(s, z0=z_old), z0=z_new, s_def=s_def)
 
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -132,7 +132,7 @@ class NetworkTestCase(unittest.TestCase):
             t1, y1[:,i,j] = oneport.step_response(n=1000)
 
         t2, y2 = dut_dc.step_response(n=1000)
-        
+
         npy.testing.assert_almost_equal(t1, t2)
         npy.testing.assert_almost_equal(y1, y2)
 
@@ -190,7 +190,7 @@ class NetworkTestCase(unittest.TestCase):
             sio = io.StringIO(data)
             sio.name = os.path.basename(filename) # hack a bug to touchstone reader
             rf.Network(sio)
-            
+
         filename = os.path.join(self.test_dir, 'hfss_oneport.s1p')
         with open(filename) as fid:
             data = fid.read()
@@ -570,7 +570,7 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.z0 = z0
         self.assertTrue(npy.allclose(ntwk.z0, npy.array([z0, z0, z0], dtype=complex)))
 
-        # If the s-array has been set and we want to set z0 along the frequency axis, 
+        # If the s-array has been set and we want to set z0 along the frequency axis,
         # wer require the frequency vector to be set too.
         # Unfortunately the frequency vector and the s shape can distinguish
         z0 = [1,2,3]
@@ -590,7 +590,7 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.z0 = npy.array(z0) + 1 # Passing as npy.array
         self.assertTrue(npy.allclose(ntwk.z0, npy.array(z0, dtype=complex)+1))
 
-        # Setting the frequency is required to be set, as the matrix size is checked against the 
+        # Setting the frequency is required to be set, as the matrix size is checked against the
         # frequency vector
         ntwk.s = npy.random.rand(1,2,2)
         ntwk.f = [1]
@@ -1128,6 +1128,21 @@ class NetworkTestCase(unittest.TestCase):
         ntw_list = [tee12, tee23, tee13]
         tee2 = rf.n_twoports_2_nport(ntw_list, nports=3)
         self.assertTrue(tee2 == tee)
+
+    def test_subnetwork_port_names(self):
+        """ Test that subnetwork keeps port_names property. Issue #429 """
+        self.ntwk1.port_names = ['A', 'B']
+        extract_ports = ['A']  # list of port names to extract
+        extract_ports_idx = [self.ntwk1.port_names.index(p) for p in extract_ports]  # get port indices
+        sub_nwk1 = self.ntwk1.subnetwork(extract_ports_idx)
+        self.assertEqual(sub_nwk1.port_names, extract_ports)
+
+        tee = rf.data.tee
+        tee.port_names = ['A', 'B', 'C']
+        extract_ports = ['A', 'C']
+        extract_ports_idx = [tee.port_names.index(p) for p in extract_ports]
+        sub_nwk = tee.subnetwork(extract_ports_idx)
+        self.assertEqual(sub_nwk.port_names, extract_ports)
 
     def test_invalid_freq(self):
 


### PR DESCRIPTION
fix #429

When the `port_names` property exists in a `Network`, extract the names to forge a new `port_names` property when creating a subnetwork.