### PR TITLE
Fix IEEEP370 deembedding methods for dataset with existing dc point or interpolation required

### DIFF
--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -1134,7 +1134,6 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                     RuntimeWarning
                     )
                 flag_DC = True
-                fold = f
                 f = f[1:]
                 s = s[1:]
             else:
@@ -1146,20 +1145,22 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                    "Non-uniform frequency vector detected. An interpolated S-parameter matrix will be created for this calculation. The output results will be re-interpolated to the original vector.",
                    RuntimeWarning
                    )
-                raise NotImplementedError("TODO : handle interpolation.")
-                # flag_df = True
-                # df = f[1] - f[0]
-                # projected_n = round(f[-1]/f[0])
-                # if(projected_n < 10000):
-                #     fnew = f[0] * (np.arange(0, projected_n) + 1)
-                # else:
-                #     dfnew = f[-1]/10000
-                #     fnew = dfnew * (np.arange(0, 10000) + 1)
-                # stemp = Network(frequency = Frequency.from_f(f, 'Hz'), s = s)
-                # stemp.interpolate_self(fnew)
-                # f = fnew
-                # s = stemp.s
-                # del stemp
+                flag_df = True
+                f_original = f
+                df = f[1] - f[0]
+                projected_n = round(f[-1]/f[0])
+                if(projected_n < 10000):
+                    fnew = f[0] * (np.arange(0, projected_n) + 1)
+                else:
+                    dfnew = f[-1]/10000
+                    fnew = dfnew * (np.arange(0, 10000) + 1)
+                stemp = Network(frequency = Frequency.from_f(f, 'Hz'), s = s)
+                f_interp = Frequency.from_f(fnew, unit = 'Hz')
+                stemp.interpolate_self(f_interp, kind = 'linear',
+                                       fill_value = 'extrapolate')
+                f = fnew
+                s = stemp.s
+                del stemp
                          
             else:
                 flag_df = False
@@ -1183,7 +1184,7 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                 z11x = self.forced_z0_line
             else:
                 z11x = z11[x]
-            
+
             if self.verbose:
                 fig = plt.figure()
                 fig.suptitle('Midpoint length and impedance determination')
@@ -1263,49 +1264,57 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                         e01[i] *= -1
                 e10[i] = e10e01[i] / e01[i]
             
-            # S-parameters are setup correctly
-            if not flag_DC and not flag_df:
-                fixture_model_1r = zeros((n, 2, 2), dtype = complex)
-                fixture_model_1r[:, 0, 0] = e001
-                fixture_model_1r[:, 1, 0] = e01
-                fixture_model_1r[:, 0, 1] = e01
-                fixture_model_1r[:, 1, 1] = e111
+            # revert to initial freq axis
+            if flag_df:
+                interp_e001 = interp1d(f, e001, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e001 = interp_e001(f_original)
+                interp_e01 = interp1d(f, e01, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e01 = interp_e01(f_original)
+                interp_e111 = interp1d(f, e111, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e111 = interp_e111(f_original)
+                interp_e002 = interp1d(f, e002, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e002 = interp_e002(f_original)
+                interp_e10 = interp1d(f, e10, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e10 = interp_e10(f_original)
+                interp_e112 = interp1d(f, e112, kind = 'linear',
+                                fill_value = 'extrapolate',
+                                assume_sorted = True)
+                e112 = interp_e112(f_original)
+                f = f_original
                 
-                fixture_model_2r = zeros((n, 2, 2), dtype = complex)
-                fixture_model_2r[:, 1, 1] = e002
-                fixture_model_2r[:, 0, 1] = e10
-                fixture_model_2r[:, 1, 0] = e10
-                fixture_model_2r[:, 0, 0] = e112
+            # dc point was included in the original file
+            if flag_DC:
+                e001 = concatenate(([self.dc_interp(e001, f)], e001))
+                e01  = concatenate(([self.dc_interp(e01, f)], e01))
+                e111 = concatenate(([self.dc_interp(e111, f)], e111))
+                e002 = concatenate(([self.dc_interp(e002, f)], e002))
+                e10 = concatenate(([self.dc_interp(e10, f)], e10))
+                e112 = concatenate(([self.dc_interp(e112, f)], e112))
+                f = concatenate(([0], f))
             
+            # S-parameters are now setup correctly
+            n = len(f)
+            fixture_model_1r = zeros((n, 2, 2), dtype = complex)
+            fixture_model_1r[:, 0, 0] = e001
+            fixture_model_1r[:, 1, 0] = e01
+            fixture_model_1r[:, 0, 1] = e01
+            fixture_model_1r[:, 1, 1] = e111
             
-            # S-parameters are not setup correctly
-            else:
-                # dc point was included in the original file
-                if flag_DC:
-                    fixture_model_1r = zeros((n + 1, 2, 2), dtype = complex)
-                    fixture_model_1r[:, 0, 0] = concatenate((
-                        [self.dc_interp(e001, f)], e001))
-                    fixture_model_1r[:, 1, 0] = concatenate((
-                        [self.dc_interp(e01, f)], e01))
-                    fixture_model_1r[:, 0, 1] = concatenate((
-                        [self.dc_interp(e01, f)], e01))
-                    fixture_model_1r[:, 1, 1] = concatenate((
-                        [self.dc_interp(e111, f)], e111))
-                        
-                    fixture_model_2r = zeros((n + 1, 2, 2), dtype = complex)
-                    fixture_model_2r[:, 0, 0] = concatenate((
-                        [self.dc_interp(e002, f)], e002))
-                    fixture_model_2r[:, 1, 0] = concatenate((
-                        [self.dc_interp(e10, f)], e10))
-                    fixture_model_2r[:, 0, 1] = concatenate((
-                        [self.dc_interp(e10, f)], e10))
-                    fixture_model_2r[:, 1, 1] = concatenate((
-                        [self.dc_interp(e112, f)], e112))
-                        
-                    f = concatenate(([0], f))
-                # todo implement using Network.interpolate to revert to initial freq axis
-                if flag_df:
-                    raise NotImplementedError("TODO : handle interpolation.")
+            fixture_model_2r = zeros((n, 2, 2), dtype = complex)
+            fixture_model_2r[:, 1, 1] = e002
+            fixture_model_2r[:, 0, 1] = e10
+            fixture_model_2r[:, 1, 0] = e10
+            fixture_model_2r[:, 0, 0] = e112
             
             # create the S-parameter objects for the errorboxes
             s_fixture_model_r1  = Network(frequency = Frequency.from_f(f, 'Hz'), s = fixture_model_1r, z0 = z11x)
@@ -2069,13 +2078,16 @@ class IEEEP370_SE_ZC_2xThru(Deembedding):
                "Non-uniform frequency vector detected. An interpolated S-parameter matrix will be created for this calculation. The output results will be re-interpolated to the original vector.",
                RuntimeWarning
                )
-            raise NotImplementedError("TODO : handle interpolation.")
-            # self.flag_df = True
-            # forg = f
-            # projected_n = np.floor(f[-1]/f[0])
-            # fnew = f[0] * (np.arange(0, projected_n) + 1)
-            # sfix_dut_fix.interpolate_self(Frequency.from_f(fnew, 'Hz'))
-            # s2xthru.interpolate_self(Frequency.from_f(fnew, 'Hz'))   
+            self.flag_df = True
+            f_original = f
+            projected_n = np.floor(f[-1]/f[0])
+            fnew = f[0] * (np.arange(0, projected_n) + 1)
+            f_interp = Frequency.from_f(fnew, unit = 'Hz')
+            sfix_dut_fix.interpolate_self(f_interp, kind = 'linear',
+                                   fill_value = 'extrapolate')
+            s2xthru.interpolate_self(f_interp, kind = 'linear',
+                                   fill_value = 'extrapolate')   
+            f = fnew
             
         # check if 2x-thru is not the same frequency vector as the
         # fixture-dut-fixture
@@ -2137,10 +2149,11 @@ class IEEEP370_SE_ZC_2xThru(Deembedding):
         # interpolate to original frequency if needed
         # revert back to original frequency vector
         if self.flag_df:
-            raise NotImplementedError("TODO : handle interpolation.")
-            # cannot extrapolate outside f bounds
-            # s_side1.interpolate_self(Frequency.from_f(forg, 'Hz'))
-            # s_side2.interpolate_self(Frequency.from_f(forg, 'Hz'))
+            f_interp = Frequency.from_f(f_original, unit = 'Hz')
+            s_side1.interpolate_self(f_interp, kind = 'linear',
+                                   fill_value = 'extrapolate')
+            s_side2.interpolate_self(f_interp, kind = 'linear',
+                                   fill_value = 'extrapolate')
         
         # add DC back in
         if self.flag_DC:

--- a/skrf/calibration/tests/test_deembedding.py
+++ b/skrf/calibration/tests/test_deembedding.py
@@ -298,7 +298,7 @@ class DeembeddingTestCase(unittest.TestCase):
         
     def test_IEEEP370_SE_NZC_2xThru_with_dc(self):
         """
-        Test test_IEEEP370_SE_NZC_2xThru.
+        Test test_IEEEP370_SE_NZC_2xThru_with_dc.
 
         After de-embedding fixtures model from 2xtru, the network is a perfect
         thru.
@@ -345,7 +345,7 @@ class DeembeddingTestCase(unittest.TestCase):
         
     def test_IEEEP370_SE_ZC_2xThru_with_dc(self):
         """
-        Test test_IEEEP370_SE_ZC_2xThru.
+        Test test_IEEEP370_SE_ZC_2xThru_with_dc.
 
         After de-embedding fixtures model from 2xtru, the network is a perfect
         thru.
@@ -362,6 +362,9 @@ class DeembeddingTestCase(unittest.TestCase):
                                        leadin = 0,
                                        NRP_enable = False,
                                        name = 'zc2xthru')
+        print(s2xthru_dc.frequency.f[0])
+        print(fdf_dc.frequency.f[0])
+        print(dm_zc.s_side1.frequency.f[0])
         residuals = dm_zc.deembed(s2xthru_dc)
         # insertion loss magnitude deviate from 1.0 from less than 0.2 dB
         il_mag = 20.*np.log10(np.abs(residuals.s[:, 1, 0] + 1e-12))
@@ -373,7 +376,7 @@ class DeembeddingTestCase(unittest.TestCase):
         
     def test_IEEEP370_SE_NZC_2xThru_no_180deg_phase_jumps(self):
         """
-        Test test_IEEEP370_SE_NZC_2xThru.
+        Test test_IEEEP370_SE_NZC_2xThru_no_180deg_phase_jumps.
 
         After de-embedding fixtures model from 2xtru, the network is a perfect
         thru.


### PR DESCRIPTION
Fix issues with IEEEP370 deembedding methods when there is a DC point and add test cases for the issue not to come back again.