### PR TITLE
Remove comparison to CPW model from MTRL example

### DIFF
--- a/doc/source/examples/metrology/Multiline TRL.ipynb
+++ b/doc/source/examples/metrology/Multiline TRL.ipynb
@@ -258,9 +258,7 @@
     "\n",
     "$\\gamma = \\frac{2\\pi f}{c}\\sqrt{\\epsilon_{r,eff}}$, where $c$ equals the speed of light and $f$ is frequency.\n",
     "\n",
-    "In general it's a complex value with the imaginary part indicating losses.\n",
-    "\n",
-    "CPW line effective permittivity can be approximated as average of substrate and air permittivities."
+    "In general it's a complex value with the imaginary part indicating losses."
    ]
   },
   {
@@ -271,20 +269,13 @@
    "source": [
     "# Define calibration standard media \n",
     "freq = dut.frequency\n",
-    "cpw = CPW(freq, z0=55, w=40e-6, s=25e-6, ep_r=12.9,\n",
-    "                     t=5e-6, rho=2e-8)\n",
     "\n",
     "# Get the cal with the both lines\n",
     "cal = cals[-1]\n",
     "\n",
-    "# Calculate CPW complex permittivity from the propagation constant\n",
-    "c = 299792458\n",
-    "er_eff = -(c*cpw.gamma/(2*np.pi*freq.f))**2\n",
-    "\n",
     "plt.figure()\n",
     "plt.title('CPW effective permittivity (real part)')\n",
     "plt.plot(f_ghz, cal.er_eff.real, label='Solved er_eff')\n",
-    "plt.plot(f_ghz, er_eff.real, label='Actual er_eff')\n",
     "plt.xlabel('Frequency (GHz)')\n",
     "plt.legend(loc='lower right')"
    ]
@@ -307,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we know the ideals in this simulation we can re-define them here, and compare the determined reflect to the actual reflect.  (see below for simulation details)"
+    "Applying the calibration to the measured reflect standard we can get the calibrated S-parameters of the unknown reflect."
    ]
   },
   {
@@ -317,9 +308,8 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "plt.title('Solved and actual reflection coefficient of the reflect standard')\n",
-    "cal.apply_cal(measured[1]).plot_s_deg(n=0, m=0, label='Solved')\n",
-    "cpw.delay_short(10e-6, 'm').plot_s_deg(n=0, m=0, label='Actual')"
+    "plt.title('Solved reflection coefficient of the reflect standard')\n",
+    "cal.apply_cal(measured[1]).plot_s_deg(n=0, m=0, label='Solved short')"
    ]
   },
   {


### PR DESCRIPTION
CPW model was changed and data in the files does not match to the current CPW model anymore. The comparisons to the model did not match up anymore due to it. To avoid needing to update this document in future remove the comparison to CPW model.