### PR TITLE
Added >> operator override, for 4-port network cascading.

### DIFF
--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -5,7 +5,7 @@ implemented in Python.
 # Python 3 compatibility
 from __future__ import absolute_import, print_function, division
 
-__version__ = '0.23.1'
+__version__ = '0.23.2dbanas'
 ## Import all  module names for coherent reference of name-space
 #import io
 

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -5,7 +5,7 @@ implemented in Python.
 # Python 3 compatibility
 from __future__ import absolute_import, print_function, division
 
-__version__ = '0.23.2dbanas'
+__version__ = '0.23'
 ## Import all  module names for coherent reference of name-space
 #import io
 

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -5,7 +5,7 @@ implemented in Python.
 # Python 3 compatibility
 from __future__ import absolute_import, print_function, division
 
-__version__ = '0.23'
+__version__ = '0.23.1'
 ## Import all  module names for coherent reference of name-space
 #import io
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -555,16 +555,21 @@ class Network(object):
         """
         check_nports_equal(self, other)
         check_frequency_exist(self)
-        (h,_) = shape(self.s[0])
-        if h != 4:
-            raise ValueError("Operator >> may only be used to cascade 4-port networks.")
-            
+        (n,_) = shape(self.s[0])
+        if (n / 2) != (n // 2):
+            raise ValueError("Operator >> requires an even number of ports.")
+
+        ix_old = list(range(n))
+        n_2    = n//2
+        n_2_1  = list(range(n_2))
+        ix_new = list(sum(zip(n_2_1, list(map((lambda x: x + n_2), n_2_1))), ()))
+
         _ntwk1 = self.copy()
-        _ntwk1.renumber([1,2],[2,1])
+        _ntwk1.renumber(ix_old,ix_new)
         _ntwk2 = other.copy()
-        _ntwk2.renumber([1,2],[2,1])
+        _ntwk2.renumber(ix_old,ix_new)
         _rslt = _ntwk1 ** _ntwk2
-        _rslt.renumber([1,2],[2,1])
+        _rslt.renumber(ix_new,ix_old)
         return _rslt
 
     def __floordiv__(self, other: Union['Network', Tuple['Network', ...]] ) -> 'Network':

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -539,6 +539,34 @@ class Network(object):
         else:
             return cascade(self, other)
 
+    def __rshift__(self, other: 'Network') -> 'Network':
+        """
+        Cascade two 4-port networks with "1=>2/3=>4" port numbering.
+
+        Returns
+        -------
+        ntw : :class:`Network`
+            Cascaded Network
+
+        See Also
+        --------
+        cascade
+
+        """
+        check_nports_equal(self, other)
+        check_frequency_exist(self)
+        (h,_) = shape(self.s[0])
+        if h != 4:
+            raise ValueError("Operator >> may only be used to cascade 4-port networks.")
+            
+        _ntwk1 = self.copy()
+        _ntwk1.renumber([1,2],[2,1])
+        _ntwk2 = other.copy()
+        _ntwk2.renumber([1,2],[2,1])
+        _rslt = _ntwk1 ** _ntwk2
+        _rslt.renumber([1,2],[2,1])
+        return _rslt
+
     def __floordiv__(self, other: Union['Network', Tuple['Network', ...]] ) -> 'Network':
         """
         de-embedding 1 or 2 network[s], from this network

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -542,9 +542,10 @@ class Network(object):
     def __rshift__(self, other: 'Network') -> 'Network':
         """
         Cascade two 4-port networks with "1=>2/3=>4" port numbering.
-    Note
-    ----
-    connection diagram::
+        
+        Note
+        ----
+        connection diagram::
 
               A               B
            +---------+   +---------+

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -60,6 +60,9 @@ class NetworkTestCase(unittest.TestCase):
         self.Fix = rf.concat_ports([l1, l1, l1, l1])
         self.DUT = rf.concat_ports([l2, l2, l2, l2])
         self.Meas = rf.concat_ports([l3, l3, l3, l3])
+        self.Fix2 = rf.concat_ports([l1, l1, l1, l1], port_order='first')
+        self.DUT2 = rf.concat_ports([l2, l2, l2, l2], port_order='first')
+        self.Meas2 = rf.concat_ports([l3, l3, l3, l3], port_order='first')
 
     def test_timedomain(self):
         t = self.ntwk1.s11.s_time
@@ -342,6 +345,10 @@ class NetworkTestCase(unittest.TestCase):
     def test_cascade(self):
         self.assertEqual(self.ntwk1 ** self.ntwk2, self.ntwk3)
         self.assertEqual(self.Fix ** self.DUT ** self.Fix.flipped(), self.Meas)
+
+    def test_cascade2(self):
+        self.assertEqual(self.ntwk1 >> self.ntwk2, self.ntwk3)
+        self.assertEqual(self.Fix2 >> self.DUT2 >> self.Fix2.flipped(), self.Meas2)
 
     def test_connect(self):
         self.assertEqual(rf.connect(self.ntwk1, 1, self.ntwk2, 0) , \


### PR DESCRIPTION
When applied to 4-port networks, the `**` operator override assumes the "1=>3/2=>4" port numbering convention.
Currently, users of the other port numbering convention are out of luck, having to perform a bunch of port renumbering in their client code, which is ugly.

This PR adds an override of the `>>` operator, to alleviate this pain.
Users may now write: `rslt = n1 >> n2`, when networks `n1` and `n2` use the "1=>2/3=>4" port numbering convention.
