### PR TITLE
Improve s2z, z2s, s2y and y2s accuracy

### DIFF
--- a/skrf/mathFunctions.py
+++ b/skrf/mathFunctions.py
@@ -1258,3 +1258,58 @@ def is_positive_semidefinite(mat: npy.ndarray, tol: float = ALMOST_ZERO) -> bool
     except npy.linalg.LinAlgError:
         return False
     return npy.all(v > -tol)
+
+def rsolve(A: npy.ndarray, B: npy.ndarray) -> npy.ndarray:
+    r"""Solves x @ A = B.
+
+    Calls numpy.linalg.solve with transposed matrices.
+
+    Input should have dimension of similar to (nfreqs, nports, nports).
+
+    Parameters
+    ----------
+    A : npy.ndarray
+    B : npy.ndarray
+
+    Returns
+    -------
+    x : npy.ndarray
+    """
+    return npy.transpose(npy.linalg.solve(npy.transpose(A, (0, 2, 1)).conj(),
+            npy.transpose(B, (0, 2, 1)).conj()), (0, 2, 1)).conj()
+
+def nudge_eig(mat: npy.ndarray, cond: float = 1e-9, min_eig: float = 1e-12) -> npy.ndarray:
+    r"""Nudge eigenvalues with absolute value smaller than
+    min(cond * max(eigenvalue), min_eig) to that value.
+    Can be used to avoid singularities in solving matrix equations.
+
+    Input should have dimension of similar to (nfreqs, nports, nports).
+
+    Parameters
+    ----------
+    mat : npy.ndarray
+        Matrices to nudge
+    cond : float, optional
+        Minimum eigenvalue ratio compared to the maximum eigenvalue
+    min_eig : float, optional
+        Minimum eigenvalue
+    Returns
+    -------
+    res : npy.ndarray
+        Nudged matrices
+    """
+    # Eigenvalues and vectors
+    eigw, eigv = npy.linalg.eig(mat)
+    # Max eigenvalue for each frequency
+    max_eig = npy.amax(npy.abs(eigw), axis=1)
+    # Calculate mask for positions where problematic eigenvalues are
+    mask = npy.logical_or(npy.abs(eigw) < cond * max_eig[:, None], npy.abs(eigw) < min_eig)
+    mask_cond = cond * npy.repeat(max_eig[:, None], mat.shape[-1], axis=-1)[mask]
+    mask_min = min_eig * npy.ones(mask_cond.shape)
+    # Correct the eigenvalues
+    eigw[mask] = npy.maximum(mask_cond, mask_min)
+
+    # Now assemble the eigendecomposited matrices back
+    e = npy.zeros_like(mat)
+    npy.einsum('ijj->ij', e)[...] = eigw
+    return rsolve(eigv, eigv @ e)

--- a/skrf/tests/test_mathFunctions.py
+++ b/skrf/tests/test_mathFunctions.py
@@ -181,8 +181,14 @@ class TestUnitConversions(unittest.TestCase):
         cond_A = npy.linalg.cond(A)
         A2 = rf.nudge_eig(A, cond=1e-9, min_eig=1e-12)
 
+        self.assertFalse(A is A2)
         self.assertTrue(npy.all(npy.linalg.cond(A2) < cond_A))
         npy.testing.assert_allclose(A2, A, atol=1e-9)
+
+    def test_nudge_eig2(self):
+        A = npy.diag([1, 1, 1, 1]).reshape(1, 4, 4)
+        A2 = rf.nudge_eig(A, cond=1e-9, min_eig=1e-12)
+        self.assertTrue(A is A2)
 
 if __name__ == "__main__":
     # Launch all tests

--- a/skrf/tests/test_mathFunctions.py
+++ b/skrf/tests/test_mathFunctions.py
@@ -1,7 +1,7 @@
 from skrf.mathFunctions import LOG_OF_NEG
 import skrf as rf
 import unittest
-import numpy as np
+import numpy as npy
 from numpy import e, log, pi, isnan, inf
 from numpy.testing import assert_equal, run_module_suite, assert_almost_equal
 
@@ -12,7 +12,7 @@ class TestUnitConversions(unittest.TestCase):
     """
 
     def setUp(self):
-        pass        
+        pass
 
     def test_complex_2_magnitude(self):
         """
@@ -20,7 +20,7 @@ class TestUnitConversions(unittest.TestCase):
             5 = 3 + 4j
         """
         assert_almost_equal(rf.complex_2_magnitude(3+4j), 5.0)
-        
+
 
     def test_complex_2_db10(self):
         """
@@ -41,7 +41,7 @@ class TestUnitConversions(unittest.TestCase):
     def test_complex_2_quadrature(self):
         """
         Test complex to quadrature conversion with:
-            2, pi  = abs(2j), angle(2j) * abs(2j) 
+            2, pi  = abs(2j), angle(2j) * abs(2j)
         """
         assert_almost_equal(rf.complex_2_quadrature(0+2j), (2, pi))
 
@@ -74,7 +74,7 @@ class TestUnitConversions(unittest.TestCase):
 
         assert_equal(rf.mag_2_db, rf.magnitude_2_db) # Just an alias
 
-        
+
     def test_mag_2_db10(self):
         """
         Test magnitude to db10 conversion
@@ -119,7 +119,7 @@ class TestUnitConversions(unittest.TestCase):
 
     def test_db_2_np(self):
         """
-        Test dB to Np conversion with: 
+        Test dB to Np conversion with:
             1 [dB] = ln(10)/20 [Np]
         """
         assert_almost_equal(rf.db_2_np(1), log(10)/20)
@@ -135,7 +135,7 @@ class TestUnitConversions(unittest.TestCase):
         """
         assert_almost_equal(rf.feet_2_meter(0.01), 0.003048)
         assert_almost_equal(rf.feet_2_meter(1), 0.3048)
-        
+
 
     def test_meter_2_feet(self):
         """
@@ -158,15 +158,33 @@ class TestUnitConversions(unittest.TestCase):
         Test inf_to_num function
         """
         # scalar
-        assert_equal(rf.inf_to_num(np.inf), rf.INF)
-        assert_equal(rf.inf_to_num(-np.inf), -rf.INF)
-        
+        assert_equal(rf.inf_to_num(npy.inf), rf.INF)
+        assert_equal(rf.inf_to_num(-npy.inf), -rf.INF)
+
         # array
-        x = np.array([0, np.inf, 0, -np.inf])
-        y = np.array([0, rf.INF, 0, -rf.INF])
+        x = npy.array([0, npy.inf, 0, -npy.inf])
+        y = npy.array([0, rf.INF, 0, -rf.INF])
         assert_equal(rf.inf_to_num(x), y)
+
+    def test_rsolve(self):
+        A = npy.random.random((3, 2, 2)) + 1j*npy.random.random((3, 2, 2))
+        B = npy.random.random((3, 2, 2)) + 1j*npy.random.random((3, 2, 2))
+        # Make sure they are not singular
+        A = rf.nudge_eig(A)
+        B = rf.nudge_eig(B)
+
+        x = rf.rsolve(A, B)
+        npy.testing.assert_allclose(x @ A, B)
+
+    def test_nudge_eig(self):
+        A = npy.zeros((3, 2, 2))
+        cond_A = npy.linalg.cond(A)
+        A2 = rf.nudge_eig(A, cond=1e-9, min_eig=1e-12)
+
+        self.assertTrue(npy.all(npy.linalg.cond(A2) < cond_A))
+        npy.testing.assert_allclose(A2, A, atol=1e-9)
 
 if __name__ == "__main__":
     # Launch all tests
     run_module_suite()
-    
+

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -420,12 +420,22 @@ class NetworkTestCase(unittest.TestCase):
         self.ntwk1.plot_s_smith()
 
     def test_zy_singularities(self):
-        open = rf.N(f=[1], s=[1], z0=[50])
-        short = rf.N(f=[1], s=[-1], z0=[50])
-        react = rf.N(f=[1],s=[[0,1],[1,0]],z0=50)
-        z = open.z
-        y = short.y
-        a = react.y
+        networks = [
+            rf.N(f=[1], s=[1], z0=[50]),
+            rf.N(f=[1], s=[-1], z0=[50]),
+            rf.N(f=[1], s=[[0, 1], [1, 0]], z0=[50]),
+            rf.N(f=[1], s=[[1, 0], [0, 1]], z0=50),
+            rf.N(f=[1], s=[[-1, 0], [0, -1]], z0=50),
+            rf.N(f=[1], s=[[0.5, 0.5], [0.5, 0.5]], z0=[50]),
+            rf.N(f=[1], s=[[-0.5, -0.5], [-0.5, -0.5]], z0=[50]),
+        ]
+        # These conversion can be very inaccurate since results are very close
+        # to singular.
+        # Test that they are close with loose accuracy tolerance.
+        for net in networks:
+            for s_def in rf.S_DEFINITIONS:
+                npy.testing.assert_allclose(rf.z2s(rf.s2z(net.s, net.z0, s_def=s_def), net.z0, s_def=s_def), net.s, atol=1e-3)
+                npy.testing.assert_allclose(rf.y2s(rf.s2y(net.s, net.z0, s_def=s_def), net.z0, s_def=s_def), net.s, atol=1e-3)
 
     def test_conversions(self):
         #Converting to other format and back to S-parameters should return the original network
@@ -445,12 +455,45 @@ class NetworkTestCase(unittest.TestCase):
         #Converting to other format and back to S-parameters should return the original network
         for ports in range(3, 6):
             s_random = npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports)) + 1j * npy.random.uniform(-10, 10, (self.freq.npoints, ports, ports))
-            ntwk_random = rf.Network(s=s_random, frequency=self.freq)
-            for test_z0 in (50, 20+60j, 90-50j):
-                for test_ntwk in (self.ntwk1, self.ntwk2, self.ntwk3, ntwk_random):
-                    ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0)
-                    npy.testing.assert_allclose(rf.z2s(rf.s2z(ntwk.s, test_z0), test_z0), ntwk.s)
-                    npy.testing.assert_allclose(rf.y2s(rf.s2y(ntwk.s, test_z0), test_z0), ntwk.s)
+            test_ntwk = rf.Network(s=s_random, frequency=self.freq)
+            random_z0 = npy.random.uniform(1, 100, (self.freq.npoints, ports)) +\
+            1j * npy.random.uniform(-100, 100, (self.freq.npoints, ports))
+            for test_z0 in (50, random_z0):
+                for s_def in rf.S_DEFINITIONS:
+                    ntwk = rf.Network(s=test_ntwk.s, f=test_ntwk.f, z0=test_z0, s_def=s_def)
+                    npy.testing.assert_allclose(rf.z2s(rf.s2z(ntwk.s, test_z0, s_def=s_def), test_z0, s_def=s_def), ntwk.s)
+                    npy.testing.assert_allclose(rf.y2s(rf.s2y(ntwk.s, test_z0, s_def=s_def), test_z0, s_def=s_def), ntwk.s)
+
+    def test_y_z_compatability(self):
+        # Test that npy.linalg.inv(Z) == Y
+        fpoints = 3
+        for p in range(2, 6):
+            s = npy.random.uniform(-1, 1, (fpoints, p, p)) + 1j * npy.random.uniform(-1, 1, (fpoints, p, p))
+            random_z0 = npy.random.uniform(1, 100, (fpoints, p)) + 1j * npy.random.uniform(-100, 100, (fpoints, p))
+            for test_z0 in (50, random_z0):
+                for s_def in rf.S_DEFINITIONS:
+                    z = rf.s2z(s, test_z0, s_def=s_def)
+                    y = npy.linalg.inv(z)
+                    npy.testing.assert_allclose(rf.y2s(y, test_z0, s_def=s_def), s)
+
+    def test_unknown_s_def(self):
+        # Test that Exception is raised when given unknown s_def
+        s = npy.array([0]).reshape(1, 1, 1)
+        z0 = npy.array([50])
+        # These should work
+        # These also test that functions work with dtype=float input
+        rf.s2z(s, z0)
+        rf.z2s(s, z0)
+        rf.s2y(s, z0)
+        rf.y2s(s, z0)
+        with pytest.raises(Exception) as e:
+            rf.s2z(s, z0, s_def='error')
+        with pytest.raises(Exception) as e:
+            rf.z2s(s, z0, s_def='error')
+        with pytest.raises(Exception) as e:
+            rf.y2s(s, z0, s_def='error')
+        with pytest.raises(Exception) as e:
+            rf.s2y(s, z0, s_def='error')
 
     def test_sparam_renormalize(self):
         #Converting to other format and back to S-parameters should return the original network


### PR DESCRIPTION
Slightly nudge the S-parameters if Z-parameters would be too close to infinity by changing any eigenvalues that are too small.
The previous method of adding a small value if S-parameter was one did not fix the issue except for in special cases (open and short).

Also improves the numerical accuracy in calculation by avoiding directly calculating the inverse of a matrix.

Fixes #659.

Example:
```python
net = skrf.Network(s=[[0.5, 0.5],[0.5, 0.5]])
print(net.z)
print()
print(skrf.z2s(skrf.s2z(net.s, net.z0), net.z0))

```

```
Previously:
numpy.linalg.LinAlgError: Singular matrix

After:
[[[4.99999984e+10+0.j 4.99999983e+10+0.j]
  [4.99999983e+10+0.j 4.99999984e+10+0.j]]]

[[[0.49999998-0.j 0.50000002-0.j]
  [0.49999998-0.j 0.50000002-0.j]]]
```