### PR TITLE
Avoid division by zero at 0 Hz in DistributedCircuit

### DIFF
--- a/skrf/media/distributedCircuit.py
+++ b/skrf/media/distributedCircuit.py
@@ -195,7 +195,11 @@ class DistributedCircuit(Media):
             Distributed impedance in units of ohm/m
         """
         w  = self.frequency.w
-        return self.R + 1j*w*self.L
+        Z = self.R + 1j*w*self.L
+        # Avoid divide by zero.
+        # Needs to be imaginary to avoid all divide by zeros in the media class.
+        Z[Z.imag == 0] += 1j*1e-12
+        return Z
 
     @property
     def Y(self) -> NumberLike:
@@ -215,7 +219,11 @@ class DistributedCircuit(Media):
         """
 
         w  = self.frequency.w
-        return self.G + 1j*w*self.C
+        Y = self.G + 1j*w*self.C
+        # Avoid divide by zero.
+        # Needs to be imaginary to avoid all divide by zeros in the media class.
+        Y[Y.imag == 0] += 1j*1e-12
+        return Y
 
     @property
     def Z0(self) -> NumberLike:


### PR DESCRIPTION
Adds small offset to avoid dividing by zero if frequency is zero. DC S-parameters are extremely slightly off since adding the offset adds very small imaginary part when DC S-parameters should be real. It's better than nans though and fixing it properly would need more radical changes.

These changes are enough to avoid nans when both or only either R or G is zero. Just adding offset to Y is not enough when R is zero.

```python
import skrf
from skrf.media import DistributedCircuit
freq = skrf.F(0,0,1)
m = DistributedCircuit(frequency = freq,
                          z0 = 50,
                          C = 93.5e-12,
                          L = 273e-9,
                          R = 0,
                          G = 0)
line = m.line(10, 'm', z0=m.Z0, embed=True)
print(line.s)
```
```
Before:

[[[nan+nanj nan+nanj]
  [nan+nanj nan+nanj]]]

After:

[[[-4.4408921e-16-2.499e-10j  1.0000000e+00-2.501e-10j]
  [ 1.0000000e+00-2.501e-10j -4.4408921e-16-2.499e-10j]]]
```
