### PR TITLE
Simplify z0 handing

### DIFF
--- a/doc/source/tutorials/Networks.ipynb
+++ b/doc/source/tutorials/Networks.ipynb
@@ -206,7 +206,7 @@
     "print(ntw2)\n",
     "ntw3 = rf.Network(frequency=freq, s=s, z0=[20, 30], name='different z0 for each port')\n",
     "print(ntw3)\n",
-    "ntw4 = rf.Network(frequency=freq, s=s, z0=rand(101,2), name='different z0 for each frequencies and ports')\n",
+    "ntw4 = rf.Network(frequency=freq, s=s, z0=rand(4,2), name='different z0 for each frequencies and ports')\n",
     "print(ntw4)"
    ]
   },
@@ -978,7 +978,7 @@
   "anaconda-cloud": {},
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.5 ('.venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -992,7 +992,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637c323cf467337602e9974a89cb4d3fc95fac3ef875a73e62754f8e768d8de7"
+   }
   }
  },
  "nbformat": 4,

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -405,9 +405,10 @@ class Media(ABC):
         result.frequency = self.frequency
         result.s = npy.zeros((self.frequency.npoints, nports, nports), dtype=complex)
         if z0 is None:
-            z0 = self.z0
+            z0 = npy.zeros(result.s.shape[:2])
+            z0[:] = self.z0[:, None]
         elif isinstance(z0, str):
-            z0 = parse_z0(z0)*self.z0
+            z0 = npy.ones(result.s.shape[:2]) * parse_z0(z0)
 
         if z0_norm:
             z0 = z0*self.z0

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -405,8 +405,6 @@ class Media(ABC):
         result.frequency = self.frequency
         result.s = npy.zeros((self.frequency.npoints, nports, nports), dtype=complex)
         if z0 is None:
-            # z0 = npy.zeros(result.s.shape[:2])
-            # z0[:] = self.z0[:, None]
             z0 = self.z0
         elif isinstance(z0, str):
             z0 = npy.ones(result.s.shape[:2]) * parse_z0(z0)

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -405,8 +405,9 @@ class Media(ABC):
         result.frequency = self.frequency
         result.s = npy.zeros((self.frequency.npoints, nports, nports), dtype=complex)
         if z0 is None:
-            z0 = npy.zeros(result.s.shape[:2])
-            z0[:] = self.z0[:, None]
+            # z0 = npy.zeros(result.s.shape[:2])
+            # z0[:] = self.z0[:, None]
+            z0 = self.z0
         elif isinstance(z0, str):
             z0 = npy.ones(result.s.shape[:2]) * parse_z0(z0)
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1304,7 +1304,7 @@ class Network(object):
         elif z0.shape == self.s.shape[:2]:
             self._z0 = z0
         else:
-            raise AttributeError(f'Unable to broadcast z0 shape (', z0.shape ,') to s shape', self.s.shape, self.nports, self.frequency.npoints)
+            raise AttributeError(f'Unable to broadcast z0 shape {z0.shape} to s shape {self.s.shape}.')
 
     @property
     def frequency(self) -> Frequency:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -469,17 +469,16 @@ class Network(object):
 
         # When initializing Network from different parameters than s
         # we need to make sure that z0 has been set first because it will be
-        # needed in conversion to S-parameters.
-        s_shape = [npy.array(kwargs[attr]).shape for attr in params]
-        if s_shape:
-            self.s = npy.zeros(s_shape[0], dtype=complex)
+        # needed in conversion to S-parameters. s is initialized with zeros here,
+        # to determine the correct z0 shape afterwards.
+
+        if params:
+            s_shape = npy.array(kwargs[params[0]]).shape
+            self.s = npy.zeros(s_shape, dtype=complex)
 
         self.z0 = kwargs.get('z0', self._z0)
 
-        # z0 might be set here again, but it's on purpose as z0.setter will
-        # fix the _z0 shape if s has been assigned or raise Exception if
-        # z0 and s shapes are not compatible.
-        for attr in PRIMARY_PROPERTIES + ['frequency', 'f', 'z0', 'noise', 'noise_freq']:
+        for attr in PRIMARY_PROPERTIES + ['frequency', 'f', 'noise', 'noise_freq']:
             if attr in kwargs:
                 self.__setattr__(attr, kwargs[attr])
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -474,7 +474,7 @@ class Network(object):
         if s_shape:
             self.s = npy.zeros(s_shape[0], dtype=complex)
 
-        self.z0 = kwargs.get('z0', 50)
+        self.z0 = kwargs.get('z0', self._z0)
 
         # z0 might be set here again, but it's on purpose as z0.setter will
         # fix the _z0 shape if s has been assigned or raise Exception if

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3029,7 +3029,6 @@ class Network(object):
                 self.s = renormalize_s(self.s, self.z0, z_new, s_def, self.s_def)
         # Update s_def if it was changed
         self.s_def = s_def
-        x = fix_z0_shape(z_new, self.frequency.npoints, self.nports)
         self.z0 = z_new
 
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1968,7 +1968,6 @@ class Network(object):
         # Call z0 getter and setter only when s and z0 shapes match.
         z0_new = npy.delete(self.z0, idx, axis=0)
         self.s = npy.delete(self.s, idx, axis=0)
-        print("23", self.s.shape, z0_new.shape, self.z0.shape)
         self.z0 = z0_new
 
         if self.noisy:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1271,26 +1271,6 @@ class Network(object):
 
         """
         return self._z0
-        # if we are unable to determine the s-matrix shape we return an scalar
-        if not hasattr(self, '_s'):
-            return self._z0
-
-        # _z0 is an scalar, so a npy.array with shape fxn is filled with _z0
-        if self._z0.ndim == 0:
-            self._z0 = npy.full(self._s.shape[:2], self._z0)
-        elif self._z0.ndim == 1:
-            # _z0 is a vector, either of length nports or frequency.npoints.
-            # Create a npy.array with shape fxn and broadcast vector to array.
-            z0 = npy.zeros(self._s.shape[:2], dtype=complex)
-            if len(self._z0) == self.nports:
-                z0[:] = self._z0[None, :]
-            else:
-                z0[:] = self._z0[:,None]
-            self._z0 = z0
-        elif self._z0.ndim == 2:
-            # _z0 is a matrix of correct shape, so we can return directly
-            pass
-        return self._z0
 
     @z0.setter
     def z0(self, z0: NumberLike) -> None:
@@ -1322,7 +1302,6 @@ class Network(object):
         elif z0.shape == self.s.shape[:2]:
             self._z0 = z0
         else:
-
             raise AttributeError('Unable to broadcast z0 shape (', z0.shape ,') to s shape', self.s.shape, self.nports, self.frequency.npoints)
 
     @property

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -962,6 +962,9 @@ class Network(object):
         self._s = fix_param_shape(s)
         self.__generate_secondary_properties()
         self.__generate_subnetworks()
+        
+        if self.z0.ndim == 0:
+            self.z0 = self.z0
 
     @property
     def s_traveling(self) -> npy.ndarray:
@@ -1302,7 +1305,7 @@ class Network(object):
         elif z0.shape == self.s.shape[:2]:
             self._z0 = z0
         else:
-            raise AttributeError('Unable to broadcast z0 shape (', z0.shape ,') to s shape', self.s.shape, self.nports, self.frequency.npoints)
+            raise AttributeError(f'Unable to broadcast z0 shape (', z0.shape ,') to s shape', self.s.shape, self.nports, self.frequency.npoints)
 
     @property
     def frequency(self) -> Frequency:

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -913,11 +913,9 @@ class NetworkTestCase(unittest.TestCase):
         # Unfortunately the frequency vector and the s shape can distinguish
         z0 = [1,2,3]
         ntwk.s = npy.random.rand(3,2,2)
-        with self.assertRaises(AttributeError):
-            ntwk.z0 = z0
+        ntwk.z0 = z0[::-1]
 
         ntwk.f = [1,2,3]
-        ntwk.z0 = z0[::-1]
         self.assertTrue(npy.allclose(ntwk.z0, npy.array([z0[::-1], z0[::-1]], dtype=complex).T))
 
     def test_z0_matrix(self):


### PR DESCRIPTION
This PR tries to simplify `z0` handling and stores `z0` in a numpy array regardless the simplicity. 
If `z0` is assigned with an scalar, the value is broadcasted automatically to `s`' shape. This allows the getter to be much simpler than before.