### PR TITLE
update to pytest-cov ~=4.0 and drop the deprecation warning ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "pytest ~=7.0",
     "coverage ~=6.0",
     "flake8 ~=5.0",
-    "pytest-cov ~=3.0",
+    "pytest-cov ~=4.0",
     "nbval ~=0.9"
 ]
 
@@ -105,5 +105,4 @@ norecursedirs = [
 filterwarnings = [
     "error",
     "ignore::pytest.PytestRemovedIn8Warning",
-    'ignore:.*hookimpl.*old-style configuration options.*:pytest.PytestDeprecationWarning'
 ]


### PR DESCRIPTION
pytest-cov v4 updated to use the modern pytest hooks and avoids the warnings so they need not be ignored.

https://github.com/pytest-dev/pytest-cov/issues/561#issuecomment-1297143745