### PR TITLE
Update general.py - introducing sort to read_all networks function

### DIFF
--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -249,7 +249,7 @@ def write(file, obj, overwrite = True):
         pickle.dump(obj, fid, protocol=2)
         fid.close()
 
-def read_all(dir: str ='.', sorted = None, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
+def read_all(dir: str ='.', sort = None, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
     """
     Read all skrf objects in a directory.
 
@@ -319,8 +319,8 @@ def read_all(dir: str ='.', sorted = None, contains = None, f_unit = None, obj_t
     else:
         filelist.extend(files)
          
-    if sorted is not None:
-      filelist = sorted(filelist)
+    if sort is not None:
+      filelist.sort()
 
     for filename in filelist:
         if contains is not None and contains not in filename:
@@ -414,6 +414,7 @@ def write_all(dict_objs, dir='.', *args, **kwargs):
     """
     if not os.path.exists('.'):
         raise OSError('No such directory: %s'%dir)
+         
 
 
     for k in dict_objs:
@@ -498,7 +499,7 @@ def load_all_touchstones(dir = '.', contains=None, f_unit=None):
 
     Notes
     -------
-    Alternatively you can use the :func:`read_all` function.
+    Alternatively you can use the :func:`#` function.
 
     Parameters
     -----------

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -249,7 +249,7 @@ def write(file, obj, overwrite = True):
         pickle.dump(obj, fid, protocol=2)
         fid.close()
 
-def read_all(dir: str ='.', sort = None, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
+def read_all(dir: str ='.', sort = True, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
     """
     Read all skrf objects in a directory.
 
@@ -261,6 +261,8 @@ def read_all(dir: str ='.', sort = None, contains = None, f_unit = None, obj_typ
     ----------
     dir : str, optional
         the directory to load from, default  \'.\'
+    sort: boolean, default is True
+        filenames sorted by https://docs.python.org/3/library/stdtypes.html#list.sort without arguements
     contains : str, optional
         if not None, only files containing this substring will be loaded
     f_unit : ['hz','khz','mhz','ghz','thz']
@@ -319,7 +321,7 @@ def read_all(dir: str ='.', sort = None, contains = None, f_unit = None, obj_typ
     else:
         filelist.extend(files)
          
-    if sort is not None:
+    if sort is True:
         filelist.sort()
 
     for filename in filelist:
@@ -499,7 +501,7 @@ def load_all_touchstones(dir = '.', contains=None, f_unit=None):
 
     Notes
     -------
-    Alternatively you can use the :func:`#` function.
+    
 
     Parameters
     -----------

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -320,7 +320,7 @@ def read_all(dir: str ='.', sort = None, contains = None, f_unit = None, obj_typ
         filelist.extend(files)
          
     if sort is not None:
-      filelist.sort()
+        filelist.sort()
 
     for filename in filelist:
         if contains is not None and contains not in filename:

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -249,7 +249,7 @@ def write(file, obj, overwrite = True):
         pickle.dump(obj, fid, protocol=2)
         fid.close()
 
-def read_all(dir: str ='.', contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
+def read_all(dir: str ='.', sorted = None, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
     """
     Read all skrf objects in a directory.
 
@@ -318,6 +318,9 @@ def read_all(dir: str ='.', contains = None, f_unit = None, obj_type=None, files
             filelist.append(filename)
     else:
         filelist.extend(files)
+         
+    if sorted is not None:
+      filelist = sorted(filelist)
 
     for filename in filelist:
         if contains is not None and contains not in filename:


### PR DESCRIPTION
The reading of files is not traceable or inconsistent, especially for linux machines. 
Filenames were chosen arbitrary and a simple filelist.sort() could fix it.

I already submitted somehow same request in 2020.

I would even recommend to set sorted even as standard. I do not know why this request has been removed again afterwards, probably just by error or there is a specific reason. Probably there's a reason for the backchange I'm not aware of or missed when skimming the code for the first time.

I did not set it the sorted as standard so far because of above mentioned reasons. 

Please consider this change, as I am really struggling with it. 
Thanks in advance.