### PR TITLE
Vector Fitting: Minor updates

### DIFF
--- a/doc/source/examples/vectorfitting/vectorfitting_ex1_ringslot.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex1_ringslot.ipynb
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use the model in a circuit simulation, an equivalent circuit can be created based on the fitting parameters. This is currently only implemented for SPICE, but the structure of the equivalent circuit can be adopted to any kind of circuit simulator."
+    "To use the model in a circuit simulation, an equivalent circuit can be created based on the fitting parameters. This is currently only implemented for SPICE, but the structure of the equivalent circuit can be adopted to any kind of circuit simulator. Attention: A UserWarning about a non-passive fit was printed (see output of vector_fit() above). The assessment and enforcement of model passivity is described in more detail in [this example](./vectorfitting_ex4_passivity.ipynb), which is important for certain use cases in circuit simulators, i.e. transient simulations."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/vectorfitting/vectorfitting_ex3_Agilent_E5071B.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex3_Agilent_E5071B.ipynb
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As shown in the plots, a very good fit was achieved. This is also indicated with the low rms error of less than 0.01. To use the model in a circuit simulation, an equivalent circuit can be created based on the fitting parameters. This is currently only implemented for SPICE, but the structure of the equivalent circuit can be adopted to any kind of circuit simulator."
+    "As shown in the plots, a very good fit was achieved. This is also indicated with the low rms error of less than 0.01. However, a UserWarning about a non-passive fit was printed (see output of vector_fit() above). The assessment and enforcement of model passivity is described in more detail in [this example](./vectorfitting_ex4_passivity.ipynb), which is important for certain use cases in circuit simulators, i.e. transient simulations. To use the model in a circuit simulation, an equivalent circuit can be created based on the fitting parameters. This is currently only implemented for SPICE, but the structure of the equivalent circuit can be adopted to any kind of circuit simulator."
    ]
   },
   {
@@ -169,7 +169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.8"
   },
   "nbsphinx": {
    "timeout": 240

--- a/doc/source/examples/vectorfitting/vectorfitting_ex4_passivity.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex4_passivity.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The fitting result does not look too bad. Let's check the RMS error:"
+    "The fitting result looks fine, but a UserWarning about a non-passive vector fit was printed. Before investigating this issue, let's check the RMS error:"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An RMS error of less than 0.05 usually indicates a good fit and confirms our optical inspection. But is the model still passive at all frequencies?"
+    "An RMS error of less than 0.05 usually indicates a good fit and confirms our optical inspection. But what about the passivity of the fitted model?"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's not passive? What's going on? Wasn't the original data of the ring slot representing a passive network?"
+    "Why is the model not passive? Wasn't the original data of the ring slot representing a passive network?"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The network data was passive, but the vector fitted model is not. Let's investigate (and correct?) the problem. "
+    "The network data was passive, but the vector fitted model is not. Let's investigate (and correct?) the problem some more. "
    ]
   },
   {
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The network is not passive in two frequency bands: From dc to about 44.9 GHz, and from 84.3 GHz to 98.5 GHz.\n",
+    "The network is not passive in two frequency bands: From dc to about 27.8 GHz, and from 84.3 GHz to 98.5 GHz.\n",
     "Luckily, passivity can be enforced to obtain passive vector fitted model:"
    ]
   },
@@ -243,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -85,6 +85,8 @@ class VectorFitting:
 
     def __init__(self, network: 'Network'):
         self.network = network
+        """ Instance variable holding the Network to be fitted. This is the Network passed during initialization, 
+        which may be changed or set to *None*. """
 
         self.poles = None
         """ Instance variable holding the list of fitted poles. Will be initialized by :func:`vector_fit`. """

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1383,8 +1383,8 @@ class VectorFitting:
         return resp
 
     @check_plotting
-    def plot(self, component: str, parameter: str = 's', i: int = -1, j: int = -1, freqs: Any = None,
-             ax: mplt.Axes = None) -> mplt.Axes:
+    def plot(self, component: str, i: int = -1, j: int = -1, freqs: Any = None,
+             parameter: str = 's', ax: mplt.Axes = None) -> mplt.Axes:
         """
         Plots the specified component of the parameter :math:`H_{i+1,j+1}` in the fit, where :math:`H` is
         either the scattering (:math:`S`), the impedance (:math:`Z`), or the admittance (:math:`H`) response specified
@@ -1402,11 +1402,6 @@ class VectorFitting:
             `re` for real part in linear scale,
             `im` for imaginary part in linear scale.
 
-        parameter : str, optional
-            The network representation to be used. This is only relevant for the plot of the original sampled response
-            in :attr:`network` that is used for comparison with the fit. Must be one of the following items unless
-            :attr:`network` is `None`: ['s', 'z', 'y'] for *scattering* (default), *impedance*, or *admittance*.
-
         i : int, optional
             Row index of the response. `-1` to plot all rows.
 
@@ -1416,6 +1411,11 @@ class VectorFitting:
         freqs : list of float or ndarray or None, optional
             List of frequencies for the response plot. If None, the sample frequencies of the fitted network in
             :attr:`network` are used. This only works if :attr:`network` is not `None`.
+
+        parameter : str, optional
+            The network representation to be used. This is only relevant for the plot of the original sampled response
+            in :attr:`network` that is used for comparison with the fit. Must be one of the following items unless
+            :attr:`network` is `None`: ['s', 'z', 'y'] for *scattering* (default), *impedance*, or *admittance*.
 
         ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.


### PR DESCRIPTION
Fixes a few minor issues:
- extending `VectorFitting.plot()` to plot either S, Z, or Y parameters of the (optional) base network in `VectorFitting.network`
- adding a docstring for `VectorFitting.network` to have it listed in the docs
- addressing the new UserWarnings in case of non-passive fits of passive networks in the example notebooks