### PR TITLE
Fixed NanoVNA backend configuration for PyVISA-py

### DIFF
--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -122,7 +122,7 @@ class NanoVNAv2(abcvna.VNA):
     """
 
     def __init__(self, address: str = 'ASRL/dev/ttyACM0::INSTR'):
-        super().__init__(address=address, kwargs={'visa_library': 'py'})
+        super().__init__(address=address, kwargs={'visa_library': '@py'})
         self._protocol_reset()
         self._frequency = np.linspace(1e6, 10e6, 101)
         self.set_frequency_sweep(1e6, 10e6, 101)

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -472,7 +472,7 @@ class NanoVNAv2(abcvna.VNA):
     @property
     def s11(self) -> skrf.Network:
         """
-        Returns :math:`S_{1,1}` as a 1-port Network.
+        Measures :math:`S_{1,1}` and returns it as a 1-port Network.
 
         Returns
         -------
@@ -486,7 +486,7 @@ class NanoVNAv2(abcvna.VNA):
     @property
     def s21(self) -> skrf.Network:
         """
-        Returns :math:`S_{2,1}` as a 1-port Network.
+        Measures :math:`S_{2,1}` and returns it as a 1-port Network.
 
         Returns
         -------

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -122,7 +122,7 @@ class NanoVNAv2(abcvna.VNA):
     """
 
     def __init__(self, address: str = 'ASRL/dev/ttyACM0::INSTR'):
-        super().__init__(address=address, kwargs={'visa_library': '@py'})
+        super().__init__(address=address, visa_library='@py')
         self._protocol_reset()
         self._frequency = np.linspace(1e6, 10e6, 101)
         self.set_frequency_sweep(1e6, 10e6, 101)

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -479,8 +479,8 @@ class NanoVNAv2(abcvna.VNA):
         skrf.Network
         """
         traces = self.get_list_of_traces()
-        ntwk = self.get_traces(traces[0])
-        ntwk.name = 'S11'
+        ntwk = self.get_traces([traces[0]])[0]
+        ntwk.name = 'NanoVNA_S11'
         return ntwk
 
     @property
@@ -493,6 +493,6 @@ class NanoVNAv2(abcvna.VNA):
         skrf.Network
         """
         traces = self.get_list_of_traces()
-        ntwk = self.get_traces(traces[1])
-        ntwk.name = 'S21'
+        ntwk = self.get_traces([traces[1]])[0]
+        ntwk.name = 'NanoVNA_S21'
         return ntwk

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -470,7 +470,14 @@ class NanoVNAv2(abcvna.VNA):
         raise NotImplementedError
 
     @property
-    def s11(self):
+    def s11(self) -> skrf.Network:
+        """
+        Returns :math:`S_{1,1}` as a 1-port Network.
+
+        Returns
+        -------
+        skrf.Network
+        """
         traces = self.get_list_of_traces()
         ntwk = self.get_traces(traces[0])
         ntwk.name = 'S11'
@@ -478,6 +485,13 @@ class NanoVNAv2(abcvna.VNA):
 
     @property
     def s21(self):
+        """
+        Returns :math:`S_{2,1}` as a 1-port Network.
+
+        Returns
+        -------
+        skrf.Network
+        """
         traces = self.get_list_of_traces()
         ntwk = self.get_traces(traces[1])
         ntwk.name = 'S21'

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -484,7 +484,7 @@ class NanoVNAv2(abcvna.VNA):
         return ntwk
 
     @property
-    def s21(self):
+    def s21(self) -> skrf.Network:
         """
         Returns :math:`S_{2,1}` as a 1-port Network.
 

--- a/skrf/vi/vna/nanovna_v2.py
+++ b/skrf/vi/vna/nanovna_v2.py
@@ -468,3 +468,17 @@ class NanoVNAv2(abcvna.VNA):
 
     def get_switch_terms(self, ports=(1, 2), **kwargs):
         raise NotImplementedError
+
+    @property
+    def s11(self):
+        traces = self.get_list_of_traces()
+        ntwk = self.get_traces(traces[0])
+        ntwk.name = 'S11'
+        return ntwk
+
+    @property
+    def s21(self):
+        traces = self.get_list_of_traces()
+        ntwk = self.get_traces(traces[1])
+        ntwk.name = 'S21'
+        return ntwk


### PR DESCRIPTION
The current initialization for the NanoVNA V2 does not work on machines with multiple VISA backends installed (IVI, PyVISA-py, ...). 

For the serial communication with the NanoVNA V2, the PyVISA-py backend is required, but the identifier was wrong (`py` instead of `@py`). This causes an error if PyVISA-py is not the default backend.

I might add another feature to the instrument class, so I'll create the PR as a draft for now.