### PR TITLE
Z0 getter fix

### DIFF
--- a/doc/source/examples/metrology/Measuring a Mutiport Device with a 2-Port Network Analyzer.ipynb
+++ b/doc/source/examples/metrology/Measuring a Mutiport Device with a 2-Port Network Analyzer.ipynb
@@ -259,10 +259,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "composite = wg.match(nports = 4)  # composite network, to be filled.\n",
     "measured,measured_renorm = {},{}  # measured subnetworks and renormalized sub-networks\n",
-    "\n",
     "\n",
     "# ports  `a` and `b` are the ports we will connect the VNA too\n",
     "for a,b in port_combos:\n",
@@ -289,9 +287,8 @@
     "    # properly copy the port impedances\n",
     "    composite.z0[:,a] = two_port.z0[:,0]\n",
     "    composite.z0[:,b] = two_port.z0[:,1]\n",
-    "    \n",
     "\n",
-    "# finally renormalize from \n",
+    "# finally renormalize from load z0 to 50 ohms\n",
     "composite.renormalize(50)"
    ]
   },
@@ -458,8 +455,6 @@
     "    # construct the impedance array, of shape FXN\n",
     "    z_loads = array([k.z.flatten() for k in loads]).T\n",
     "    composite = wg.match(nports = dut.nports)  # composite network, to be filled.\n",
-    "    #measured,measured_renorm = {},{}  # measured subnetworks and renormalized sub-networks\n",
-    "\n",
     "\n",
     "    # ports  `a` and `b` are the ports we will connect the VNA too\n",
     "    for a,b in port_combos:\n",
@@ -489,11 +484,10 @@
     "        composite.z0[:,a] = two_port.z0[:,0]\n",
     "        composite.z0[:,b] = two_port.z0[:,1]\n",
     "\n",
-    "\n",
-    "    # finally renormalize from \n",
+    "    # finally renormalize from load z0 to 50 ohms\n",
     "    composite.renormalize(50)\n",
     "    \n",
-    "    return composite\n"
+    "    return composite"
    ]
   },
   {
@@ -509,29 +503,21 @@
     "wg.frequency.npoints = 11\n",
     "dut = wg.random(4)\n",
     "\n",
-    "#er = lambda gamma: mean((tippits(dut,gamma)-dut).s_mag)/mean(dut.s_mag)\n",
     "def er(gamma, *args):\n",
     "    return max(abs(tippits(dut, rf.db_2_mag(gamma),*args).s_db-dut.s_db).flatten())\n",
     "\n",
-    "gammas = linspace(-80,0,11)\n",
-    "\n",
+    "gammas = linspace(-40,-0.1,11)\n",
     "\n",
     "title('Error vs $|\\Gamma|$')\n",
-    "plot(gammas, [er(k) for k in gammas])\n",
     "plot(gammas, [er(k) for k in gammas])\n",
     "semilogy()\n",
     "xlabel('$|\\Gamma|$ of Loads (dB)')\n",
     "ylabel('Max Error in DUT\\'s dB(S)')\n",
     "\n",
-    "\n",
-    "\n",
     "figure()\n",
-    "\n",
-    "#er = lambda gamma: max(abs(tippits(dut,gamma,(1e-5,.1)).s_db-dut.s_db).flatten())\n",
     "noise = (1e-5,.1)\n",
     "title('Error vs $|\\Gamma|$ with reasonable noise')\n",
     "plot(gammas, [er(k, noise) for k in gammas])\n",
-    "plot(gammas, [er(k,noise) for k in gammas])\n",
     "semilogy()\n",
     "xlabel('$|\\Gamma|$ of Loads (dB)')\n",
     "ylabel('Max Error in DUT\\'s dB(S)')"
@@ -549,7 +535,7 @@
   "anaconda-cloud": {},
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -563,7 +549,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1191,7 +1191,7 @@ class Network(object):
 
         # _z0 is an scalar, so a npy.array with shape fxn is filled with _z0
         if self._z0.ndim == 0:
-            return npy.full(self._s.shape[:2], self._z0)
+            self._z0 = npy.full(self._s.shape[:2], self._z0)
         elif self._z0.ndim == 1:
             # _z0 is a vector, either of length nports or frequency.npoints.
             # Create a npy.array with shape fxn and broadcast vector to array.
@@ -1200,10 +1200,11 @@ class Network(object):
                 z0[:] = self._z0[None, :]
             else:
                 z0[:] = self._z0[:,None]
-            return z0
+            self._z0 = z0
         elif self._z0.ndim == 2:
             # _z0 is a matrix of correct shape, so we can return directly
-            return self._z0
+            pass
+        return self._z0
 
     @z0.setter
     def z0(self, z0: NumberLike) -> None:

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -652,6 +652,20 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.z0 = z0
         self.assertTrue(npy.allclose(ntwk.z0, npy.array(z0, dtype=complex)))
 
+    def test_z0_assign(self):
+        """ Test that z0 getter returns a reference to _z0 so that it can
+        be assigned to with array indexing"""
+        ntwk = rf.Network(s=npy.zeros((3,2,2)), f=[1,2,3])
+        ntwk.z0[0, 0] = 2
+        self.assertTrue(ntwk.z0[0, 0] == 2)
+
+        ntwk = rf.Network(s=npy.zeros((3,2,2)), f=[1,2,3], z0=npy.ones(3))
+        ntwk.z0[0, 0] = 2
+        self.assertTrue(ntwk.z0[0, 0] == 2)
+
+        ntwk = rf.Network(s=npy.zeros((3,2,2)), f=[1,2,3], z0=npy.ones((3,2)))
+        ntwk.z0[0, 0] = 2
+        self.assertTrue(ntwk.z0[0, 0] == 2)
 
     def test_yz(self):
         tinyfloat = 1e-12


### PR DESCRIPTION
Z0 getter must return a reference to the `Network._z0` so that code like `net.z0[0, 0] = 50` can work. Fixes #660.

I really don't like this code. I tried to refactor it but every time something broke in the tests. At least this keeps the current functionality.