### PR TITLE
IEEEP370 example: import from skrf.deembedding, not calibration.

### DIFF
--- a/doc/source/examples/networktheory/IEEEP370 Deembedding.ipynb
+++ b/doc/source/examples/networktheory/IEEEP370 Deembedding.ipynb
@@ -33,10 +33,10 @@
    "source": [
     "import skrf as rf\n",
     "import matplotlib.pyplot as plt\n",
-    "from skrf.calibration import IEEEP370_SE_NZC_2xThru\n",
-    "from skrf.calibration import IEEEP370_MM_NZC_2xThru\n",
-    "from skrf.calibration import IEEEP370_SE_ZC_2xThru\n",
-    "from skrf.calibration import IEEEP370_MM_ZC_2xThru\n",
+    "from skrf.deembedding import IEEEP370_SE_NZC_2xThru\n",
+    "from skrf.deembedding import IEEEP370_MM_NZC_2xThru\n",
+    "from skrf.deembedding import IEEEP370_SE_ZC_2xThru\n",
+    "from skrf.deembedding import IEEEP370_MM_ZC_2xThru\n",
     "from skrf.media import MLine\n",
     "import numpy as np\n",
     "rf.stylely()"


### PR DESCRIPTION
In scikit-rf, we clearly distinguish between calibration (almost complete error correction at the VNA measurement plane) and deembedding (partial error correction to remove fixture effects).

IEEEP370 is a deembedding method, not a calibration method. Thus, it should be imported from `skrf.deembedding`, not `skrf.calibration`. The fact that `skrf.calibration` also works is only an implementation detail and goes against the official API documentation, and it should be discouraged.