### PR TITLE
More accurate Coaxial resistance model

### DIFF
--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -94,6 +94,21 @@ class MediaTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             coax = Coaxial.from_attenuation_VF(frequency=frequency2, att=att)
 
+    def test_R(self):
+        freq = rf.Frequency(0, 100, 2)
+
+        rho = 1e-7
+        dint = 0.44e-3
+        coax = Coaxial(freq, z0=50, Dint=dint, Dout=1.0e-3, sigma=1/rho)
+
+        dc_res = rho / (npy.pi * (dint/2)**2)
+
+        # Old R calculation valid only when skin depth is much smaller
+        # then inner conductor radius
+        R_simple = coax.Rs/(2*npy.pi)*(1/coax.a + 1/coax.b)
+
+        self.assertTrue(abs(1 - coax.R[0]/dc_res) < 1e-2)
+        self.assertTrue(abs(1 - coax.R[1]/R_simple[1]) < 1e-2)
 
 if __name__ == "__main__":
     # Launch all tests


### PR DESCRIPTION
Improved coaxial cable resistance calculation that works at DC.

S21 with 1 mm coax gives very similar results at high frequencies:
```python
coax1mm = Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e7)
```
![coax_s21](https://user-images.githubusercontent.com/544240/166104322-47792950-b434-4678-bcf7-178323a8bf0a.png)

However S-parameters are not calculated correctly at DC. Example:

```python
import numpy as np
import skrf
from skrf.media import Coaxial

freq = skrf.Frequency(0, 0, 1)
coax1mm = Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e6)
print('gamma', coax1mm.gamma)

line = coax1mm.line(1, 'm', embed=True)

r_dc = coax1mm.R[0]
print('DC R', r_dc)

# Series resistor with the same resistance
net_r = coax1mm.resistor(R=r_dc)

print()
print('Resistor S-parameters')
print(net_r.s)
print()
print('Line S-parameters')
print(line.s)
print()
```

```
skrf/tlineFunctions.py:160: RuntimeWarning: divide by zero encountered in true_divide
  return sqrt(rho/(pi*f*mu_r*mu_0))
gamma [0.+0.j]
skrf/media/media.py:340: RuntimeWarning: divide by zero encountered in double_scalars
  return 1.0*theta/npy.imag(gamma[int(gamma.size/2)])
skrf/media/media.py:340: RuntimeWarning: invalid value encountered in double_scalars
  return 1.0*theta/npy.imag(gamma[int(gamma.size/2)])
DC R 6.57664599284452

Resistor S-parameters
[[[0.06170813+0.j 0.93829187+0.j]
  [0.93829187+0.j 0.06170813+0.j]]]

Line S-parameters
[[[nan+nanj nan+nanj]
  [nan+nanj nan+nanj]]]

```