### PR TITLE
write_touchstone: don't write z_ref in complex format if it's real, fix #724

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2282,7 +2282,14 @@ class Network(object):
                 output.write('!Data is not renormalized\n')
                 output.write('# {} S {} R\n'.format(ntwk.frequency.unit, form))
             else:
-                output.write('# {} S {} R {} \n'.format(ntwk.frequency.unit, form, r_ref))
+                # Write "r_ref.real" instead of "r_ref", so we get a real number "a" instead
+                # of a complex number "(a+0j)", which is unsupported by the standard Touchstone
+                # format (non-HFSS). We already checked in the beginning that "r_ref" must be
+                # real in this case (write_z0 == False).
+                assert r_ref.imag == 0, "Complex reference impedance is encountered when " \
+                                        "generating a standard Touchstone (non-HFSS), this " \
+                                        "should never happen in scikit-rf."
+                output.write('# {} S {} R {} \n'.format(ntwk.frequency.unit, form, r_ref.real))
 
             # write ports
             try:


### PR DESCRIPTION
<del>This commit checks if the imaginary part of the impedance is zero, if so, It also checks if the real impedance is an integer.</del> If so, it writes the reference impedance as an integer or real number, instead of a complex number. This fixes the issue #724.

This ensures that, for the most common use-case of 50 ohms, the impedance line is given in the familiar form:
<del>
    # MHz S RI R 50
</del>