### PR TITLE
Treat all warnings in tests as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest ~=7",
-    "coverage ~=6",
-    "flake8 ~=5",
-    "pytest-cov >=3",
+    "pytest ~=7.0",
+    "coverage ~=6.0",
+    "flake8 ~=5.0",
+    "pytest-cov ~=3.0",
     "nbval ~=0.9"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest >=7",
-    "coverage >=6",
-    "flake8 >=5",
+    "pytest ~=7",
+    "coverage ~=6",
+    "flake8 ~=5",
     "pytest-cov >=3",
-    "nbval >=0.9"
+    "nbval ~=0.9"
 ]
 
 plot = [
@@ -75,7 +75,7 @@ documentation = "https://scikit-rf.readthedocs.io/en/latest/"
 
 [build-system]
 requires = [
-  "setuptools >= 40.9.0",
+  "setuptools >= 64",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import warnings
 import pickle
+import pytest
 
 import skrf as rf
 import numpy as npy
@@ -1231,7 +1232,8 @@ class LRRMTest(EightTermTest):
         o_i = wg.load(1, nports=1, name='open')
         s_i = wg.short(nports=1, name='short')
         m_i = wg.load(0.1, nports=1, name='load')
-        thru = wg.line(d=50, z0=75, unit='um', name='thru', embed=True)
+        with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            thru = wg.line(d=50, z0=75, unit='um', name='thru', embed=True)
         # Make sure calibration works with non-symmetric thru
         thru.s[:,1,1] += 0.02 + 0.05j
 

--- a/skrf/calibration/tests/test_deembedding.py
+++ b/skrf/calibration/tests/test_deembedding.py
@@ -1,3 +1,4 @@
+import pytest
 import skrf as rf
 import unittest
 import os
@@ -345,7 +346,8 @@ class DeembeddingTestCase(unittest.TestCase):
         s2xthru = rf.Network(os.path.join(self.test_dir, 's2xthru.s2p'))
         # interpolate to dc
         s2xthru_dc = s2xthru.extrapolate_to_dc(kind='linear')
-        dm_nzc = rf.IEEEP370_SE_NZC_2xThru(dummy_2xthru = s2xthru_dc, 
+        with pytest.warns(RuntimeWarning, match="DC point detected"):
+            dm_nzc = rf.IEEEP370_SE_NZC_2xThru(dummy_2xthru = s2xthru_dc, 
                                         name = '2xthru')
         residuals = dm_nzc.deembed(s2xthru_dc)
         # insertion loss magnitude deviate from 1.0 from less than 0.1 dB
@@ -370,8 +372,9 @@ class DeembeddingTestCase(unittest.TestCase):
         nonuniform_freq = rf.Frequency(s2xthru.f[0], s2xthru.f[-1], 
                                        npoints=len(s2xthru)-10, unit='Hz')
         s2xthru_nu = s2xthru.interpolate(nonuniform_freq)
-        dm_nzc_nu = rf.IEEEP370_SE_NZC_2xThru(dummy_2xthru = s2xthru_nu, 
-                                            name = '2xthru')
+        with pytest.warns(RuntimeWarning, match="Non-uniform frequency vector detected"):
+            dm_nzc_nu = rf.IEEEP370_SE_NZC_2xThru(dummy_2xthru = s2xthru_nu, 
+                                                name = '2xthru')
         residuals = dm_nzc_nu.deembed(s2xthru_nu)
         # insertion loss magnitude deviate from 1.0 from less than 0.1 dB
         il_mag = 20.*np.log10(np.abs(residuals.s[:, 1, 0] + 1e-12))
@@ -418,13 +421,14 @@ class DeembeddingTestCase(unittest.TestCase):
         fdf = rf.Network(os.path.join(self.test_dir, 'fdf.s2p'))
         s2xthru_dc = s2xthru.extrapolate_to_dc(kind='linear')
         fdf_dc = fdf.extrapolate_to_dc(kind='linear')
-        dm_zc  = rf.IEEEP370_SE_ZC_2xThru(dummy_2xthru = s2xthru_dc, 
-                                       dummy_fix_dut_fix = fdf_dc, 
-                                       bandwidth_limit = 10e9, 
-                                       pullback1 = 0, pullback2 = 0,
-                                       leadin = 0,
-                                       NRP_enable = False,
-                                       name = 'zc2xthru')
+        with pytest.warns(RuntimeWarning, match="DC point detected"):
+            dm_zc  = rf.IEEEP370_SE_ZC_2xThru(dummy_2xthru = s2xthru_dc, 
+                                        dummy_fix_dut_fix = fdf_dc, 
+                                        bandwidth_limit = 10e9, 
+                                        pullback1 = 0, pullback2 = 0,
+                                        leadin = 0,
+                                        NRP_enable = False,
+                                        name = 'zc2xthru')
         residuals = dm_zc.deembed(s2xthru_dc)
         # insertion loss magnitude deviate from 1.0 from less than 0.2 dB
         il_mag = 20.*np.log10(np.abs(residuals.s[:, 1, 0] + 1e-12))
@@ -451,13 +455,14 @@ class DeembeddingTestCase(unittest.TestCase):
                                        npoints=len(s2xthru)-10, unit='Hz')
         s2xthru_nu = s2xthru.interpolate(nonuniform_freq)
         fdf_nu = fdf.interpolate(nonuniform_freq)
-        dm_zc_nu  = rf.IEEEP370_SE_ZC_2xThru(dummy_2xthru = s2xthru_nu, 
-                                       dummy_fix_dut_fix = fdf_nu, 
-                                       bandwidth_limit = 10e9, 
-                                       pullback1 = 0, pullback2 = 0,
-                                       leadin = 0,
-                                       NRP_enable = False,
-                                       name = 'zc2xthru')
+        with pytest.warns(RuntimeWarning, match="Non-uniform frequency vector detected"):
+            dm_zc_nu  = rf.IEEEP370_SE_ZC_2xThru(dummy_2xthru = s2xthru_nu, 
+                                        dummy_fix_dut_fix = fdf_nu, 
+                                        bandwidth_limit = 10e9, 
+                                        pullback1 = 0, pullback2 = 0,
+                                        leadin = 0,
+                                        NRP_enable = False,
+                                        name = 'zc2xthru')
         residuals = dm_zc_nu.deembed(s2xthru_nu)
         # insertion loss magnitude deviate from 1.0 from less than 0.2 dB
         il_mag = 20.*np.log10(np.abs(residuals.s[:, 1, 0] + 1e-12))

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -794,9 +794,8 @@ def networkset_2_spreadsheet(ntwkset: 'NetworkSet', file_name: str = None, file_
         # add file extension if missing
         if not file_name.endswith('.xlsx'):
             file_name += '.xlsx'
-        writer = ExcelWriter(file_name)
-        [network_2_spreadsheet(k, writer, sheet_name=k.name, *args, **kwargs) for k in ntwkset]
-        writer.save()
+        with ExcelWriter(file_name) as writer:
+            [network_2_spreadsheet(k, writer, sheet_name=k.name, *args, **kwargs) for k in ntwkset]
     else:
         [network_2_spreadsheet(k,*args, **kwargs) for k in ntwkset]
 

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -124,15 +124,19 @@ class Touchstone:
         # open the file depending on encoding
         # Guessing the encoding by trial-and-error, unless specified encoding
         try:
-            if encoding is not None:
-                fid = get_fid(file, encoding=encoding)
-                self.filename = fid.name
-                self.load_file(fid)
-            else:
-                # Assume default encoding
-                fid = get_fid(file)
-                self.filename = fid.name
-                self.load_file(fid)
+            try:
+                if encoding is not None:
+                    fid = get_fid(file, encoding=encoding)
+                    self.filename = fid.name
+                    self.load_file(fid)
+                else:
+                    # Assume default encoding
+                    fid = get_fid(file)
+                    self.filename = fid.name
+                    self.load_file(fid)
+            except Exception as e:
+                fid.close()
+                raise e
 
         except UnicodeDecodeError:
             # Unicode fails -> Force Latin-1
@@ -149,13 +153,14 @@ class Touchstone:
         except Exception as e:
             raise ValueError(f'Something went wrong by the file opening: {e}')
 
-        self.gamma = []
-        self.z0 = []
+        finally:
+            self.gamma = []
+            self.z0 = []
 
-        if self.has_hfss_port_impedances:
-            self.get_gamma_z0_from_fid(fid)
+            if self.has_hfss_port_impedances:
+                self.get_gamma_z0_from_fid(fid)
 
-        fid.close()
+            fid.close()
 
     def load_file(self, fid: typing.TextIO):
         """

--- a/skrf/media/coaxial.py
+++ b/skrf/media/coaxial.py
@@ -14,7 +14,7 @@ A coaxial transmission line defined from its electrical or geometrical/physical 
 
 #from copy import deepcopy
 from scipy.constants import  epsilon_0, mu_0, pi, c
-from numpy import sqrt, log, real, imag, exp, expm1, size
+from numpy import sqrt, log, real, imag, exp, expm1, size, array
 from ..tlineFunctions import surface_resistivity, skin_depth
 from .distributedCircuit import DistributedCircuit
 from .media import Media, DefinedGammaZ0
@@ -122,7 +122,7 @@ class Coaxial(DistributedCircuit, Media):
 
         """
         # test size of parameters
-        if size(att) not in (1, size(frequency)):
+        if size(array(att, dtype="object")) not in (1, size(array(frequency, dtype="object"))):
             raise ValueError('Attenuation should be scalar or of same size that the frequency.')
     
         # create gamma

--- a/skrf/media/cpw.py
+++ b/skrf/media/cpw.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 class CPW(Media):
-    """
+    r"""
     Coplanar waveguide.
     
     

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -13,6 +13,7 @@ Media class.
 
 """
 from numbers import Number
+from pathlib import Path
 import warnings
 
 import numpy as npy
@@ -1463,17 +1464,20 @@ class DefinedGammaZ0(Media):
         write_csv
         """
         try:
-            f = open(filename)
+            fid = open(filename)
         except(TypeError):
             # they may have passed a file
-            f = filename
+            fid = filename
 
-        header = f.readline()
+        header = fid.readline()
         # this is not the correct way to do this ... but whatever
         f_unit = header.split(',')[0].split('[')[1].split(']')[0]
 
         f,z_re,z_im,g_re,g_im,pz_re,pz_im = \
-                npy.loadtxt(f,  delimiter=',').T
+                npy.loadtxt(fid,  delimiter=',').T
+
+        if isinstance(filename, (str, Path)):
+            fid.close()
 
         return cls(
             frequency = Frequency.from_f(f, unit=f_unit),

--- a/skrf/media/mline.py
+++ b/skrf/media/mline.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class MLine(Media):
-    """
+    r"""
     A microstripline transmission line defined in terms of width, thickness
     and height on a given relative permittivity substrate. The line has a
     conductor resistivity and a tangential loss factor.

--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
 import os
+
+import pytest
 import skrf as rf
 from skrf.media import Coaxial
 import numpy as npy
@@ -105,10 +107,11 @@ class MediaTestCase(unittest.TestCase):
 
         # Old R calculation valid only when skin depth is much smaller
         # then inner conductor radius
-        R_simple = coax.Rs/(2*npy.pi)*(1/coax.a + 1/coax.b)
+        with pytest.warns(RuntimeWarning, match="divide by zero"):
+            R_simple = coax.Rs/(2*npy.pi)*(1/coax.a + 1/coax.b)
 
-        self.assertTrue(abs(1 - coax.R[0]/dc_res) < 1e-2)
-        self.assertTrue(abs(1 - coax.R[1]/R_simple[1]) < 1e-2)
+            self.assertTrue(abs(1 - coax.R[0]/dc_res) < 1e-2)
+            self.assertTrue(abs(1 - coax.R[1]/R_simple[1]) < 1e-2)
 
 if __name__ == "__main__":
     # Launch all tests

--- a/skrf/media/tests/test_cpw.py
+++ b/skrf/media/tests/test_cpw.py
@@ -9,6 +9,8 @@ from skrf.frequency import Frequency
 import skrf as rf
 from numpy.testing import assert_array_almost_equal, assert_allclose, run_module_suite
 from matplotlib import pyplot as plt
+import pytest
+
 rf.stylely()
 
 
@@ -107,7 +109,8 @@ class CPWTestCase(unittest.TestCase):
                             tand = self.tand,
                             compatibility_mode = 'qucs',
                             diel = 'frequencyinvariant')
-            line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
+            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+                line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
             line.name = '`Media.CPW` skrf,qucs'
             
             # residuals
@@ -183,7 +186,8 @@ class CPWTestCase(unittest.TestCase):
                             tand = self.tand,
                             compatibility_mode = 'ads',
                             diel = 'djordjevicsvensson')
-            line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
+            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+                line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
             line.name = '`Media.CPW` skrf,ads'
             
             # residuals
@@ -286,7 +290,9 @@ class CPWTestCase(unittest.TestCase):
         with self.assertWarns(RuntimeWarning) as context:
             cpw = CPW(frequency = freq, z0 = 50., w = 3.0e-3, s = 0.3e-3, t = 35e-6,
                        ep_r = 4.5, rho = 1.7e-8)
-            line = cpw.line(d = 25e-3, unit = 'm', embed = True, z0 = cpw.Z0)
+            
+            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+                line = cpw.line(d = 25e-3, unit = 'm', embed = True, z0 = cpw.Z0)
             
     def test_zero_thickness(self):
         """

--- a/skrf/media/tests/test_mline.py
+++ b/skrf/media/tests/test_mline.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from asyncio import Future
 import unittest
 import os
 import numpy as npy

--- a/skrf/media/tests/test_mline.py
+++ b/skrf/media/tests/test_mline.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from asyncio import Future
 import unittest
 import os
 import numpy as npy
+import pytest
 
 from skrf.media import MLine
 from skrf.frequency import Frequency
@@ -139,7 +141,8 @@ class MLineTestCase(unittest.TestCase):
                             model = ref['model'], disp = ref['disp'],
                             diel = 'frequencyinvariant',
                             compatibility_mode = 'qucs')
-            line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
+            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+                line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
             line.name = 'skrf,qucs'
             
             # residuals
@@ -210,7 +213,8 @@ class MLineTestCase(unittest.TestCase):
                             tand = self.tand, rough = self.d,
                             model = 'hammerstadjensen', disp = ref['disp'],
                             diel = ref['diel'])
-            line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
+            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+                line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
             line.name = 'skrf,ads'
             
             # residuals

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -483,9 +483,9 @@ class Network(object):
 
 
         if "f" in kwargs.keys():
-            kwargs["frequency"] = Frequency.from_f(kwargs.pop("f"))
+            kwargs["frequency"] = Frequency.from_f(kwargs.pop("f"), unit=f_unit)
 
-        for attr in PRIMARY_PROPERTIES + ['frequency', 'f', 'noise', 'noise_freq']:
+        for attr in PRIMARY_PROPERTIES + ['frequency', 'noise', 'noise_freq']:
             if attr in kwargs:
                 self.__setattr__(attr, kwargs[attr])
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -483,6 +483,8 @@ class Network(object):
 
 
         if "f" in kwargs.keys():
+            if f_unit is None:
+                f_unit = "ghz"
             kwargs["frequency"] = Frequency.from_f(kwargs.pop("f"), unit=f_unit)
 
         for attr in PRIMARY_PROPERTIES + ['frequency', 'noise', 'noise_freq']:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -456,6 +456,9 @@ class Network(object):
                     fid.close()
                     self.read_touchstone(filename, self.encoding)
 
+                if not fid.closed:
+                    fid.close()
+
             if name is None and isinstance(file, str):
                 name = os.path.splitext(os.path.basename(file))[0]
 
@@ -477,6 +480,10 @@ class Network(object):
             self.s = npy.zeros(s_shape, dtype=complex)
 
         self.z0 = kwargs.get('z0', self._z0)
+
+
+        if "f" in kwargs.keys():
+            kwargs["frequency"] = Frequency.from_f(kwargs.pop("f"))
 
         for attr in PRIMARY_PROPERTIES + ['frequency', 'f', 'noise', 'noise_freq']:
             if attr in kwargs:

--- a/skrf/network2.py
+++ b/skrf/network2.py
@@ -750,13 +750,13 @@ def s2z(s,z0=50):
     z0 = fix_z0_shape(z0, nfreqs, nports)
 
     z = npy.zeros(s.shape, dtype='complex')
-    I = npy.mat(npy.identity(s.shape[1]))
+    I = npy.identity(s.shape[1])
 
     s[s==1.] = 1. + 1e-12 # solve numerical singularity
     s[s==-1.] = -1. + 1e-12 # solve numerical singularity
     for fidx in range(s.shape[0]):
-        sqrtz0 = npy.mat(npy.sqrt(npy.diagflat(z0[fidx])))
-        z[fidx] = sqrtz0 * (I-s[fidx])**-1 * (I+s[fidx]) * sqrtz0
+        sqrtz0 = npy.sqrt(npy.diagflat(z0[fidx]))
+        z[fidx] = sqrtz0 @ npy.linalg.inv(I-s[fidx]) @ (I+s[fidx]) @ sqrtz0
     return z
 
 def s2y(s, z0=50):
@@ -808,12 +808,12 @@ def s2y(s, z0=50):
     nfreqs, nports, nports = s.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
     y = npy.zeros(s.shape, dtype='complex')
-    I = npy.mat(npy.identity(s.shape[1]))
+    I = npy.identity(s.shape[1])
     s[s==-1.] = -1. + 1e-12 # solve numerical singularity
     s[s==1.] = 1. + 1e-12 # solve numerical singularity
     for fidx in range(s.shape[0]):
-        sqrty0 = npy.mat(npy.sqrt(npy.diagflat(1.0/z0[fidx])))
-        y[fidx] = sqrty0*(I-s[fidx])*(I+s[fidx])**-1*sqrty0
+        sqrty0 = npy.sqrt(npy.diagflat(1.0/z0[fidx]))
+        y[fidx] = sqrty0 @ (I-s[fidx]) @ npy.linalg.inv(I+s[fidx]) @ sqrty0
     return y
 
 def s2t(s):
@@ -923,10 +923,10 @@ def z2s(z, z0=50):
     nfreqs, nports, nports = z.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
     s = npy.zeros(z.shape, dtype='complex')
-    I = npy.mat(npy.identity(z.shape[1]))
+    I = npy.identity(z.shape[1])
     for fidx in range(z.shape[0]):
-        sqrty0 = npy.mat(npy.sqrt(npy.diagflat(1.0/z0[fidx])))
-        s[fidx] = (sqrty0*z[fidx]*sqrty0 - I) * (sqrty0*z[fidx]*sqrty0 + I)**-1
+        sqrty0 = npy.sqrt(npy.diagflat(1.0/z0[fidx]))
+        s[fidx] = (sqrty0 @ z[fidx] @ sqrty0 - I) @ npy.linalg.inv(sqrty0 @ z[fidx] @ sqrty0 + I)
     return s
 
 def z2y(z):
@@ -973,7 +973,7 @@ def z2y(z):
     """
     z = z.copy() # to prevent the original array from being altered
     z = fix_parameter_shape(z)
-    return npy.array([npy.mat(z[f,:,:])**-1 for f in range(z.shape[0])])
+    return npy.array([npy.linalg.inv(z[f,:,:]) for f in range(z.shape[0])])
 
 def z2t(z):
     """
@@ -1070,10 +1070,10 @@ def y2s(y, z0=50):
     nfreqs, nports, nports = y.shape
     z0 = fix_z0_shape(z0, nfreqs, nports)
     s = npy.zeros(y.shape, dtype='complex')
-    I = npy.mat(npy.identity(s.shape[1]))
+    I = npy.identity(s.shape[1])
     for fidx in range(s.shape[0]):
-        sqrtz0 = npy.mat(npy.sqrt(npy.diagflat(z0[fidx])))
-        s[fidx] = (I - sqrtz0*y[fidx]*sqrtz0) * (I + sqrtz0*y[fidx]*sqrtz0)**-1
+        sqrtz0 = npy.sqrt(npy.diagflat(z0[fidx]))
+        s[fidx] = (I - sqrtz0 @ y[fidx] @ sqrtz0) @ npy.linalg.inv(I + sqrtz0 @ y[fidx] @ sqrtz0)
     return s
 
 def y2z(y):

--- a/skrf/network2.py
+++ b/skrf/network2.py
@@ -1120,7 +1120,7 @@ def y2z(y):
     """
     y = y.copy() # to prevent the original array from being altered
     y = fix_parameter_shape(y)
-    return npy.array([npy.mat(y[f,:,:])**-1 for f in range(y.shape[0])])
+    return npy.array([npy.linalg.inv(y[f,:,:]) for f in range(y.shape[0])])
 
 def y2t(y):
     """

--- a/skrf/qfactor.py
+++ b/skrf/qfactor.py
@@ -466,8 +466,8 @@ class Qfactor(object):
             G[i] = v1.real
             G[i2] = v1.imag
             v2 = v1 * t
-            M[i, :] = v.real, -v.imag, y.real, -y.imag, v2.imag
-            M[i2, :] = v.imag, v.real, y.imag, y.real, -v2.real
+            M[i, :] = np.array([v.real, -v.imag, y.real, -y.imag, v2.imag], dtype="object")
+            M[i2, :] = np.array([v.imag, v.real, y.imag, y.real, -v2.real], dtype="object")
 
         T = M.transpose()  # unweighted
         C = T @ M
@@ -717,23 +717,23 @@ class Qfactor(object):
                     u2 = -u * self.f[i] / Flwst
                     v = (c2 + y * c3) * expm7
                     u3 = v * fdn
-                    M[i, :] = (
-                        expm7.real,
+                    M[i, :] = np.array(
+                        [expm7.real,
                         -expm7.imag,
                         ym.real,
                         -ym.imag,
                         u.real,
                         u2.real,
-                        -u3.imag,
+                        -u3.imag], dtype="object"
                     )
-                    M[i2, :] = (
-                        expm7.imag,
+                    M[i2, :] = np.array(
+                        [expm7.imag,
                         expm7.real,
                         ym.imag,
                         ym.real,
                         u.imag,
                         u2.imag,
-                        u3.real,
+                        u3.real], dtype="object"
                     )
                     r = self.s[i] - v  # residual
                     G[i] = r.real
@@ -897,8 +897,8 @@ class Qfactor(object):
                     u2 = -u * self.f[i] / Flwst
                     FL = Flwst * m5 / m6
                     t = 2 * (self.f[i] - FL) / FL
-                    M[i, :] = 1.0, 0.0, y.real, -y.imag, u.real, u2.real, t, 0.0
-                    M[i2, :] = 0.0, 1.0, y.imag, y.real, u.imag, u2.imag, 0.0, t
+                    M[i, :] = np.array([1.0, 0.0, y.real, -y.imag, u.real, u2.real, t, 0.0], dtype="object")
+                    M[i2, :] = np.array([0.0, 1.0, y.imag, y.real, u.imag, u2.imag, 0.0, t], dtype="object")
                     v = c2 + c3 * y + (m8 + 1j * m9) * t
                     r = self.s[i] - v  # residual
                     G[i] = r.real

--- a/skrf/tests/test_frequency.py
+++ b/skrf/tests/test_frequency.py
@@ -3,6 +3,7 @@ import unittest
 import warnings
 
 import numpy as npy
+import pytest
 
 import skrf as rf
 from skrf.frequency import InvalidFrequencyWarning
@@ -67,18 +68,11 @@ class FrequencyTestCase(unittest.TestCase):
 
         with self.assertWarns(InvalidFrequencyWarning):
             freq = rf.Frequency.from_f([1,2,2])
-
-        with warnings.catch_warnings(record=True) as warns:
+        
+        with self.assertWarns(InvalidFrequencyWarning):
             freq = rf.Frequency.from_f([1,2,2], unit="Hz")
-
-            w = [w for w in warns if issubclass(w.category, InvalidFrequencyWarning)]
-            if w:
-                inv = freq.drop_non_monotonic_increasing()
-                self.assertListEqual(inv, [2])
-
-            else:
-                self.fail("Warning is not triggered")
-
+            inv = freq.drop_non_monotonic_increasing()
+            self.assertListEqual(inv, [2])
             self.assertTrue(npy.allclose(freq.f, [1,2]))
 
     def test_immutability(self):

--- a/skrf/tests/test_mathFunctions.py
+++ b/skrf/tests/test_mathFunctions.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as npy
 from numpy import e, log, pi, isnan, inf
 from numpy.testing import assert_equal, run_module_suite, assert_almost_equal
-
+import pytest
 
 class TestUnitConversions(unittest.TestCase):
     """
@@ -67,10 +67,12 @@ class TestUnitConversions(unittest.TestCase):
         assert_almost_equal(rf.magnitude_2_db(10, True), 20)
         assert_almost_equal(rf.magnitude_2_db(10, False), 20)
 
-        assert_almost_equal(rf.magnitude_2_db(0), -inf)
-        assert_almost_equal(rf.magnitude_2_db(-1, True), LOG_OF_NEG)
-        assert_almost_equal(rf.magnitude_2_db([10, -1], True), [20, LOG_OF_NEG])
-        self.assertTrue(isnan(rf.magnitude_2_db(-1, False)))
+        with pytest.warns(RuntimeWarning, match="divide by zero"):
+            assert_almost_equal(rf.magnitude_2_db(0), -inf)
+        with pytest.warns(RuntimeWarning, match="invalid value encountered in log10"):
+            assert_almost_equal(rf.magnitude_2_db(-1, True), LOG_OF_NEG)
+            assert_almost_equal(rf.magnitude_2_db([10, -1], True), [20, LOG_OF_NEG])
+            self.assertTrue(isnan(rf.magnitude_2_db(-1, False)))
 
         assert_equal(rf.mag_2_db, rf.magnitude_2_db) # Just an alias
 
@@ -82,10 +84,12 @@ class TestUnitConversions(unittest.TestCase):
         assert_almost_equal(rf.mag_2_db10(10, True), 10)
         assert_almost_equal(rf.mag_2_db10(10, False), 10)
 
-        assert_almost_equal(rf.magnitude_2_db(0), -inf)
-        assert_almost_equal(rf.mag_2_db10(-1, True), LOG_OF_NEG)
-        assert_almost_equal(rf.mag_2_db10([10, -1], True), [10, LOG_OF_NEG])
-        self.assertTrue(isnan(rf.mag_2_db10(-1, False)))
+        with pytest.warns(RuntimeWarning, match="divide by zero"):
+            assert_almost_equal(rf.magnitude_2_db(0), -inf)
+        with pytest.warns(RuntimeWarning, match="invalid value encountered in log10"):
+            assert_almost_equal(rf.mag_2_db10(-1, True), LOG_OF_NEG)
+            assert_almost_equal(rf.mag_2_db10([10, -1], True), [10, LOG_OF_NEG])
+            self.assertTrue(isnan(rf.mag_2_db10(-1, False)))
 
 
     def test_db10_2_mag(self):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1,6 +1,7 @@
 from numpy.core.fromnumeric import squeeze
+import py
 import pytest
-from skrf.frequency import InvalidFrequencyWarning
+from skrf.frequency import Frequency, InvalidFrequencyWarning
 import unittest
 import os
 import io
@@ -339,8 +340,9 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_stitch(self):
         tmp = self.ntwk1.copy()
-        tmp.f = tmp.f+ tmp.f[0]
-        c = rf.stitch(self.ntwk1, tmp)
+        tmp.frequency = Frequency.from_f(tmp.f + tmp.f[0], 'Hz')
+        with pytest.warns(rf.frequency.InvalidFrequencyWarning):
+            c = rf.stitch(self.ntwk1, tmp)
 
     def test_cascade(self):
         self.assertEqual(self.ntwk1 ** self.ntwk2, self.ntwk3)
@@ -872,7 +874,7 @@ class NetworkTestCase(unittest.TestCase):
         for s_def in S_DEFINITIONS:
             ntwk = rf.Network(s_def=s_def)
             ntwk.z0 = rf.fix_z0_shape(z0, 2, 3)
-            ntwk.f = freqs
+            ntwk.frequency = Frequency.from_f(freqs)
             # test #1: define the network directly from z
             ntwk.z = z_ref
             npy.testing.assert_allclose(ntwk.z, z_ref)
@@ -892,7 +894,7 @@ class NetworkTestCase(unittest.TestCase):
         for s_def in S_DEFINITIONS:
             ntwk = rf.Network(s_def=s_def)
             ntwk.z0 = npy.array([50j, -50j])
-            ntwk.f = npy.array([1000])
+            ntwk.frequency = Frequency.from_f(npy.array([1000]))
             ntwk.s = npy.random.rand(1,2,2) + npy.random.rand(1,2,2)*1j
             self.assertFalse(npy.any(npy.isnan(ntwk.z)))
             self.assertFalse(npy.any(npy.isnan(ntwk.y)))
@@ -929,7 +931,7 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.s = npy.random.rand(3,2,2)
         ntwk.z0 = z0[::-1]
 
-        ntwk.f = [1,2,3]
+        ntwk.frequency = Frequency.from_f([1,2,3])
         self.assertTrue(npy.allclose(ntwk.z0, npy.array([z0[::-1], z0[::-1]], dtype=complex).T))
 
     def test_z0_matrix(self):
@@ -943,7 +945,7 @@ class NetworkTestCase(unittest.TestCase):
         # Setting the frequency is required to be set, as the matrix size is checked against the
         # frequency vector
         ntwk.s = npy.random.rand(1,2,2)
-        ntwk.f = [1]
+        ntwk.frequency = Frequency.from_f([1])
         ntwk.z0 = z0
         self.assertTrue(npy.allclose(ntwk.z0, npy.array(z0, dtype=complex)))
 
@@ -966,7 +968,7 @@ class NetworkTestCase(unittest.TestCase):
         tinyfloat = 1e-12
         ntwk = rf.Network()
         ntwk.z0 = npy.array([28,75+3j])
-        ntwk.f = npy.array([1000, 2000])
+        ntwk.frequency = Frequency.from_f(npy.array([1000, 2000]))
         ntwk.s = rf.z2s(npy.array([[[1+1j,5,11],[40,5,3],[16,8,9+8j]],
                                    [[1,20,3],[14,10,16],[27,18,-19-2j]]]))
         self.assertTrue((abs(rf.y2z(ntwk.y)-ntwk.z) < tinyfloat).all())

--- a/skrf/tests/test_network2.py
+++ b/skrf/tests/test_network2.py
@@ -1,6 +1,7 @@
 import unittest
 import skrf as rf
 import os
+import numpy as np
 
 from skrf import network2 as n2
 
@@ -26,13 +27,16 @@ class Network2TestCase(unittest.TestCase):
     #    n2.Network()
 
     def test_init_from_s(self):
-        n2.Network(frequency=self.freq, s=self.s_2port, z0=50)
+        net = n2.Network(frequency=self.freq, s=self.s_2port, z0=50)
+        assert np.allclose(net.s.val, self.s_2port, atol=1e-3)
 
     def test_init_from_z(self):
-        n2.Network(frequency=self.freq, z=self.s_2port, z0=50)
+        net = n2.Network(frequency=self.freq, z=self.s_2port, z0=50)
+        assert np.allclose(net.z.val, self.s_2port, atol=1e-3)
 
     def test_init_from_y(self):
-        n2.Network(frequency=self.freq, y=self.s_2port, z0=50)
+        net = n2.Network(frequency=self.freq, y=self.s_2port, z0=50)
+        assert np.allclose(net.y.val, self.s_2port, atol=1e-3)
 
     def test_init_from_ntwkv1(self):
         n2.Network.from_ntwkv1(rf.data.ring_slot)

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -1,4 +1,6 @@
 import unittest
+
+import pytest
 import skrf
 import numpy as np
 import tempfile
@@ -26,7 +28,10 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
+        with pytest.warns(UserWarning, match="The fitted network is passive, but the vector fit is not passive") as record:
+            vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
+
+        assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):
@@ -38,11 +43,13 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_no_convergence(self):
         # perform a bad fit that does not converge and check if a RuntimeWarning is given
-        with warnings.catch_warnings(record=True) as warning:
-            nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
-            vf = skrf.vectorFitting.VectorFitting(nw)
+        nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        vf = skrf.vectorFitting.VectorFitting(nw)
+        
+        with pytest.warns(RuntimeWarning) as record:
             vf.vector_fit(n_poles_real=0, n_poles_cmplx=5, fit_proportional=False, fit_constant=True)
-            self.assertEqual(warning[-1].category, RuntimeWarning)
+        
+        assert len(record) == 1
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
@@ -59,27 +66,34 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_constant=True, fit_proportional=True)
 
         # write equivalent SPICE subcircuit to tmp file
-        tmp_file = tempfile.NamedTemporaryFile(suffix='.sp')
-        tmp_file.close()  # tmp_file.name can be used to open the file a second time on Linux but not on Windows
-        vf.write_spice_subcircuit_s(tmp_file.name)
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.sp', delete=False)
+        name = tmp_file.name
+        tmp_file.close()
+        vf.write_spice_subcircuit_s(name)
 
         # written tmp file should contain 69 lines
-        n_lines = len(open(tmp_file.name, 'r').readlines())
+        with open(name, 'r') as f:
+            n_lines = len(f.readlines())
         self.assertEqual(n_lines, 69)
+        os.remove(name)
 
     def test_read_write_npz(self):
         # fit ring slot example network
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
+
+        with pytest.warns(UserWarning) as record:
+            vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
+
+        assert len(record) == 1
 
         # export (write) fitted parameters to .npz file in tmp directory
-        tmp_dir = tempfile.TemporaryDirectory()
-        vf.write_npz(tmp_dir.name)
+        with  tempfile.TemporaryDirectory() as name:
+            vf.write_npz(name)
 
-        # create a new vector fitting instance and import (read) those fitted parameters
-        vf2 = skrf.vectorFitting.VectorFitting(nw)
-        vf2.read_npz(os.path.join(tmp_dir.name, 'coefficients_{}.npz'.format(nw.name)))
+            # create a new vector fitting instance and import (read) those fitted parameters
+            vf2 = skrf.vectorFitting.VectorFitting(nw)
+            vf2.read_npz(os.path.join(name, 'coefficients_{}.npz'.format(nw.name)))
 
         # compare both sets of parameters
         self.assertTrue(np.allclose(vf.poles, vf2.poles))

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -815,12 +815,9 @@ def suppress_warning_decorator(msg):
         @wraps(func)
         def suppressed_func(*k, **kw):
             show_warnings = []
-            with warnings.catch_warnings(record=True) as wlist:
-                 res = func(*k, **kw)
-                 for w in wlist:
-                     if not w.message.args[0].startswith(msg):
-                         show_warnings.append(w)
-            for w in show_warnings:
-                warnings.warn(w.message.args[0])
+            with warnings.catch_warnings() as wlist:
+                warnings.filterwarnings("ignore", message=f"{msg}.*")
+                res = func(*k, **kw)
+            return res
         return suppressed_func
     return suppress_warnings_decorated

--- a/skrf/vi/sa.py
+++ b/skrf/vi/sa.py
@@ -44,7 +44,7 @@ class HP8500(Driver):
     >>> my_sa.cont_sweep()
     """
     def __init__(self, address=18, *args, **kwargs):
-        """
+        r"""
         Initializer
 
         Parameters
@@ -65,7 +65,7 @@ class HP8500(Driver):
         return f
 
     def get_ntwk(self, trace='a', goto_local=False, *args, **kwargs):
-        """
+        r"""
         Get a trace and return the data in a :class:`~skrf.network.Network` format
 
         This will save instrument stage to reg 1, activate single sweep

--- a/skrf/vi/stages.py
+++ b/skrf/vi/stages.py
@@ -49,7 +49,7 @@ class ESP300(Driver):
 
     def __init__(self, address=1, current_axis=1,\
             always_wait_for_stop=True,delay=0,**kwargs):
-        """
+        r"""
         Initializer
 
         Parameters

--- a/skrf/vi/vna_old.py
+++ b/skrf/vi/vna_old.py
@@ -112,7 +112,7 @@ class PNA(Driver):
     """
     def __init__(self, address, channel=1,timeout = 3, echo = False,
         front_panel_lockout= False, **kwargs):
-        """
+        r"""
         Constructor
 
         Parameters
@@ -546,7 +546,7 @@ class PNA(Driver):
         return out
 
     def get_oneport(self, port=1, *args, **kwargs):
-        """
+        r"""
         Get a one-port Network object for given ports.
 
         This calls :func:`~PNA.get_data_snp` and :func:`~PNA.get_frequency`
@@ -579,7 +579,7 @@ class PNA(Driver):
         return ntwk
 
     def get_twoport(self, ports=[1,2], sweep=True, single=True, *args, **kwargs):
-        """
+        r"""
         Get a two-port Network object for given ports.
 
         This calls :func:`~PNA.get_data_snp` and :func:`~PNA.get_frequency`

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ extras =
     plot
     docs
 commands =
-    pytest {posargs}
+    python -m pytest {posargs}
 
 [pytest]
 testpaths = 
@@ -35,7 +35,8 @@ norecursedirs =
     skrf/vi
     skrf/src
     doc/source/examples/instrumentcontrol
-filterwarnings =
+filterwarnings = 
     error
+    ignore::pytest.PytestRemovedIn8Warning
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ norecursedirs =
     skrf/vi
     skrf/src
     doc/source/examples/instrumentcontrol
-
+filterwarnings =
+    error
 
 


### PR DESCRIPTION
This PR changes the pytest call to treat all warnings as errors.
The following commits modified the tests and/or the source code to remove all warnings