### PR TITLE
Fix SOLT cal kit example HTML rendering

### DIFF
--- a/doc/source/examples/metrology/SOLT Calibration Standards Creation.ipynb
+++ b/doc/source/examples/metrology/SOLT Calibration Standards Creation.ipynb
@@ -113,8 +113,7 @@
     "A shunt impedance is connected at the end of the transmission line,\n",
     "and models the distributed capacitance or inductance\n",
     "in the open or short standard. It's given as a third-degree\n",
-    "polynomial with four coefficients, $ y(x) = a_0 + a_1 x + a_2 x^2 +\n",
-    "a_3 x^3 $, where $x$ is the frequency and $a_i$ are the coefficients.\n",
+    "polynomial with four coefficients, $y(x) = a_0 + a_1 x + a_2 x^2 + a_3 x^3$, where $x$ is the frequency and $a_i$ are the coefficients.\n",
     "For an open standard, they're $\\text{C}_0$, $\\text{C}_1$, $\\text{C}_2$,\n",
     "$\\text{C}_3$, the first constant term is in femtofarad. For a short\n",
     "standard, they're $\\text{L}_0$, $\\text{L}_1$, $\\text{L}_2$, $\\text{L}_3$,\n",
@@ -971,25 +970,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## References\n",
     "\n",
-    "<div id=\"ref1\"></div>[1]: [Specifying Calibration Standards and Kits for Agilent Vector Network Analyzers](https://www.keysight.com/zz/en/assets/7018-01375/application-notes/5989-4840.pdf). See Equation 36, 37 for the propagation constant formulas of the offset transmission line.\n",
+    "<div id=\"ref1\"></div>\\[1]: [Specifying Calibration Standards and Kits for Agilent Vector Network Analyzers](https://www.keysight.com/zz/en/assets/7018-01375/application-notes/5989-4840.pdf). See Equation 36, 37 for the propagation constant formulas of the offset transmission line.\n",
     "\n",
-    "<div id=\"ref2\"></div>[2]: [METAS VNA Tools II - Math Reference V2.1](https://www.metas.ch/dam/metas/de/data/Fachbereiche/Hochfrequenz/vna-tools/vnatoolsmath-v2-1-0.pdf). See Page 26, 27 for formulas of the Keysight and R&S coefficients. The Keysight formulas are equivalent to [[1](#ref1)].\n",
+    "<div id=\"ref2\"></div>\\[2]: [METAS VNA Tools II - Math Reference V2.1](https://www.metas.ch/dam/metas/de/data/Fachbereiche/Hochfrequenz/vna-tools/vnatoolsmath-v2-1-0.pdf). See Page 26, 27 for formulas of the Keysight and R&S coefficients. The Keysight formulas are equivalent to [[1](#ref1)].\n",
     "\n",
-    "<div id=\"ref3\"></div>[3]: S-Parameters for Signal Integrity, Peter J. Pupalaikis. Page 481.\n",
+    "<div id=\"ref3\"></div>\\[3]: S-Parameters for Signal Integrity, Peter J. Pupalaikis. Page 481.\n",
     "\n",
-    "<div id=\"ref4\"></div>[4]: [Effect of Loss on VNA Calibration Standards](https://loco.lab.asu.edu/loco-memos/edges_reports/report_20130807.pdf). Source of the Keysight 85033E example.\n",
+    "<div id=\"ref4\"></div>\\[4]: [Effect of Loss on VNA Calibration Standards](https://loco.lab.asu.edu/loco-memos/edges_reports/report_20130807.pdf). Source of the Keysight 85033E example.\n",
     "\n",
-    "<div id=\"ref5\"></div>[5]: [Maury Microwave 3.5mm Coaxial Calibration Kit User Guide](https://www.maurymw.com/CalKit_Explorer/downloads/8050-511.pdf). Source of the Maury Microwave 8050CK10 example. The coefficients of this calibration kit are given in multiple formats (Anritsu, Keysight, and R&S). You can compare and contrast their differences."
+    "<div id=\"ref5\"></div>\\[5]: [Maury Microwave 3.5mm Coaxial Calibration Kit User Guide](https://www.maurymw.com/CalKit_Explorer/downloads/8050-511.pdf). Source of the Maury Microwave 8050CK10 example. The coefficients of this calibration kit are given in multiple formats (Anritsu, Keysight, and R&S). You can compare and contrast their differences."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1003,7 +1004,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #685.

Remove line break in the middle of equation. Escape markdown in References section.