### PR TITLE
Vector Fitting: bugfix for data including dc samples

### DIFF
--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -46,7 +46,7 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
-        nw = skrf.Network('./cst_example_4ports.s4p')
+        nw = skrf.Network('./skrf/tests/cst_example_4ports.s4p')
         vf = skrf.VectorFitting(nw)
         vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
         # quality of the fit is not important in this test; it only needs to finish

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -44,6 +44,14 @@ class VectorFittingTestCase(unittest.TestCase):
             vf.vector_fit(n_poles_real=0, n_poles_cmplx=5, fit_proportional=False, fit_constant=True)
             self.assertEqual(warning[-1].category, RuntimeWarning)
 
+    def test_dc(self):
+        # perform the fit on data including a dc sample (0 Hz)
+        nw = skrf.Network('./cst_example_4ports.s4p')
+        vf = skrf.VectorFitting(nw)
+        vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
+        # quality of the fit is not important in this test; it only needs to finish
+        self.assertLess(vf.get_rms_error(), 0.2)
+
     def test_spice_subcircuit(self):
         # fit ring slot example network
         nw = skrf.data.ring_slot

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -189,6 +189,12 @@ class VectorFitting:
 
         fmin = np.amin(freqs_norm)
         fmax = np.amax(freqs_norm)
+
+        # poles cannot be at f=0; hence, f_min for starting pole must be greater than 0
+        if fmin == 0.0:
+            # random choice: use 1/1000 of first non-zero frequency
+            fmin = freqs_norm[1] / 1000
+
         if init_pole_spacing == 'log':
             pole_freqs_real = np.geomspace(fmin, fmax, n_poles_real)
             pole_freqs_cmplx = np.geomspace(fmin, fmax, n_poles_cmplx)


### PR DESCRIPTION
Vector Fitting crashes if the fitted data includes a dc sample.

The first starting pole $p_0$ is always positioned at $\omega_0=2\pi f[0]$, which is $0$ in such cases. The respective coefficient then becomes `inf` or `NaN` and causes the crash:
$\frac{1}{j \pi f_0 - p_0} = \frac{1}{0-0}$.

This fix places $p_0$ at $\omega_0=2\pi f[1] / 1000$, so the coefficient is less problematic:
$\frac{1}{j \pi f_0 - p_0} = \frac{1}{0-\omega_1 / 1000}$.

The factor 1/1000 is chosen arbitrarily and works well in my tests. There might be a better way to do it, but let's go with this for now.