### PR TITLE
matplotlib as optional dependency

### DIFF
--- a/skrf/calibration/deembedding.py
+++ b/skrf/calibration/deembedding.py
@@ -61,8 +61,8 @@ import numpy as np
 from numpy import concatenate, conj, flip, real, angle, exp, zeros
 from numpy.fft import fft, fftshift, irfft, ifftshift
 from scipy.interpolate import interp1d
-import matplotlib.pyplot as plt
 
+from ..util import subplots
 
 class Deembedding(ABC):
     """
@@ -1205,15 +1205,13 @@ class IEEEP370_SE_NZC_2xThru(Deembedding):
                 z11x = z11[x]
 
             if self.verbose:
-                fig = plt.figure()
+                fig, (ax1, ax2) = subplots(2,1)
                 fig.suptitle('Midpoint length and impedance determination')
-                ax1 = plt.subplot(2, 1, 1)
                 ax1.plot(t21, label = 't21')
                 ax1.plot([x], [t21[x]], marker = 'o', linestyle = 'none',
                             label = 't21x')
                 ax1.grid()
                 ax1.legend()
-                ax2 = plt.subplot(2, 1, 2, sharex = ax1)
                 ax2.plot(z11, label = 'z11')
                 ax2.plot([x], [z11x], marker = 'o', linestyle = 'none',
                             label = 'z11x')
@@ -2074,7 +2072,7 @@ class IEEEP370_SE_ZC_2xThru(Deembedding):
             s22dut = s_dut.s[:, 1, 1]
             if self.verbose:
                 if i == 0:
-                    fig, axs = plt.subplots(2, 2)
+                    fig, axs = subplots(2, 2)
                     axs[0, 0].plot(z1, color = 'k')
                     axs[0, 0].set_xlim((0, x))
                     axs[0, 1].plot(z2, color = 'k')
@@ -2120,7 +2118,7 @@ class IEEEP370_SE_ZC_2xThru(Deembedding):
             s11dut = s_dut.s[:, 0, 0]
             if self.verbose:
                 if i == 0:
-                    fig, axs = plt.subplots(1, 2)
+                    fig, axs = subplots(1, 2)
                     axs[0].plot(z1, color = 'k')
                     axs[0].set_xlim((0, x))
                     axs[1].set_xlim((n-100, n+x*2+10))

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -62,25 +62,19 @@ import sys
 import getpass
 import warnings
 
-import matplotlib as mpl
-# if running on remote mode on a linux server which does not have a display (like Docker images for CI)
-# seems to cause problems only in Python2, so let's try reconfiguring the backend only in that case
-if os.name == 'posix' and not os.environ.get('DISPLAY', '') and mpl.rcParams['backend'] != 'agg' and sys.version.startswith('2'):
-    print('No display found. Using non-interactive Agg backend.')
-    # https://matplotlib.org/faq/usage_faq.html
-    if getpass.getuser() != 'jovyan':  # only if not running on Binder
-        mpl.use('Agg')
 import numpy as npy
+
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import ticker, rcParams
 from matplotlib.patches import Circle   # for drawing smith chart
 from matplotlib.pyplot import quiver
 from matplotlib.dates import date2num
+import matplotlib.tri as tri
 
 from . import network, frequency, calibration, networkSet, circuit
 from . import mathFunctions as mf
 from . util import now_string_2_dt
-import matplotlib.tri as tri
 
 try:
     import networkx as nx

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -19,7 +19,10 @@ from skrf.media import CPW
 from skrf.media import DistributedCircuit
 from skrf.constants import S_DEFINITIONS
 from skrf.networkSet import tuner_constellation
-from skrf.plotting import plot_contour
+try:
+    from skrf.plotting import plot_contour
+except ImportError:
+    pass
 
 class NetworkTestCase(unittest.TestCase):
     """
@@ -585,21 +588,27 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(self.Fix.inv ** self.Meas ** self.Fix.flipped().inv,
                          self.DUT)
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_one_port_db(self):
         self.ntwk1.plot_s_db(0,0)
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_one_port_deg(self):
         self.ntwk1.plot_s_deg(0,0)
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_one_port_smith(self):
         self.ntwk1.plot_s_smith(0,0)
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_two_port_db(self):
         self.ntwk1.plot_s_db()
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_two_port_deg(self):
         self.ntwk1.plot_s_deg()
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_two_port_smith(self):
         self.ntwk1.plot_s_smith()
 
@@ -1255,6 +1264,7 @@ class NetworkTestCase(unittest.TestCase):
         net_dc = self.ntwk1.extrapolate_to_dc(dc_sparam=zeros)
         net_dc = self.ntwk1.extrapolate_to_dc(dc_sparam=zeros.tolist())
 
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_noise_deembed(self):
 
 
@@ -1290,9 +1300,11 @@ class NetworkTestCase(unittest.TestCase):
           newnetw.set_noise_a(thru.noise_freq, nfmin_db=nfmin_set, gamma_opt=gamma_opt_set, rn=rn_set )
           z = newnetw.nfdb_gs(g)[:,0]
           freq = thru.noise_freq.f[0]
-          gamma_opt_rb, nfmin_rb = plot_contour(freq,x,y,z, min0max1=0, graph=False)
-          self.assertTrue(abs(nfmin_set - nfmin_rb) < 1.e-2, 'nf not retrieved by noise deembed')
-          self.assertTrue(abs(gamma_opt_rb.s[0,0,0] - gamma_opt_set) < 1.e-1, 'nf not retrieved by noise deembed')
+
+          if "matplotlib" in sys.modules:
+            gamma_opt_rb, nfmin_rb = plot_contour(freq,x,y,z, min0max1=0, graph=False)
+            self.assertTrue(abs(nfmin_set - nfmin_rb) < 1.e-2, 'nf not retrieved by noise deembed')
+            self.assertTrue(abs(gamma_opt_rb.s[0,0,0] - gamma_opt_set) < 1.e-1, 'nf not retrieved by noise deembed')
 
 
     def test_se2gmm2se(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -5,6 +5,7 @@ import skrf
 import numpy as np
 import tempfile
 import os
+import sys
 import warnings
 
 
@@ -59,6 +60,9 @@ class VectorFittingTestCase(unittest.TestCase):
         # quality of the fit is not important in this test; it only needs to finish
         self.assertLess(vf.get_rms_error(), 0.2)
 
+    @pytest.mark.skipif(
+        "matplotlib" not in sys.modules, 
+        reason="Spice subcircuit uses Engformatter which is not available without matplotlib.")
     def test_spice_subcircuit(self):
         # fit ring slot example network
         nw = skrf.data.ring_slot
@@ -101,9 +105,9 @@ class VectorFittingTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(vf.proportional_coeff, vf2.proportional_coeff))
         self.assertTrue(np.allclose(vf.constant_coeff, vf2.constant_coeff))
 
+    @pytest.mark.skipif("matplotlib" in sys.modules, reason="Raise Error only if matplotlib is not installed.")
     def test_matplotlib_missing(self):
         vf = skrf.vectorFitting.VectorFitting(skrf.data.ring_slot)
-        skrf.vectorFitting.mplt = None
         with self.assertRaises(RuntimeError):
             vf.plot_convergence()
 

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -87,7 +87,7 @@ def axis_kwarg(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        ax = kwargs.get('ax', None)
+        ax = kwargs.pop('ax', None)
         try:
             if ax is None:
                 ax = plt.gca()

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -76,8 +76,8 @@ except ImportError:
 
 def axis_kwarg(func):
     """
-    This decorator checks if matplotlib.pyplot is available under the name mplt.
-    If not, raise an RuntimeError.
+    This decorator checks if a :class:`matplotlib.axes.Axes` object is passed, 
+    if not the current axis will be gathered through :func:`plt.gca`.
 
     Raises
     ------
@@ -99,6 +99,15 @@ def axis_kwarg(func):
 
 
 def subplots(*args, **kwargs) -> Tuple[Figure, npy.ndarray]:
+    """
+    Wraps the matplotlib subplots call and raises if not available.
+
+    Raises
+    ------
+    RuntimeError
+        When trying to get subplots without matplotlib installed.
+    """
+
     try:
         return plt.subplots(*args, **kwargs)
     except NameError:

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -53,7 +53,7 @@ General Purpose Objects
 import contextlib
 import fnmatch
 import os
-from typing import Iterable, Tuple, List, Union, Any
+from typing import Iterable, Tuple, List, Union, Any, TypeVar
 import warnings
 import numpy as npy
 from datetime import datetime
@@ -64,6 +64,45 @@ from subprocess import Popen, PIPE
 import sys
 from functools import wraps
 from .constants import Number, NumberLike
+
+try:
+    from matplotlib.figure import Figure
+    from matplotlib.axes import Axes
+    import matplotlib.pyplot as plt
+except ImportError:
+    Figure = TypeVar("Figure")
+    Axes = TypeVar("Axes")
+    pass
+
+def axis_kwarg(func):
+    """
+    This decorator checks if matplotlib.pyplot is available under the name mplt.
+    If not, raise an RuntimeError.
+
+    Raises
+    ------
+    RuntimeError
+        When trying to run the decorated function without matplotlib
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        ax = kwargs.get('ax', None)
+        try:
+            if ax is None:
+                ax = plt.gca()
+        except NameError:
+            raise RuntimeError("Plotting is not available")
+        func(*args, ax=ax, **kwargs)
+
+    return wrapper
+
+
+def subplots(*args, **kwargs) -> Tuple[Figure, npy.ndarray]:
+    try:
+        return plt.subplots(*args, **kwargs)
+    except NameError:
+        raise RuntimeError("Plotting is not available")
 
 def now_string() -> str:
     """

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -74,7 +74,7 @@ except ImportError:
     Axes = TypeVar("Axes")
     pass
 
-def axis_kwarg(func):
+def axes_kwarg(func):
     """
     This decorator checks if a :class:`matplotlib.axes.Axes` object is passed, 
     if not the current axis will be gathered through :func:`plt.gca`.

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1371,7 +1371,7 @@ class VectorFitting:
 
     @axis_kwarg
     def plot(self, component: str, i: int = -1, j: int = -1, freqs: Any = None,
-             parameter: str = 's', *,ax = None):
+             parameter: str = 's', *, ax: Axes = None) -> Axes:
         """
         Plots the specified component of the parameter :math:`H_{i+1,j+1}` in the fit, where :math:`H` is
         either the scattering (:math:`S`), the impedance (:math:`Z`), or the admittance (:math:`H`) response specified

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     pass
 
-from .util import axis_kwarg, Axes
+from .util import axes_kwarg, Axes
 
 # imports for type hinting
 if TYPE_CHECKING:
@@ -1369,7 +1369,7 @@ class VectorFitting:
                 resp += residues[i] / (s - pole) + np.conjugate(residues[i]) / (s - np.conjugate(pole))
         return resp
 
-    @axis_kwarg
+    @axes_kwarg
     def plot(self, component: str, i: int = -1, j: int = -1, freqs: Any = None,
              parameter: str = 's', *, ax: Axes = None) -> Axes:
         """
@@ -1683,7 +1683,7 @@ class VectorFitting:
 
         return self.plot('im', *args, **kwargs)
 
-    @axis_kwarg
+    @axes_kwarg
     def plot_s_singular(self, freqs: Any = None, *, ax: Axes = None) -> Axes:
         """
         Plots the singular values of the vector fitted S-matrix in linear scale.
@@ -1734,7 +1734,7 @@ class VectorFitting:
         ax.legend(loc='best')
         return ax
 
-    @axis_kwarg
+    @axes_kwarg
     def plot_convergence(self, ax: Axes = None) -> Axes:
         """
         Plots the history of the model residue parameter **d_res** during the iterative pole relocation process of the
@@ -1761,7 +1761,7 @@ class VectorFitting:
         ax2.set_ylabel('Residue', color='orangered')
         return ax
 
-    @axis_kwarg
+    @axes_kwarg
     def plot_passivation(self, ax: Axes = None) -> Axes:
         """
         Plots the history of the greatest singular value during the iterative passivity enforcement process, which

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -19,25 +19,6 @@ from .util import axis_kwarg, Axes
 if TYPE_CHECKING:
     from .network import Network
 
-def check_plotting(func):
-    """
-    This decorator checks if matplotlib.pyplot is available under the name mplt.
-    If not, raise an RuntimeError.
-
-    Raises
-    ------
-    RuntimeError
-        When trying to run the decorated function without matplotlib
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if mplt is None:
-            raise RuntimeError('Plotting is not available')
-        func(*args, **kwargs)
-
-    return wrapper
-
 
 class VectorFitting:
     """

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1,23 +1,23 @@
-import numpy as np
 import os
-
-# imports for type hinting
+import logging
+import warnings
+from timeit import default_timer as timer
 from typing import Any, Tuple, TYPE_CHECKING
-if TYPE_CHECKING:
-    from .network import Network
 
-from functools import wraps
+import numpy as np
+
 try:
     from . import plotting    # will perform the correct setup for matplotlib before it is called below
     import matplotlib.pyplot as mplt
     from matplotlib.ticker import EngFormatter
 except ImportError:
-    mplt = None
+    pass
 
-import logging
-import warnings
-from timeit import default_timer as timer
+from .util import axis_kwarg, Axes
 
+# imports for type hinting
+if TYPE_CHECKING:
+    from .network import Network
 
 def check_plotting(func):
     """
@@ -1388,9 +1388,9 @@ class VectorFitting:
                 resp += residues[i] / (s - pole) + np.conjugate(residues[i]) / (s - np.conjugate(pole))
         return resp
 
-    @check_plotting
+    @axis_kwarg
     def plot(self, component: str, i: int = -1, j: int = -1, freqs: Any = None,
-             parameter: str = 's', ax: mplt.Axes = None) -> mplt.Axes:
+             parameter: str = 's', *,ax = None):
         """
         Plots the specified component of the parameter :math:`H_{i+1,j+1}` in the fit, where :math:`H` is
         either the scattering (:math:`S`), the impedance (:math:`Z`), or the admittance (:math:`H`) response specified
@@ -1441,9 +1441,6 @@ class VectorFitting:
 
         components = ['db', 'mag', 'deg', 'deg_unwrap', 're', 'im']
         if component.lower() in components:
-            if ax is None:
-                ax = mplt.gca()
-
             if self.residues is None or self.poles is None:
                 raise RuntimeError('Poles and/or residues have not been fitted. Cannot plot the model response.')
 
@@ -1555,7 +1552,7 @@ class VectorFitting:
         else:
             raise ValueError(f'The specified component ("{component}") is not valid. Must be in {components}.')
 
-    def plot_s_db(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_db(self, *args, **kwargs) -> Axes:
         """
         Plots the magnitude in dB of the scattering parameter response(s) in the fit.
 
@@ -1580,7 +1577,7 @@ class VectorFitting:
 
         return self.plot('db', *args, **kwargs)
 
-    def plot_s_mag(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_mag(self, *args, **kwargs) -> Axes:
         """
         Plots the magnitude in linear scale of the scattering parameter response(s) in the fit.
 
@@ -1605,7 +1602,7 @@ class VectorFitting:
 
         return self.plot('mag', *args, **kwargs)
 
-    def plot_s_deg(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_deg(self, *args, **kwargs) -> Axes:
         """
         Plots the phase in degrees of the scattering parameter response(s) in the fit.
 
@@ -1630,7 +1627,7 @@ class VectorFitting:
 
         return self.plot('deg', *args, **kwargs)
 
-    def plot_s_deg_unwrap(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_deg_unwrap(self, *args, **kwargs) -> Axes:
         """
         Plots the unwrapped phase in degrees of the scattering parameter response(s) in the fit.
 
@@ -1655,7 +1652,7 @@ class VectorFitting:
 
         return self.plot('deg_unwrap', *args, **kwargs)
 
-    def plot_s_re(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_re(self, *args, **kwargs) -> Axes:
         """
         Plots the real part of the scattering parameter response(s) in the fit.
 
@@ -1680,7 +1677,7 @@ class VectorFitting:
 
         return self.plot('re', *args, **kwargs)
 
-    def plot_s_im(self, *args, **kwargs) -> mplt.Axes:
+    def plot_s_im(self, *args, **kwargs) -> Axes:
         """
         Plots the imaginary part of the scattering parameter response(s) in the fit.
 
@@ -1705,8 +1702,8 @@ class VectorFitting:
 
         return self.plot('im', *args, **kwargs)
 
-    @check_plotting
-    def plot_s_singular(self, freqs: Any = None, ax: mplt.Axes = None) -> mplt.Axes:
+    @axis_kwarg
+    def plot_s_singular(self, freqs: Any = None, *, ax: Axes = None) -> Axes:
         """
         Plots the singular values of the vector fitted S-matrix in linear scale.
 
@@ -1739,9 +1736,6 @@ class VectorFitting:
             else:
                 freqs = self.network.f
 
-        if ax is None:
-            ax = mplt.gca()
-
         # get system matrices of state-space representation
         A, B, C, D, E = self._get_ABCDE()
 
@@ -1759,8 +1753,8 @@ class VectorFitting:
         ax.legend(loc='best')
         return ax
 
-    @check_plotting
-    def plot_convergence(self, ax: mplt.Axes = None) -> mplt.Axes:
+    @axis_kwarg
+    def plot_convergence(self, ax: Axes = None) -> Axes:
         """
         Plots the history of the model residue parameter **d_res** during the iterative pole relocation process of the
         vector fitting, which should eventually converge to a fixed value. Additionally, the relative change of the
@@ -1778,9 +1772,6 @@ class VectorFitting:
             figure.
         """
 
-        if ax is None:
-            ax = mplt.gca()
-
         ax.semilogy(np.arange(len(self.delta_max_history)) + 1, self.delta_max_history, color='darkblue')
         ax.set_xlabel('Iteration step')
         ax.set_ylabel('Max. relative change', color='darkblue')
@@ -1789,8 +1780,8 @@ class VectorFitting:
         ax2.set_ylabel('Residue', color='orangered')
         return ax
 
-    @check_plotting
-    def plot_passivation(self, ax: mplt.Axes = None) -> mplt.Axes:
+    @axis_kwarg
+    def plot_passivation(self, ax: Axes = None) -> Axes:
         """
         Plots the history of the greatest singular value during the iterative passivity enforcement process, which
         should eventually converge to a value slightly lower than 1.0 or stop after reaching the maximum number of
@@ -1807,9 +1798,6 @@ class VectorFitting:
             matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
             figure.
         """
-
-        if ax is None:
-            ax = mplt.gca()
 
         ax.plot(np.arange(len(self.history_max_sigma)) + 1, self.history_max_sigma)
         ax.set_xlabel('Iteration step')

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # running 'tox -- --nbval-lax' will also run all the notebooks located in doc/
 [tox]
 isolated_build = True
-envlist = py{37, 38, 39, 310, 311}
+envlist = py{37, 38, 39, 310, 311}, minimal-dependencies
 
 [gh-actions]
 python = 
@@ -25,3 +25,11 @@ extras =
 commands =
     python -m pytest {posargs}
 
+[testenv:minimal-dependencies]
+passenv = GITHUB_*
+usedevelop = true
+basepython = python3.9
+extras = 
+    test
+commands =
+    python -m pytest skrf/tests/test_network.py skrf/tests/test_vectorfitting.py

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py{37, 38, 39, 310, 311}, minimal-dependencies
 python = 
     3.7: py37
     3.8: py38
-    3.9: py39
+    3.9: py39, minimal-dependencies
     3.10: py310
     3.11: py311
 
@@ -32,4 +32,4 @@ basepython = python3.9
 extras = 
     test
 commands =
-    python -m pytest skrf/tests/test_network.py skrf/tests/test_vectorfitting.py
+    python -m pytest skrf/tests/test_network.py skrf/tests/test_vectorfitting.py 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
 
+# This is the default testsetup with all (optional) dependencies installed
 [testenv]
 passenv = GITHUB_*
 usedevelop = true
@@ -25,6 +26,8 @@ extras =
 commands =
     python -m pytest {posargs}
 
+# This setup tests only a subset of the functionality without any optional 
+# (runtime) dependencies.
 [testenv:minimal-dependencies]
 passenv = GITHUB_*
 usedevelop = true


### PR DESCRIPTION
This PR makes matplotlib an optional dependency again and adds a testsetup which tries to test the most basic network commands without matplotlib installed.