### PR TITLE
Attempt to simplify media line creation

### DIFF
--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -847,7 +847,14 @@ class Media(ABC):
         result.s = \
                 npy.array([[s11, s21],[s21,s11]]).transpose().reshape(-1,2,2)
 
+        # todo: some magic here to make embed emmit a warning but keep
+        # `media.line(line_l, 'm', embed=True, z0=media.Z0)` working for
+        # backward compatibility
         if embed:
+            warnings.warn('In a future version,`embed` will be deprecated.\n'
+                          'Port impedance of the line network will be media or line Z0 embedded into media or line z0.\n'
+                          'Line Z0 or z0 will have priority on media if not set to None.',
+              FutureWarning, stacklevel = 2)
             # Use the same s_def here as the line to avoid changing it during
             # cascade.
             result = self.thru(s_def='traveling')**result**self.thru(s_def='traveling')


### PR DESCRIPTION
Attempt to fix #651 

`Media.line` creation should follow these a, b, c, and d cases depending on the parameters `Z0` and `z0` of `Media` and `line`. If one of these parameters is not `None` in both `Media` and `line`, `line` has priority.

| | Media port impedance |  Line port impedance | Expected resulting network port impedance and normalization |
|---|---|---|---|
| a | `media.z0 == None` | `line.z0 == None` | `z0 = media.Z0`, no renormalization required |
| b | `media.z0 == None` | `line.z0 == z2` | `z0 = line.z0 = z2`, renormalization media.Z0 to z2 |
| c | `media.z0 == z1` | `line.z0 == None` | `z0 = media.z0 = z1`, renormalization media.Z0 to z1 |
| d | `media.z0 == z1` | `line.z0 == z2` | `z0 = line.z0 = z2`, renormalization media.Z0 to z2 |

This should keep functioning: `media.line(line_l, 'm', embed=True, z0=media.Z0)` , but `embed` parameter should  issue a `FutureWarning` to indicate future deprecation of this behaviour if set to `True`.