### PR TITLE
Fixes and improves time-domain gating

### DIFF
--- a/skrf/time.py
+++ b/skrf/time.py
@@ -287,9 +287,9 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     gate[start_idx:stop_idx] = window
 
     # time-domain gating
-    s_td = ifftshift(ifft(nw_gated.s[:, 0, 0]))
+    s_td = fftshift(ifft(nw_gated.s[:, 0, 0]))
     s_td_g = s_td * gate
-    nw_gated.s[:, 0, 0] = fft(fftshift(s_td_g))
+    nw_gated.s[:, 0, 0] = fft(ifftshift(s_td_g))
 
     if mode == 'bandstop':
         nw_gated = ntwk - nw_gated

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -223,12 +223,12 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     span : number, or None
         span of time gate, (ns).  If None span will be half of the
         distance to the second tallest peak
-    mode: ['bandpass','bandstop']
+    mode : ['bandpass', 'bandstop']
         mode of gate
-    boundary:  {'reflect', 'constant', 'nearest', 'mirror', 'wrap'},
-        passed to `scipy.ndimage.filters.convolve1d`
     window : string, float, or tuple
         passed to `window` arg of `scipy.signal.get_window()`
+    return_all : bool
+        whether or not the response of the normalized time gate is returned together with the gated Network as a Tuple.
 
     Note
     ----
@@ -303,7 +303,7 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     if return_all:
         # compute and return frequency response of time gate
         nw_gate = nw_gated.copy()
-        nw_gate.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate), norm='forward'))
+        nw_gate.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate)))
         return nw_gated, nw_gate
     else:
         return nw_gated

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -23,7 +23,10 @@ from scipy.ndimage import convolve1d
 from scipy import signal
 import numpy as npy
 from numpy import fft
-from typing import List
+# imports for type hinting
+from typing import List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .network import Network
 
 
 def indexes(y: npy.ndarray, thres: float = 0.3, min_dist: int = 1) -> npy.ndarray:
@@ -190,8 +193,8 @@ def detect_span(ntwk) -> float:
     return span
 
 
-def time_gate(ntwk: skrf.Network, start: float = None, stop: float = None, center: float = None, span: float = None,
-              mode: str = 'bandpass', window=('kaiser', 6), return_all: bool = False) -> skrf.Network:
+def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: float = None, span: float = None,
+              mode: str = 'bandpass', window=('kaiser', 6), return_all: bool = False) -> 'Network':
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -16,6 +16,8 @@ Time domain functions
    indexes
 
 """
+import skrf
+
 from .util import find_nearest_index
 from scipy.ndimage import convolve1d
 from scipy import signal
@@ -188,14 +190,12 @@ def detect_span(ntwk) -> float:
     return span
 
 
-def time_gate(ntwk, start: float = None, stop: float = None, center: float = None, span: float = None,
-              mode: str = 'bandpass', window=('kaiser', 6), media=None,
-              boundary: str = 'reflect', return_all: bool = False):
+def time_gate(ntwk: skrf.Network, start: float = None, stop: float = None, center: float = None, span: float = None,
+              mode: str = 'bandpass', window=('kaiser', 6), return_all: bool = False) -> skrf.Network:
     """
-    Time-gate one-port s-parameters.
+    Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
-    The gate can be defined with start/stop times, or by
-    center/span. all times are in units of nanoseconds. common
+    The gate can be defined with start/stop times, or by center/span. All times are in units of nanoseconds. Common
     windows are:
 
     * ('kaiser', 6)
@@ -225,18 +225,12 @@ def time_gate(ntwk, start: float = None, stop: float = None, center: float = Non
     boundary:  {'reflect', 'constant', 'nearest', 'mirror', 'wrap'},
         passed to `scipy.ndimage.filters.convolve1d`
     window : string, float, or tuple
-        passed to `window` arg of `scipy.signal.get_window`
+        passed to `window` arg of `scipy.signal.get_window()`
 
     Note
     ----
     You cant gate things that are 'behind' strong reflections. This
     is due to the multiple reflections that occur.
-
-    If `center!=0`, then the ntwk's time response is shifted
-    to t=0, gated, then shifted back to where it was. This is
-    done in frequency domain using `ntwk.delay()`. If the media being
-    gated is dispersive (ie waveguide), then the gate `span` will be
-    span at t=0, which is different.
 
     If you need to time-gate an N-port network, then you should
     gate each s-parameter independently.
@@ -246,16 +240,14 @@ def time_gate(ntwk, start: float = None, stop: float = None, center: float = Non
     ntwk : Network
         copy of ntwk with time-gated s-parameters
 
-
     .. warning::
         Depending on sharpness of the gate, the band edges may be
         inaccurate, due to properties of FFT. We do not re-normalize
         anything.
-
-
     """
+
     if ntwk.nports >1:
-        raise ValueError('Time-gating only works on one-ports. try taking ntwk.s11 or ntwk.s21 first')
+        raise ValueError('Time-gating only works on one-ports. Try passing `ntwk.s11` or `ntwk.s21`.')
 
     if start is not None and stop is not None:
         start *= 1e-9
@@ -287,47 +279,30 @@ def time_gate(ntwk, start: float = None, stop: float = None, center: float = Non
     window_width = abs(stop_idx - start_idx)
     window = signal.get_window(window, window_width)
 
+    nw_gated = ntwk.copy()
+
     # create the gate by padding the window with zeros
-    gate = npy.r_[npy.zeros(start_idx),
-                           window,
-                           npy.zeros(len(t) - stop_idx)]
+    gate = npy.zeros_like(t)
+    gate[start_idx:stop_idx] = window
 
-    #FFT the gate, so we have it's frequency response, aka kernel
-    kernel=fft.ifftshift(fft.fft(fft.fftshift(gate, axes=0), axis=0))
-    kernel =abs(kernel).flatten() # take mag and flatten
-    kernel=kernel/sum(kernel) # normalize kernel
-
-    out = ntwk.copy()
-
-    # conditionally delay ntwk, to center at t=0, this is
-    # equivalent to gating at center.  (this is probably very inefficient)
-    if center!=0:
-        out = out.delay(-center*1e9, 'ns',port=0,media=media)
-
-    # waste of code to handle convolve1d suck
-    re = out.s_re[:,0,0]
-    im = out.s_im[:,0,0]
-    s = convolve1d(re,kernel, mode=boundary)+\
-     1j*convolve1d(im,kernel, mode=boundary)
-    out.s[:,0,0] = s
-    # conditionally  un-delay ntwk
-    if center!=0:
-        out = out.delay(center*1e9, 'ns',port=0,media=media)
+    # time-domain gating
+    s_td = npy.fft.ifftshift(npy.fft.ifft(nw_gated.s[:, 0, 0]))
+    s_td_g = s_td * gate
+    nw_gated.s[:, 0, 0] = npy.fft.fft(npy.fft.fftshift(s_td_g))
 
     if mode == 'bandstop':
-        out = ntwk-out
+        nw_gated = ntwk - nw_gated
     elif mode=='bandpass':
         pass
     else:
         raise ValueError('mode should be \'bandpass\' or \'bandstop\'')
 
     if return_all:
-        # compute the gate ntwk and add delay
-        gate_ntwk = out.s11.copy()
-        gate_ntwk.s = kernel
-        gate_ntwk= gate_ntwk.delay(center*1e9, 'ns', media=media)
+        # compute and return frequency response of time gate
+        gate_ntwk = nw_gated.copy()
+        gate_ntwk.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate), norm='forward'))
 
-        return {'gated_ntwk':out,
-                'gate':gate_ntwk}
+        return {'gated_ntwk': nw_gated,
+                'gate': gate_ntwk}
     else:
-        return out
+        return nw_gated

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -19,6 +19,7 @@ Time domain functions
 from .util import find_nearest_index
 from scipy import signal
 import numpy as npy
+from numpy.fft import fft, fftshift, ifft, ifftshift
 
 # imports for type hinting
 from typing import List, TYPE_CHECKING
@@ -286,9 +287,9 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     gate[start_idx:stop_idx] = window
 
     # time-domain gating
-    s_td = npy.fft.ifftshift(npy.fft.ifft(nw_gated.s[:, 0, 0]))
+    s_td = ifftshift(ifft(nw_gated.s[:, 0, 0]))
     s_td_g = s_td * gate
-    nw_gated.s[:, 0, 0] = npy.fft.fft(npy.fft.fftshift(s_td_g))
+    nw_gated.s[:, 0, 0] = fft(fftshift(s_td_g))
 
     if mode == 'bandstop':
         nw_gated = ntwk - nw_gated
@@ -300,7 +301,7 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     if return_all:
         # compute and return frequency response of time gate
         nw_gate = nw_gated.copy()
-        nw_gate.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate)))
+        nw_gate.s = ifftshift(fft(fftshift(gate)))
         nw_gate.name = 'gate'
         return nw_gated, nw_gate
     else:

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -192,7 +192,7 @@ def detect_span(ntwk) -> float:
 
 
 def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: float = None, span: float = None,
-              mode: str = 'bandpass', window=('kaiser', 6), return_all: bool = False) -> 'Network':
+              mode: str = 'bandpass', window=('kaiser', 6)) -> 'Network':
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
@@ -225,8 +225,6 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         mode of gate
     window : string, float, or tuple
         passed to `window` arg of `scipy.signal.get_window()`
-    return_all : bool
-        whether or not the response of the normalized time gate is returned together with the gated Network as a Tuple.
 
     Note
     ----
@@ -298,11 +296,4 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     else:
         raise ValueError('mode should be \'bandpass\' or \'bandstop\'')
 
-    if return_all:
-        # compute and return frequency response of time gate
-        nw_gate = nw_gated.copy()
-        nw_gate.s = ifftshift(fft(fftshift(gate)))
-        nw_gate.name = 'gate'
-        return nw_gated, nw_gate
-    else:
-        return nw_gated
+    return nw_gated

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -16,13 +16,10 @@ Time domain functions
    indexes
 
 """
-import skrf
-
 from .util import find_nearest_index
-from scipy.ndimage import convolve1d
 from scipy import signal
 import numpy as npy
-from numpy import fft
+
 # imports for type hinting
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -304,6 +304,7 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         # compute and return frequency response of time gate
         nw_gate = nw_gated.copy()
         nw_gate.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate)))
+        nw_gate.name = 'gate'
         return nw_gated, nw_gate
     else:
         return nw_gated

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -302,10 +302,8 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
 
     if return_all:
         # compute and return frequency response of time gate
-        gate_ntwk = nw_gated.copy()
-        gate_ntwk.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate), norm='forward'))
-
-        return {'gated_ntwk': nw_gated,
-                'gate': gate_ntwk}
+        nw_gate = nw_gated.copy()
+        nw_gate.s = npy.fft.ifftshift(npy.fft.fft(npy.fft.fftshift(gate), norm='forward'))
+        return nw_gated, nw_gate
     else:
         return nw_gated

--- a/tools/travis-requirements.txt
+++ b/tools/travis-requirements.txt
@@ -1,4 +1,0 @@
-
-xlwt-future>=0.8.0
-xlrd>=0.6.1
-coveralls


### PR DESCRIPTION
Fix for #734.
As disussed in the issue thread, the new implementation uses time-domain multiplication instead of frequency-domain convolution. This gives a speed benefit of multiple orders of magnitude, depending on the number of samples.