### PR TITLE
Time Gate: Selectable gating methods

### DIFF
--- a/skrf/time.py
+++ b/skrf/time.py
@@ -195,7 +195,8 @@ def detect_span(ntwk) -> float:
 
 
 def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: float = None, span: float = None,
-              mode: str = 'bandpass', window=('kaiser', 6), method: str ='fft', fft_window='hann') -> 'Network':
+              mode: str = 'bandpass', window=('kaiser', 6),
+              method: str ='fft', fft_window='hann', conv_mode='wrap') -> 'Network':
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
@@ -252,6 +253,12 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         The window helps to remove artefacts such as time-domain sidelobes of the pulses, but it is a trade-off with
         the achievable pulse width. The window is removed when the gated time-domain signals is transformed back into
         frequency-domain.
+
+    conv_mode : str
+        Extension mode for the convolution (if selected) determining how the frequency-domain gate is extended beyond
+        the boundaries. This has a large effect on the generation of gating artefacts due to boundary effects. The
+        optimal mode depends on the data. See the parameter description of `scipy.ndimage.convolve1d` for the available
+        options.
 
     Note
     ----
@@ -351,7 +358,7 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     if method == 'convolution':
         # frequency-domain gating
         kernel = fftshift(fft(ifftshift(gate), norm='forward'))
-        ntwk_gated.s[:, 0, 0] = convolve1d(ntwk_gated.s[:, 0, 0], kernel, mode='wrap')
+        ntwk_gated.s[:, 0, 0] = convolve1d(ntwk_gated.s[:, 0, 0], kernel, mode=conv_mode)
     elif method == 'fft':
         # time-domain band-pass mode
         s_td = fftshift(ifft(ntwk_gated.s[:, 0, 0]))

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -23,6 +23,7 @@ from scipy import signal
 import numpy as npy
 from numpy.fft import fft, rfft, fftshift, ifft, irfft, ifftshift
 from scipy.ndimage import convolve1d
+import warnings
 
 # imports for type hinting
 from typing import List, TYPE_CHECKING
@@ -325,6 +326,12 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
 
     elif method == 'rfft':
         # time-domain low-pass mode
+        if ntwk.f[0] > 0.0:
+            # no dc point included
+            warnings.warn('The network data to be gated does not contain the dc point (0 Hz). This is required for the '
+                          'selected low-pass gating mode. Please consider to include the dc point if the results are '
+                          'inaccurate, either by direct measurement of by extrapolation using '
+                          'skrf.Network.extrapolate_to_dc().', UserWarning, stacklevel=2)
         n_td = 2 * n_fd - 1
         if fft_window is not None:
             # create low-pass window (one at lower limit at f=0, zero on upper limit)

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -192,7 +192,7 @@ def detect_span(ntwk) -> float:
 
 
 def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: float = None, span: float = None,
-              mode: str = 'bandpass', window=('kaiser', 6)) -> 'Network':
+              mode: str = 'bandpass', window=('kaiser', 6), method: str ='fft') -> 'Network':
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
@@ -225,6 +225,22 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         mode of gate
     window : string, float, or tuple
         passed to `window` arg of `scipy.signal.get_window()`
+    method : str
+        Gating method. There are 3 option: 'convolution', 'fft', 'rfft'.
+
+        With *'convolution'*, the time-domain gate gets transformed into frequency-domain using inverse FFT and the
+        gating is then achieved by convolution with the frequency-domain data.
+
+        With *'fft'* (default), the data gets transformed into time-domain using inverse FFT and the gating is achieved
+        by multiplication with the time-domain gate. The gated time-domain signal is then transformed back into
+        frequency-domain using inverse FFT. As only positive signal frequencies are considered for the inverse FFT
+        (with or without a dc component), the resulting time-domain signal has the same number of samples as in the
+        frequency-domain, but is complex-valued. This method is also know as *time-domain band-pass mode*.
+
+        With *'rfft'*, the procedure is the same as with *'fft'*, but the inverse FFT uses a complex-conjugate copy of
+        the positive signal frequencies for the negative frequencies (Hermitian frequency response). A dc sample is
+        also required. The resulting time-domain signal is real-valued and has twice the number of samples, which gives
+        an improved time resolution. This method is also known as *time-domain low-pass mode*.
 
     Note
     ----
@@ -268,6 +284,14 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         start = center - span / 2.
         stop = center + span / 2.
 
+    if method.lower() == 'convolution':
+        pass
+    elif method.lower() == 'fft':
+        pass
+    elif method.lower() == 'rfft':
+        pass
+    else:
+        raise ValueError('Invalid parameter method=`{}`'.format(method))
 
     # find start/stop gate indices
     t = ntwk.frequency.t


### PR DESCRIPTION
This PR refactors `time.time_gate()` to perform the gating either by convolution, by FFT (band-pass mode), or by RFFT (low-pass mode).

A new parameter `method` is added, which defaults to FFT.

Also, another parameter `fft_window` is added, which enables frequency-domain windowing in case of FFT and RFFT mode. The default is a Hann window, but windowing can be disabled by setting `fft_window=None`.