### PR TITLE
Three Receivers Calibration: clarify SOLT procedures and source port.

### DIFF
--- a/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
+++ b/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
@@ -77,6 +77,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Measure the Calibration Standands and DUT\n",
+    "\n",
+    "First, one measures the S-parameters of the Open, Short, and Load standards on the VNA according to the standard SOLT calibration procedures. We assume the reader is familiar with this task in scikit-rf. If not, it's fully described in the [SOLT example](https://scikit-rf.readthedocs.io/en/latest/examples/metrology/SOLT.html).\n",
+    "\n",
+    "When calibrating a three-receiver VNA, the process is almost identical. But note that there are a few minor differences. First, the Open, Short, and Load standards are only measured at port 1, not port 2. The VNA cannot measure in the reverse orientation, so there's no reason to perform OSL calibration at port 2 (unless one needs the optional isolation calibration). \n",
+    "\n",
+    "Nevetheless, scikit-rf still expects two-port networks as input, we therefore still save all results as two-port networks. In this case, only $S_{11}$ and $S_{21}$ are the actual measurements, $S_{12}$ and $S_{22}$ are unused, not meaningful, and can contain arbitrary data. One can use all-zero values as placeholders. Internally, scikit-rf will set $S_{22} = S_{11}$ and $S_{12} = S_{21}$ for the purpose of calculations.\n",
+    "\n",
+    "Then, the DUT is measured as a two-port network in the forward direction, physically flipped, and then measured again in the reverse orientation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Read in the Data"
    ]
   },

--- a/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
+++ b/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example demonstrates how to create a [TwoPortOnePath](http://scikit-rf.readthedocs.org/en/latest/reference/calibration/generated/skrf.calibration.calibration.TwoPortOnePath.html#skrf.calibration.calibration.TwoPortOnePath)  and [EnhancedResponse](http://scikit-rf.readthedocs.org/en/latest/reference/calibration/generated/skrf.calibration.calibration.EnhancedResponse.html#skrf.calibration.calibration.EnhancedResponse) calibration from  measurements taken on a Agilent PNAX with a set of VDI WR-12 TXRX-RX Frequency Extender heads.  Comparisons between the two algorithms are made by correcting an asymmetric  DUT."
+    "This example demonstrates how to create a [TwoPortOnePath](../../api/calibration/generated/skrf.calibration.calibration.TwoPortOnePath.rst) and [EnhancedResponse](../../api/calibration/generated/skrf.calibration.calibration.EnhancedResponse.rst) calibration from  measurements taken on a Agilent PNAX with a set of VDI WR-12 TXRX-RX Frequency Extender heads.  Comparisons between the two algorithms are made by correcting an asymmetric  DUT."
    ]
   },
   {
@@ -79,7 +79,7 @@
    "source": [
     "### Measure the Calibration Standands and DUT\n",
     "\n",
-    "First, one measures the S-parameters of the Open, Short, and Load standards on the VNA according to the standard SOLT calibration procedures. We assume the reader is familiar with this task in scikit-rf. If not, it's fully described in the [SOLT example](https://scikit-rf.readthedocs.io/en/latest/examples/metrology/SOLT.html).\n",
+    "First, one measures the S-parameters of the Open, Short, and Load standards on the VNA according to the standard SOLT calibration procedures. We assume the reader is familiar with this task in scikit-rf. If not, it's fully described in the [SOLT example](./SOLT.ipynb).\n",
     "\n",
     "When calibrating a three-receiver VNA, the process is almost identical. But note that there are a few minor differences. First, the Open, Short, and Load standards are only measured at port 1, not port 2. The VNA cannot measure in the reverse orientation, so there's no reason to perform OSL calibration at port 2 (unless one needs the optional isolation calibration). \n",
     "\n",
@@ -187,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the code that follows a TwoPortOnePath calibration is created from corresponding  measured and ideal responses of the calibration standards. The measured networks are read from disk, while their corresponding ideal responses are generated using scikit-rf. More information about using scikit-rf to do offline calibrations can be found [here](http://scikit-rf.readthedocs.org/en/latest/tutorials/calibration.html). "
+    "In the code that follows a TwoPortOnePath calibration is created from corresponding  measured and ideal responses of the calibration standards. The measured networks are read from disk, while their corresponding ideal responses are generated using scikit-rf. More information about using scikit-rf to do offline calibrations can be found [here](../../tutorials/Calibration.ipynb)."
    ]
   },
   {

--- a/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
+++ b/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
@@ -229,6 +229,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "By default, `TwoPortOnePath` assumes port 1 is the active source in all calibrations and measurements (thus only $S_{11}$ and $S_{21}$ are valid data). If, for some reason, the valid measurements are presented as $S_{12}$ and $S_{22}$, one can set the optional parameter `source_port=2` when creating the `TwoPortOnePath` object.\n",
+    "\n",
+    "\n",
     "### Apply Correction"
    ]
   },


### PR DESCRIPTION
This update clarifies the Correct SOLT Calibration Procedure for 1.5-port VNAs. First, I added a reference to the SOLT example. I also explained the difference between a standard SOLT calibration and a three-receiver calibration, including the fact that SOL at port 2 is not needed (unless there's need to calibrate isolation), and that the results are still saved as 2-port network, but S22 and S12 will contain no meaningful data.

This PR clarifies the question reported in Issue #629.