### PR TITLE
Three Receivers Calibration: Add Reference to NanoVNA

### DIFF
--- a/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
+++ b/doc/source/examples/metrology/Calibration With Three Receivers.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "It has long been known that full error correction is possible given a VNA with only three receivers and no internal coaxial switch. However, since no modern VNA employs such an architecture, the software required to make fully corrected measurements is not available on today's modern VNA's. \n",
     "\n",
-    "Recently, the application of Frequency Extender units containing only three receivers has become more common.  Thus, there is a need for full error correction capability on systems with three receivers and no  internal coaxial switch. This document describes how to use [scikit-rf](http://www.scikit-rf.org) to fully correct two-port measurements made on such a system."
+    "Recently, the application of Frequency Extender units containing only three receivers has become more common. Furthermore, low-cost VNAs are becoming useful tools for learning RF electronics. The representative example is NanoVNA, which uses a three-receiver design. Thus, there is a need for full error correction capability on systems with three receivers and no  internal coaxial switch. This document describes how to use [scikit-rf](http://www.scikit-rf.org) to fully correct two-port measurements made on such a system."
    ]
   },
   {

--- a/doc/source/examples/metrology/NanoVNA_V2_4port-splitter.ipynb
+++ b/doc/source/examples/metrology/NanoVNA_V2_4port-splitter.ipynb
@@ -13,7 +13,9 @@
    "id": "39fddba6",
    "metadata": {},
    "source": [
-    "The NanoVNA V2 is a 1.5-port VNA, meaning it can only measure the forward reflection and transmission coefficients $S_{11}$ and $S_{21}$ with its two ports. To measure the reverse coefficients $S_{12}$ and $S_{22}$ of a 2-port, it needs to be measured a second time with the port orientation physically flipped (or fake-flipped), as explained in [this example](TwoPortOnePath, EnhancedResponse, and FakeFlip.ipynb). The issue gets worse if the device under test (DUT) has even more ports, as described in [this example](./Measuring a Mutiport Device with a 2-Port Network Analyzer.ipynb).\n",
+    "The NanoVNA V2 is a 1.5-port VNA, meaning it can only measure the forward reflection and transmission coefficients $S_{11}$ and $S_{21}$ with its two ports. This is known as a three-receiver VNA architecture, still, fully-calibrated two-port measurements are possible despite this limitation. We recommend the readers to read [Calibration With Three Receivers](./Calibration With Three Receivers.ipynb) first to familiarize themselves with the basic background.\n",
+    "\n",
+    "In short, to measure the reverse coefficients $S_{12}$ and $S_{22}$ of a 2-port, it needs to be measured a second time with the port orientation physically flipped (or fake-flipped), as explained in [this example](TwoPortOnePath, EnhancedResponse, and FakeFlip.ipynb). The issue gets worse if the device under test (DUT) has even more ports, as described in [this example](./Measuring a Mutiport Device with a 2-Port Network Analyzer.ipynb).\n",
     "\n",
     "In this example, a [4-port SMA power splitter](https://www.minicircuits.com/WebStore/dashboard.html?model=ZX10Q-2-19-S%2B) is measured with a NanoVNA V2 using the Matched Port technique. It involves measuring the 4-port in all port combinations (12 measurements) with the unused ports terminated with a 50-Ohm match. For the VNA calibration, four more measurements with the SMA calibration standards are required (SHORT, OPEN, MATCH, THROUGH). The manufacturer of the DUT provides measured S-parameters on their website, which will later be used for comparison."
    ]


### PR DESCRIPTION
First, in the *Measuring a 4-Port With The 1.5-Port NanoVNA V2* guide, I added a suggestion for the user to read *Calibration With Three Receivers* first to familiarize themselves with the three-receiver VNA architecture. Also, I added a NanoVNA reference in the beginning of *Calibration With Three Receivers* as a new motivation for using the three-receiver calibration technique. This is another attempt to clarify the documentation per #629.