### PR TITLE
Add forced_z11x to IEEEP370_SE_NZC_2xThru and correct typo

### DIFF
--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1422,7 +1422,7 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
             
         forced_z11x_dd:
             If a value is specified, manually force this value for the midpoint
-            impedance z11x for diffrential-mode.
+            impedance z11x for differential-mode.
             This is only usefull in the case where the midpoint impedance is
             non-uniform and the x length ± 1 sample error caused by the delay
             not being an integer multiple of sampling time make the z11x choice

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1184,7 +1184,7 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                 ax1.legend()
                 ax2 = plt.subplot(2, 1, 2, sharex = ax1)
                 ax2.plot(z11, label = 'z11')
-                ax2.plot([x], [z11[x]], marker = 'o', linestyle = 'none',
+                ax2.plot([x], [z11x], marker = 'o', linestyle = 'none',
                             label = 'z11x')
                 ax2.set_xlabel('t-samples')
                 ax2.set_xlim((x - 50, x + 50))

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -991,19 +991,29 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
             
         use_z_instead_ifft:
             use z-transform instead ifft. This method is not documented in
-            the paper but exists in the IEEE repo. It is intended to be
-            used only if the length of the 2x-Thru is so short that there is
-            not enough point in time domain to determine length and impedance
-            of midpoint. Parameter `verbose` could be used for diagnostic in
-            ifft mode (default: False)
+            the paper but exists in the IEEE repo. It could be used if the
+            2x-Thru is so short that there is not enough points in time domain
+            to determine the length of half fixtures from the s21 impulse
+            response and the the impedance at split plane from the s11 step
+            response.
+            Parameter `verbose` could be used for diagnostic in
+            ifft mode. (default: False)
             
         forced_z0_line:
-            If a value is specified, manually force this value for the midpoint
-            impedance z0_line. The fixtures are renormalized with this value.
-            This is only usefull in the case where the midpoint impedance is
-            non-uniform and the x length ± 1 sample error caused by the delay
-            not being an integer multiple of sampling time make the z11x choice
-            incorrect. (Default: None)
+            If specified, the value for the split plane impedance is forced to
+            `forced_z0_line`.
+            The IEEEP370 standard recommends the 2x-Thru being at least three
+            wavelengths at the highest measured frequency. This ensures that
+            the split plane impedance measured in the S11 step response is free
+            of reflections from the launches.
+            If the 2x-Thru is too short, any point in the s11 step response
+            contain reflections from the lanches and split plane impedance
+            cannot be determined accurately by this method.
+            In this case, setting the impedance manually can improve the
+            results. However, it should be noted that each fixture model will
+            still include some reflections from the opposite side launch
+            because there is not enough time resolution to separate them.
+            (Default: None)
         
         verbose :
             view the process (default: False)
@@ -1414,29 +1424,34 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
             
         use_z_instead_ifft:
             use z-transform instead ifft. This method is not documented in
-            the paper but exists in the IEEE repo. It is intended to be
-            used only if the length of the 2x-Thru is so short that there is
-            not enough point in time domain to determine length and impedance
-            of midpoint. Parameter `verbose` could be used for diagnostic in
-            ifft mode (default: False)
+            the paper but exists in the IEEE repo. It could be used if the
+            2x-Thru is so short that there is not enough points in time domain
+            to determine the length of half fixtures from the s21 impulse
+            response and the the impedance at split plane from the s11 step
+            response.
+            Parameter `verbose` could be used for diagnostic in
+            ifft mode. (default: False)
             
         forced_z0_line_dd:
-            If a value is specified, manually force this value for the midpoint
-            impedance z0_line for differential-mode. The fixtures are
-            renormalized with this value.
-            This is only usefull in the case where the midpoint impedance is
-            non-uniform and the x length ± 1 sample error caused by the delay
-            not being an integer multiple of sampling time make the z11x choice
-            incorrect. (Default: None)
+            If specified, the value for the split plane impedance is forced to
+            `forced_z0_line` for differential-mode.
+            The IEEEP370 standard recommends the 2x-Thru being at least three
+            wavelengths at the highest measured frequency. This ensures that
+            the split plane impedance measured in the S11 step response is free
+            of reflections from the launches.
+            If the 2x-Thru is too short, any point in the s11 step response
+            contain reflections from the lanches and split plane impedance
+            cannot be determined accurately by this method.
+            In this case, setting the impedance manually can improve the
+            results. However, it should be noted that each fixture model will
+            still include some reflections from the opposite side launch
+            because there is not enough time resolution to separate them.
+            (Default: None)
             
         forced_z0_line_cc:
-            If a value is specified, manually force this value for the midpoint
-            impedance z0_line for common-mode. The fixtures are
-            renormalized with this value.
-            This is only usefull in the case where the midpoint impedance is
-            non-uniform and the x length ± 1 sample error caused by the delay
-            not being an integer multiple of sampling time make the z11x choice
-            incorrect. (Default: None)
+            Same behaviour as `forced_z0_line_dd`, but for the common-mode
+            split plane impedance.
+            (Default: None)
         
         verbose :
             view the process (default: False)

--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -973,7 +973,7 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
     """
     def __init__(self, dummy_2xthru, name=None,
                  z0 = 50, use_z_instead_ifft = False, verbose = False,
-                 forced_z11x = None, *args, **kwargs):
+                 forced_z0_line = None, *args, **kwargs):
         """
         IEEEP370_SE_NZC_2xThru De-embedding Initializer
 
@@ -997,9 +997,9 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
             of midpoint. Parameter `verbose` could be used for diagnostic in
             ifft mode (default: False)
             
-        forced_z11x:
+        forced_z0_line:
             If a value is specified, manually force this value for the midpoint
-            impedance z11x.
+            impedance z0_line. The fixtures are renormalized with this value.
             This is only usefull in the case where the midpoint impedance is
             non-uniform and the x length ± 1 sample error caused by the delay
             not being an integer multiple of sampling time make the z11x choice
@@ -1020,7 +1020,7 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
         self.z0 = z0
         dummies = [self.s2xthru]
         self.use_z_instead_ifft = use_z_instead_ifft
-        self.forced_z11x = forced_z11x
+        self.forced_z0_line = forced_z0_line
         self.verbose = verbose
 
         Deembedding.__init__(self, dummies, name, *args, **kwargs)
@@ -1168,8 +1168,8 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
             step11 = self.makeStep(t11)
             z11 = -self.z0 * (step11 + 1) / (step11 - 1)
             
-            if self.forced_z11x:
-                z11x = self.forced_z11x
+            if self.forced_z0_line:
+                z11x = self.forced_z0_line
             else:
                 z11x = z11[x]
             
@@ -1393,7 +1393,7 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
     def __init__(self, dummy_2xthru, name=None,
                  z0 = 50, port_order: str = 'second',
                  use_z_instead_ifft = False, verbose = False,
-                 forced_z11x_dd = None, forced_z11x_cc = None, *args, **kwargs):
+                 forced_z0_line_dd = None, forced_z0_line_cc = None, *args, **kwargs):
         """
         IEEEP370_MM_NZC_2xThru De-embedding Initializer
 
@@ -1420,17 +1420,19 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
             of midpoint. Parameter `verbose` could be used for diagnostic in
             ifft mode (default: False)
             
-        forced_z11x_dd:
+        forced_z0_line_dd:
             If a value is specified, manually force this value for the midpoint
-            impedance z11x for differential-mode.
+            impedance z0_line for differential-mode. The fixtures are
+            renormalized with this value.
             This is only usefull in the case where the midpoint impedance is
             non-uniform and the x length ± 1 sample error caused by the delay
             not being an integer multiple of sampling time make the z11x choice
             incorrect. (Default: None)
             
-        forced_z11x_cc:
+        forced_z0_line_cc:
             If a value is specified, manually force this value for the midpoint
-            impedance z11x for common-mode.
+            impedance z0_line for common-mode. The fixtures are
+            renormalized with this value.
             This is only usefull in the case where the midpoint impedance is
             non-uniform and the x length ± 1 sample error caused by the delay
             not being an integer multiple of sampling time make the z11x choice
@@ -1452,8 +1454,8 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
         self.port_order = port_order
         dummies = [self.s2xthru]
         self.use_z_instead_ifft = use_z_instead_ifft
-        self.forced_z11x_dd = forced_z11x_dd
-        self.forced_z11x_cc = forced_z11x_cc
+        self.forced_z0_line_dd = forced_z0_line_dd
+        self.forced_z0_line_cc = forced_z0_line_cc
         self.verbose = verbose
 
         Deembedding.__init__(self, dummies, name, *args, **kwargs)
@@ -1529,11 +1531,11 @@ class IEEEP370_MM_NZC_2xThru(Deembedding):
         dm_dd  = IEEEP370_SE_NZC_2xThru(dummy_2xthru = sdd, z0 = self.z0 * 2,
                                 use_z_instead_ifft = self.use_z_instead_ifft,
                                 verbose = self.verbose,
-                                forced_z11x = self.forced_z11x_dd)
+                                forced_z0_line = self.forced_z0_line_dd)
         dm_cc  = IEEEP370_SE_NZC_2xThru(dummy_2xthru = scc, z0 = self.z0 / 2,
                                 use_z_instead_ifft = self.use_z_instead_ifft,
                                 verbose = self.verbose,
-                                forced_z11x = self.forced_z11x_cc)
+                                forced_z0_line = self.forced_z0_line_cc)
         
         #convert back to single-ended
         mm_side1 = concat_ports([dm_dd.s_side1, dm_cc.s_side1], port_order = 'first')


### PR DESCRIPTION
`IEEEP370_SE_NZC_2xThru` use the time-domain impulse response of s21 to compute the x length of the 2x-Thru network in time samples. The impedance z11x is taken on midpoint x in a step response of Z11 with DC extrapolation. This works well in the case where the 2x-thru has an uniform impedance segment around the midpoint.

Most of the time, the 2x-Thru length is not an integer multiple of time-domain sample time. This can lead to a ± 1 sample error in midpoint determination. If the impedance is non-uniform at midpoint, it can change slightly with a shift of 1 point left or right. This PR enable advanced users to manually set the z11x impedance to a known value in this case. 

- [x] Fix indentation error causing ZL and ZR being re-affected at each loop instead at the end
- [x] Fix ZL being computed twice and ZR never
- [x] Add the ability to manually force the midpoint impedance z11x for IEEEP370_SE_NZC_2xThru