### PR TITLE
Convert All Documentation Links to Relative Path Links

### DIFF
--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -35,7 +35,7 @@ Basically, you will:
 3. Then send a `pull request (PR) <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests>`_ for your additions to be merged into the main scikit-rf repository. Your proposal will be reviewed or discussed and you may receive some comments which only aim to make your contribution as great as possible!
 
 
-.. tip:: When making your modification locally, you may need to work into a dedicated development environment in order to not interfere with the scikit-rf package that you have `already installed <https://scikit-rf.readthedocs.io/en/latest/tutorials/Installation.html>`_. You can use for example `anaconda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_. In order for the anaconda environment to find your local scikit-rf repo, use the convenient `conda-develop <https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`_ command.
+.. tip:: When making your modification locally, you may need to work into a dedicated development environment in order to not interfere with the scikit-rf package that you have `already installed <../tutorials/Installation.html>`_. You can use for example `anaconda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_. In order for the anaconda environment to find your local scikit-rf repo, use the convenient `conda-develop <https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`_ command.
 
 
 Basic git command-line workflow

--- a/doc/source/examples/metrology/One Port Tiered Calibration.ipynb
+++ b/doc/source/examples/metrology/One Port Tiered Calibration.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook will demonstrate how to use [skrf](www.scikit-rf.org) to do a two-tiered one-port calibration.  We'll use  data that was taken to characterize a waveguide-to-CPW probe. So, for this specific example the diagram above looks like:\n",
+    "This notebook will demonstrate how to use [skrf](http://scikit-rf.org) to do a two-tiered one-port calibration.  We'll use  data that was taken to characterize a waveguide-to-CPW probe. So, for this specific example the diagram above looks like:\n",
     "\n",
     "![probe diagram](oneport_tiered_calibration/images/probe.svg)"
    ]
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because we saved corresponding *ideal* and *measured* standards with identical names, the Calibration will automatically align our standards upon initialization. (More info on creating Calibration objects this can be found in [the docs](http://scikit-rf.readthedocs.org/en/latest/tutorials/calibration.html).)\n",
+    "Because we saved corresponding *ideal* and *measured* standards with identical names, the Calibration will automatically align our standards upon initialization. (More info on creating Calibration objects this can be found in [the docs](../../tutorials/Calibration.ipynb).)\n",
     "\n",
     "Similarly for the second tier 2,"
    ]

--- a/doc/source/examples/metrology/SOLT Calibration Standards Creation.ipynb
+++ b/doc/source/examples/metrology/SOLT Calibration Standards Creation.ipynb
@@ -37,7 +37,7 @@
     "lines cannot be applied to waveguides because loss is also a function of their\n",
     "physical dimensions, with significant more complicated formulas. Do you have\n",
     "waveguide experience? If so, you can help by\n",
-    "[contributing](https://scikit-rf.readthedocs.io/en/latest/contributing/index.html#examples-and-tutorials) to the doc.\n",
+    "[contributing](../../contributing/index.rst#examples-and-tutorials) to the doc.\n",
     "\n",
     "\n",
     "## Alternatives to scikit-rf Modeling\n",
@@ -442,7 +442,7 @@
     "two-port networks as standards since they're used in two-port calibrations. You can\n",
     "use the function `skrf.two_port_reflect()` to generate a two-port network\n",
     "from two one-port networks. For more information, be sure to read the\n",
-    "[SOLT calibration](https://scikit-rf.readthedocs.io/en/latest/examples/metrology/SOLT.html) example in the doc.\n"
+    "[SOLT calibration](./SOLT.ipynb) example in the doc.\n"
    ]
   },
   {

--- a/doc/source/examples/metrology/TwoPortOnePath, EnhancedResponse, and FakeFlip.ipynb
+++ b/doc/source/examples/metrology/TwoPortOnePath, EnhancedResponse, and FakeFlip.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "These measurements where taken on a Agilent PNAX with a set of VDI WR-12 TXRX-RX Frequency Extender heads. The measurements of the calibration standards and DUT's  were downloaded from the VNA by saving touchstone files of the raw s-parameter data to disk.  \n",
     "\n",
-    "In the code that follows a TwoPortOnePath calibration is created from corresponding  measured and ideal responses of the calibration standards. The measured networks are read from disk, while their corresponding ideal responses are generated using scikit-rf. More information about using scikit-rf to do offline calibrations can be found [here](http://scikit-rf.readthedocs.org/en/latest/tutorials/calibration.html). "
+    "In the code that follows a TwoPortOnePath calibration is created from corresponding  measured and ideal responses of the calibration standards. The measured networks are read from disk, while their corresponding ideal responses are generated using scikit-rf. More information about using scikit-rf to do offline calibrations can be found [here](../../tutorials/Calibration.ipynb). "
    ]
   },
   {

--- a/doc/source/examples/networktheory/IEEEP370 Deembedding.ipynb
+++ b/doc/source/examples/networktheory/IEEEP370 Deembedding.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "The target is to bisect `s2xthru` to get the left and right fixtures models and get DUT by deembedding from FIX-DUT-FIX.\n",
     "\n",
-    "The microstrip lines are inspired by [this example](https://scikit-rf.readthedocs.io/en/latest/examples/networktheory/Time%20domain%20reflectometry%2C%20measurement%20vs%20simulation.html)."
+    "The microstrip lines are inspired by [this example](./Time domain reflectometry, measurement vs simulation.ipynb)."
    ]
   },
   {

--- a/doc/source/examples/networktheory/Time Domain.ipynb
+++ b/doc/source/examples/networktheory/Time Domain.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebooks demonstrates how to use [scikit-rf](www.scikit-rf.org) for time-domain analysis and gating. A quick example is given first, followed by a more detailed explanation.\n",
+    "This notebooks demonstrates how to use [scikit-rf](http://scikit-rf.org) for time-domain analysis and gating. A quick example is given first, followed by a more detailed explanation.\n",
     "\n",
     "\n",
     "S-parameters are measured in the frequency domain, but can be analyzed in  time domain if you like. In many cases, measurements are not made down to DC. This implies that the  time-domain transform is not complete, but it can be very useful nonetheless. A major application of time-domain analysis is to use *gating* to isolate a single response in space. More information about the details of time domain analysis see [1]. \n",
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Out DUT in this example is a waveguide-to-CPW probe, that was measured in [this other example](../metrology/One%20Port%20Tiered%20Calibration.ipynb). "
+    "Out DUT in this example is a waveguide-to-CPW probe, that was measured in [this other example](../metrology/One Port Tiered Calibration.ipynb). "
    ]
   },
   {
@@ -272,7 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To make time-domain useful as a diagnostic tool, one would like to convert the x-axis to distance. This requires knowledge of the propagation velocity in the device.  **skrf** provides some transmission-line models in the module [skrf.media](http://scikit-rf.readthedocs.org/en/latest/reference/media/index.html), which  can be used for this.\n",
+    "To make time-domain useful as a diagnostic tool, one would like to convert the x-axis to distance. This requires knowledge of the propagation velocity in the device.  **skrf** provides some transmission-line models in the module [skrf.media](../../api/media/index.rst), which  can be used for this.\n",
     "\n",
     "**However...**\n",
     "\n",

--- a/doc/source/examples/networktheory/Transmission Line Properties and Manipulations.ipynb
+++ b/doc/source/examples/networktheory/Transmission Line Properties and Manipulations.ipynb
@@ -210,7 +210,7 @@
    "metadata": {},
    "source": [
     "## Using transmission line functions <a class=\"anchor\" id=\"tline_functions\"></a>\n",
-    "`scikit-rf` brings few convenient functions to deal with transmission lines. They are detailed in the [transmission line functions](https://scikit-rf.readthedocs.io/en/latest/api/tlineFunctions.html) documentation pages. \n",
+    "`scikit-rf` brings few convenient functions to deal with transmission lines. They are detailed in the [transmission line functions](../../api/tlineFunctions.rst) documentation pages. \n",
     "\n",
     "### Input impedances, reflection coefficients and SWR <a class=\"anchor\" id=\"tline_impedances\"></a>\n",
     "The reflection coefficient $\\Gamma_L$ induced by the load is given by `zl_2_Gamma0()`:"
@@ -523,7 +523,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`scikit-rf` also provides objects representing transmission line mediums. The `Media` object provides generic methods to produce Network’s for any transmission line medium, such as transmission line length (`line()`), lumped components (`resistor()`, `capacitor()`, `inductor()`, `shunt()`, etc.) or terminations (`open()`, `short()`, `load()`). For additional references, please see the [media documentation](https://scikit-rf.readthedocs.io/en/latest/api/media/). \n",
+    "`scikit-rf` also provides objects representing transmission line mediums. The `Media` object provides generic methods to produce Network’s for any transmission line medium, such as transmission line length (`line()`), lumped components (`resistor()`, `capacitor()`, `inductor()`, `shunt()`, etc.) or terminations (`open()`, `short()`, `load()`). For additional references, please see the [media documentation](../../api/media/index.rst). \n",
     "\n",
     "Let's create a transmission line `media` object for our coaxial line of characteristic impedance $Z_0$ and propagation constant $\\gamma$:"
    ]
@@ -542,13 +542,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to build the circuit illustrated by the figure above, all the circuit's Networks are created and then [cascaded](https://scikit-rf.readthedocs.io/en/latest/tutorials/Networks.html#Cascading-and-De-embedding) with the `**` operator: \n",
+    "In order to build the circuit illustrated by the figure above, all the circuit's Networks are created and then [cascaded](../../tutorials/Networks.rst#Cascading-and-De-embedding) with the `**` operator: \n",
     "\n",
     "<img src=\"transmission_line_properties_networks.svg\">\n",
     "\n",
-    " * [transmission line](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.line.html) of length $d$ (from the media created above), \n",
-    " * a [resistor](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.resistor.html) of impedance $Z_L$, \n",
-    " * then terminated by a [short](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.short.html). \n",
+    " * [transmission line](../../api/media/generated/skrf.media.Media.line.rst) of length $d$ (from the media created above), \n",
+    " * a [resistor](../../api/media/generated/skrf.media.Media.resistor.rst) of impedance $Z_L$, \n",
+    " * then terminated by a [short](../../api/media/generated/skrf.media.Media.short.rst). \n",
     "\n",
     "This results in a one-port network, which $Z$-parameter is then the input impedance: "
    ]
@@ -567,7 +567,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that full Network can also be built with convenience functions [load](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.load.html):"
+    "Note that full Network can also be built with convenience functions [load](../../api/media/generated/skrf.media.Media.load.rst):"
    ]
   },
   {
@@ -584,7 +584,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "or even more directly using or [delay_load](https://scikit-rf.readthedocs.io/en/latest/api/media/generated/skrf.media.media.Media.delay_load.html):"
+    "or even more directly using or [delay_load](../../api/media/generated/skrf.media.Media.delay_load.rst):"
    ]
   },
   {

--- a/doc/source/tutorials/NetworkSet.ipynb
+++ b/doc/source/tutorials/NetworkSet.ipynb
@@ -498,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An illustrated example is given in the [Examples section](https://scikit-rf.readthedocs.io/en/latest/examples/index.html#networkset) of the documentation.\n",
+    "An illustrated example is given in the [Examples section](../examples/index.rst#networksets) of the documentation.\n",
     "\n",
     "It is also possible to interpolate using a named parameter when they have been defined: "
    ]


### PR DESCRIPTION
This PR converts all documentation links to relative path links. This way they also work in local documentation. A few broken links were also found and fixed.

P.S: I also noticed that there is a direct reference to https://scikit-rf.readthedocs.io/ in contributing/index.rst as the project's documentation site, which was *not* mindlessly converted, it's preserved as-is as it should.