### PR TITLE
fix `media.line` and `media.shunt_xxx` does not keep their network names

### DIFF
--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -847,7 +847,7 @@ class Media(ABC):
         result.s = \
                 npy.array([[s11, s21],[s21,s11]]).transpose().reshape(-1,2,2)
 
-        if embed:
+        if embed and self.z0 is not None:
             # warns of future deprecation
             warnings.warn('In a future version,`embed` will be deprecated.\n'
                           'The line and media port impedance z0 and '

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -838,6 +838,8 @@ class Media(ABC):
         s_def = kwargs.pop('s_def', S_DEF_DEFAULT)
         # Need to use either traveling or pseudo definition here
         # for the network to match traveling waves.
+        # the definition of the line trough a match and a delay would not
+        # works for complex characteristic impedances otherwise.
         result = self.match(nports=2, s_def='traveling', **kwargs)
 
         theta = self.electrical_length(self.to_meters(d=d, unit=unit))
@@ -854,8 +856,6 @@ class Media(ABC):
                           'characteristic impedance Z0 will be used instead '
                           'to determine if the line has to be renormalized.',
               FutureWarning, stacklevel = 2)
-            # Use the same s_def here as the line to avoid changing it during
-            # cascade.
             result.renormalize(self.z0, s_def=s_def)
         else:
             result.renormalize(result.z0, s_def=s_def)

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -836,10 +836,12 @@ class Media(ABC):
 
         kwargs.update({'z0':z0})
         s_def = kwargs.pop('s_def', S_DEF_DEFAULT)
-        # Need to use either traveling or pseudo definition here
-        # for the network to match traveling waves.
-        # the definition of the line trough a match and a delay would not
-        # works for complex characteristic impedances otherwise.
+        # The use of either traveling or pseudo waves s-parameters definition
+        # is required here.
+        # A line with a complex characteristic impedance equal to port
+        # impedance does not have zero reflection coefficients with the power
+        # waves definition.
+        # Instead, reflection coefficients will have conjugation. 
         result = self.match(nports=2, s_def='traveling', **kwargs)
 
         theta = self.electrical_length(self.to_meters(d=d, unit=unit))
@@ -903,7 +905,8 @@ class Media(ABC):
         delay_short
         delay_open
         """
-        return self.line(d=d, unit=unit, **kwargs) ** self.load(Gamma0=Gamma0, **kwargs)
+        return self.line(d=d, unit=unit, **kwargs) ** self.load(Gamma0=Gamma0,
+                                                                **kwargs)
 
     def delay_short(self, d: Number, unit: str = 'deg', **kwargs) -> Network:
         r"""
@@ -1115,8 +1118,8 @@ class Media(ABC):
         shunt_delay_short
         shunt_inductor
         """
-        return self.shunt(self.capacitor(C=C, **kwargs) ** self.short(),
-                          **kwargs)
+        return self.shunt(self.capacitor(C=C, **kwargs) ** 
+                          self.short(**kwargs), **kwargs)
 
     def shunt_inductor(self, L: NumberLike, **kwargs) -> Network:
         r"""
@@ -1148,8 +1151,8 @@ class Media(ABC):
         shunt_delay_short
         shunt_capacitor
         """
-        return self.shunt(self.inductor(L=L, **kwargs) ** self.short(),
-                          **kwargs)
+        return self.shunt(self.inductor(L=L, **kwargs) **
+                          self.short(**kwargs), **kwargs)
 
     def attenuator(self, s21: NumberLike, db: bool = True, d: Number = 0,
                    unit: str = 'deg', name: str = '', **kwargs) -> Network:

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -856,8 +856,9 @@ class Media(ABC):
               FutureWarning, stacklevel = 2)
             # Use the same s_def here as the line to avoid changing it during
             # cascade.
-            result = self.thru(s_def='traveling')**result**self.thru(s_def='traveling')
-        result.renormalize(result.z0, s_def=s_def)
+            result = result.renormalize(self.z0, s_def=s_def)
+        else:
+            result.renormalize(result.z0, s_def=s_def)
 
         return result
 
@@ -1022,7 +1023,7 @@ class Media(ABC):
         shunt_capacitor
         shunt_inductor
         """
-        return self.shunt(self.delay_load(*args, **kwargs))
+        return self.shunt(self.delay_load(*args, **kwargs), **kwargs)
 
     def shunt_delay_open(self,*args,**kwargs) -> Network:
         r"""
@@ -1052,7 +1053,7 @@ class Media(ABC):
         shunt_capacitor
         shunt_inductor
         """
-        return self.shunt(self.delay_open(*args, **kwargs))
+        return self.shunt(self.delay_open(*args, **kwargs), **kwargs)
 
     def shunt_delay_short(self, *args, **kwargs) -> Network:
         r"""
@@ -1082,7 +1083,7 @@ class Media(ABC):
         shunt_capacitor
         shunt_inductor
         """
-        return self.shunt(self.delay_short(*args, **kwargs))
+        return self.shunt(self.delay_short(*args, **kwargs), **kwargs)
 
     def shunt_capacitor(self, C: NumberLike, **kwargs) -> Network:
         r"""
@@ -1114,7 +1115,8 @@ class Media(ABC):
         shunt_delay_short
         shunt_inductor
         """
-        return self.shunt(self.capacitor(C=C, **kwargs) ** self.short())
+        return self.shunt(self.capacitor(C=C, **kwargs) ** self.short(),
+                          **kwargs)
 
     def shunt_inductor(self, L: NumberLike, **kwargs) -> Network:
         r"""
@@ -1146,7 +1148,8 @@ class Media(ABC):
         shunt_delay_short
         shunt_capacitor
         """
-        return self.shunt(self.inductor(L=L, **kwargs) ** self.short())
+        return self.shunt(self.inductor(L=L, **kwargs) ** self.short(),
+                          **kwargs)
 
     def attenuator(self, s21: NumberLike, db: bool = True, d: Number = 0,
                    unit: str = 'deg', name: str = '', **kwargs) -> Network:

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -838,10 +838,8 @@ class Media(ABC):
         s_def = kwargs.pop('s_def', S_DEF_DEFAULT)
         # The use of either traveling or pseudo waves s-parameters definition
         # is required here.
-        # A line with a complex characteristic impedance equal to port
-        # impedance does not have zero reflection coefficients with the power
-        # waves definition.
-        # Instead, reflection coefficients will have conjugation. 
+        # The definition of the reflection coefficient for power waves has
+        # conjugation. 
         result = self.match(nports=2, s_def='traveling', **kwargs)
 
         theta = self.electrical_length(self.to_meters(d=d, unit=unit))

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -856,7 +856,7 @@ class Media(ABC):
               FutureWarning, stacklevel = 2)
             # Use the same s_def here as the line to avoid changing it during
             # cascade.
-            result = result.renormalize(self.z0, s_def=s_def)
+            result.renormalize(self.z0, s_def=s_def)
         else:
             result.renormalize(result.z0, s_def=s_def)
 

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -2,6 +2,7 @@
 import unittest
 import os
 import numpy as npy
+from numpy.testing import run_module_suite
 
 
 from skrf.media import DefinedGammaZ0, Media
@@ -24,46 +25,210 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
 
     def test_impedance_mismatch(self):
         """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
         """
-        fname = os.path.join(self.files_dir,\
-                'impedanceMismatch,50to25.s2p')
-        qucs_ntwk = Network(fname)
+        name = 'impedanceMismatch,50to25'
+        qucs_ntwk = Network(os.path.join(self.files_dir, name + '.s2p'))
         self.dummy_media.frequency = qucs_ntwk.frequency
-        skrf_ntwk = self.dummy_media.thru(z0=50)**\
+        skrf_ntwk = self.dummy_media.thru(z0=50, name = name)**\
             self.dummy_media.thru(z0=25)
 
         self.assertEqual(qucs_ntwk, skrf_ntwk)
+        self.assertEqual(qucs_ntwk.name, skrf_ntwk.name)
+        
+    def test_tee(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'tee'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.tee(name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_splitter(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'splitter'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.splitter(3, name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_thru(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'thru'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.thru(name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_line(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'line'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.line(90, 'deg', name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_delay_load(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'delay_load'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.delay_load(1j, 90, 'deg',
+                                                      name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+    
+    def test_shunt_delay_load(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'shunt_delay_load'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.shunt_delay_load(1j, 90, 'deg',
+                                                      name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_delay_open(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'delay_open'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.delay_open(90, 'deg', name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_shunt_delay_open(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'shunt_delay_open'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.shunt_delay_open(90, 'deg', name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_delay_short(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'delay_short'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.delay_short(90, 'deg', name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_shunt_delay_short(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'shunt_delay_short'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.shunt_delay_short(90, 'deg', name = name)
+        self.assertEqual(name, skrf_ntwk.name)
 
     def test_resistor(self):
         """
+        Compare the component values against s-parameters generated by QUCS.
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
         """
-        fname = os.path.join(self.files_dir,\
-                'resistor,1ohm.s2p')
-        qucs_ntwk = Network(fname)
+        name = 'resistor,1ohm'
+        qucs_ntwk = Network(os.path.join(self.files_dir, name + '.s2p'))
         self.dummy_media.frequency = qucs_ntwk.frequency
-        skrf_ntwk = self.dummy_media.resistor(1)
+        skrf_ntwk = self.dummy_media.resistor(1, name = name)
         self.assertEqual(qucs_ntwk, skrf_ntwk)
+        self.assertEqual(qucs_ntwk.name, skrf_ntwk.name)
 
     def test_capacitor(self):
         """
+        Compare the component values against s-parameters generated by QUCS.
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
         """
-        fname = os.path.join(self.files_dir,\
-                'capacitor,p01pF.s2p')
-        qucs_ntwk = Network(fname)
+        name = 'capacitor,p01pF'
+        qucs_ntwk = Network(os.path.join(self.files_dir, name + '.s2p'))
         self.dummy_media.frequency = qucs_ntwk.frequency
-        skrf_ntwk = self.dummy_media.capacitor(.01e-12)
+        skrf_ntwk = self.dummy_media.capacitor(.01e-12, name = name)
         self.assertEqual(qucs_ntwk, skrf_ntwk)
+        self.assertEqual(qucs_ntwk.name, skrf_ntwk.name)
+        
+    def test_shunt_capacitor(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'shunt_capacitor,p01pF'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.capacitor(.01e-12, name = name)
+        self.assertEqual(name, skrf_ntwk.name)
 
 
     def test_inductor(self):
         """
+        Compare the component values against s-parameters generated by QUCS.
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
         """
-        fname = os.path.join(self.files_dir,\
-                'inductor,p1nH.s2p')
-        qucs_ntwk = Network(fname)
+        name = 'inductor,p1nH'
+        qucs_ntwk = Network(os.path.join(self.files_dir, name + '.s2p'))
         self.dummy_media.frequency = qucs_ntwk.frequency
-        skrf_ntwk = self.dummy_media.inductor(.1e-9)
+        skrf_ntwk = self.dummy_media.inductor(.1e-9, name = name)
         self.assertEqual(qucs_ntwk, skrf_ntwk)
+        self.assertEqual(qucs_ntwk.name, skrf_ntwk.name)
+        
+    def test_shunt_inductor(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'shunt_inductor,p1nH'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.inductor(.1e-9, name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_attenuator(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'attenuator,-10dB'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.attenuator(-10, d = 90, unit = 'deg',
+                                                name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_lossless_mismatchh(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'lossless_mismatch,-10dB'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.lossless_mismatch(-10, name = name)
+        self.assertEqual(name, skrf_ntwk.name)
+    
+    def test_isolator(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'isolator'
+        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        skrf_ntwk = self.dummy_media.isolator(name = name)
+        self.assertEqual(name, skrf_ntwk.name)
 
 
     def test_scalar_gamma_z0_media(self):
@@ -399,3 +564,8 @@ class DefinedGammaZ0_s_def(unittest.TestCase):
         npy.testing.assert_allclose(thru_traveling.s, mismatch_traveling.s, rtol=1e-3)
         npy.testing.assert_allclose(thru_pseudo.s, mismatch_pseudo.s, rtol=1e-3)
         npy.testing.assert_allclose(thru_power.s, mismatch_power.s, rtol=1e-3)
+
+if __name__ == "__main__":
+    # Launch all tests
+    run_module_suite()
+    

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -210,7 +210,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
                                                 name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
-    def test_lossless_mismatchh(self):
+    def test_lossless_mismatch(self):
         """
         Test the naming of the network. When circuit is used to connect a
         topology of networks, they should have unique names.


### PR DESCRIPTION
This PR attempt to fix #731 

While creating a `media.line` with `embed == True`, the name of the network, if passed into `**kwargs` was not kept due to the `media.thru()` cascading on both side.

This does not fix the faulty `embed` behaviour regarding the characteristic impedances (see #651 for reference to this issue).

`media.shunt_xxx` methods suffer from the same issue because the `**kwargs` is not passed to the `shunt` method. This PR fixes that.