### PR TITLE
Warn users about future change of the default frequency unit

### DIFF
--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -22,8 +22,8 @@ from skrf.media import DistributedCircuit
 global NPTS  
 NPTS = 1
 
-WG_lossless =  rf.RectangularWaveguide(rf.F(75,100,NPTS), a=100*rf.mil, z0=50)
-WG =  rf.RectangularWaveguide(rf.F(75,100,NPTS), a=100*rf.mil, z0=50, rho='gold')
+WG_lossless = rf.RectangularWaveguide(rf.F(75, 100, NPTS, unit='GHz'), a=100*rf.mil, z0=50)
+WG = rf.RectangularWaveguide(rf.F(75, 100, NPTS, unit='GHz'), a=100*rf.mil, z0=50, rho='gold')
 
 
 class DetermineTest(unittest.TestCase):
@@ -203,7 +203,7 @@ class SDDLTest(OnePortTest):
     
     def test_init_with_nones(self):
         wg=self.wg
-        wg.frequency = rf.F.from_f([100])
+        wg.frequency = rf.F.from_f([100], unit='GHz')
         
         self.E = wg.random(n_ports =2, name = 'E')
         
@@ -1416,7 +1416,7 @@ class TwelveTermToEightTermTest(unittest.TestCase, CalibrationTest):
     def setUp(self):
         self.n_ports = 2
         wg= rf.wr10
-        wg.frequency = rf.F.from_f([100])
+        wg.frequency = rf.F.from_f([100], unit='GHz')
         self.wg = wg
         self.X = wg.random(n_ports =2, name = 'X')
         self.Y = wg.random(n_ports =2, name='Y')

--- a/skrf/calibration/tests/test_calibrationSet.py
+++ b/skrf/calibration/tests/test_calibrationSet.py
@@ -29,7 +29,7 @@ class DotOneport(unittest.TestCase,CalsetTest):
 
     """
     def setUp(self):
-        self.wg = rf.RectangularWaveguide(rf.F(75,100,11), a=100*rf.mil,z0=50)
+        self.wg = rf.RectangularWaveguide(rf.F(75, 100, 11, unit='GHz'), a=100*rf.mil,z0=50)
         wg = self.wg
         self.n_ports = 1
         self.E = wg.random(n_ports =2, name = 'E')
@@ -62,9 +62,9 @@ class DotEightTerm(unittest.TestCase, CalsetTest):
     @suppress_warning_decorator("divide by zero encountered in true_divide")
     def setUp(self):
         self.n_ports = 2
-        self.wg = rf.RectangularWaveguide(rf.F(75,100,3), a=100*rf.mil,z0=50)
+        self.wg = rf.RectangularWaveguide(rf.F(75, 100, 3, unit='GHz'), a=100*rf.mil,z0=50)
         wg= self.wg
-        wg.frequency = rf.F.from_f([100])
+        wg.frequency = rf.F.from_f([100], unit='GHz')
         
         self.X = wg.random(n_ports =2, name = 'X')
         self.Y = wg.random(n_ports =2, name='Y')

--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -99,7 +99,7 @@ class Frequency:
 
 
     def __init__(self, start: float = 0, stop: float = 0, npoints: int = 0,
-        unit: str = 'ghz', sweep_type: str = 'lin') -> None:
+        unit: str = None, sweep_type: str = 'lin') -> None:
         """
         Frequency initializer.
 
@@ -145,6 +145,15 @@ class Frequency:
         >>> wr1p5band = Frequency(500, 750, 401, 'ghz')
 
         """
+        if unit is None:
+            warnings.warn('''
+                          Frequency unit not passed: currently uses 'GHz' per default.
+                          The future versions of scikit-rf will use 'Hz' per default instead,
+                          so it is recommended to specify explicitly the frequency unit
+                          to obtain similar results with future versions.
+                          ''',
+                          DeprecationWarning, stacklevel=2)
+            unit = 'ghz'
         self._unit = unit.lower()
 
         start =  self.multiplier * start

--- a/skrf/io/citi.py
+++ b/skrf/io/citi.py
@@ -217,7 +217,7 @@ class Citi():
         if not 'freq' in [it.lower() for it in self._params.keys()]:
             raise ValueError('Frequency points not found')
 
-        freq = Frequency.from_f(self._params['freq']['values'])
+        freq = Frequency.from_f(self._params['freq']['values'], unit='Hz')
 
         # Network parameters: search for S, then Z or Y
         if any([it.startswith('S') for it in self._data.keys()]):

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -25,7 +25,7 @@ class IOTestCase(unittest.TestCase):
         self.ntwk_comments_file = os.path.join(self.test_dir, 'comments.s3p')
         self.test_files = [os.path.join(self.test_dir, test_file) for test_file in ['ntwk1.s2p', 'ntwk2.s2p']]
         self.embeding_network= rf.Network(os.path.join(self.test_dir, 'embedingNetwork.s2p'))
-        self.freq = rf.F(75,110,101)
+        self.freq = rf.F(75, 110, 101, unit='GHz')
 
     def read_write(self,obj):
         """

--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -96,7 +96,7 @@ class MediaTestCase(unittest.TestCase):
             coax = Coaxial.from_attenuation_VF(frequency=frequency2, att=att)
 
     def test_R(self):
-        freq = rf.Frequency(0, 100, 2)
+        freq = rf.Frequency(0, 100, 2, unit='GHz')
 
         rho = 1e-7
         dint = 0.44e-3

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -17,7 +17,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
             'qucs_prj'
             )
         self.dummy_media = DefinedGammaZ0(
-            frequency = Frequency(1,100,21,'ghz'),
+            frequency = Frequency(1, 100, 21, unit='ghz'),
             gamma=1j,
             z0 = 50 ,
             )
@@ -42,7 +42,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'tee'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.tee(name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -52,7 +52,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'splitter'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.splitter(3, name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -62,7 +62,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'thru'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.thru(name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -72,7 +72,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'line'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.line(90, 'deg', name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -82,7 +82,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'delay_load'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.delay_load(1j, 90, 'deg',
                                                       name = name)
         self.assertEqual(name, skrf_ntwk.name)
@@ -93,7 +93,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'shunt_delay_load'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.shunt_delay_load(1j, 90, 'deg',
                                                       name = name)
         self.assertEqual(name, skrf_ntwk.name)
@@ -104,7 +104,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'delay_open'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.delay_open(90, 'deg', name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -114,7 +114,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'shunt_delay_open'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.shunt_delay_open(90, 'deg', name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -124,7 +124,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'delay_short'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.delay_short(90, 'deg', name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -134,7 +134,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'shunt_delay_short'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.shunt_delay_short(90, 'deg', name = name)
         self.assertEqual(name, skrf_ntwk.name)
 
@@ -170,7 +170,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'shunt_capacitor,p01pF'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.capacitor(.01e-12, name = name)
         self.assertEqual(name, skrf_ntwk.name)
 
@@ -194,7 +194,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'shunt_inductor,p1nH'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.inductor(.1e-9, name = name)
         self.assertEqual(name, skrf_ntwk.name)
         
@@ -204,7 +204,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'attenuator,-10dB'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.attenuator(-10, d = 90, unit = 'deg',
                                                 name = name)
         self.assertEqual(name, skrf_ntwk.name)
@@ -215,7 +215,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'lossless_mismatch,-10dB'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.lossless_mismatch(-10, name = name)
         self.assertEqual(name, skrf_ntwk.name)
     
@@ -225,7 +225,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         topology of networks, they should have unique names.
         """
         name = 'isolator'
-        self.dummy_media.frequency = Frequency(1, 1, 1, 'GHz')
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.isolator(name = name)
         self.assertEqual(name, skrf_ntwk.name)
 
@@ -234,7 +234,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         """
         test ability to create a Media from scalar quantities for gamma/z0
         """
-        freq = Frequency(1,10,101)
+        freq = Frequency(1, 10, 101, unit='GHz')
         a = DefinedGammaZ0(freq, gamma=1j, z0=50)
         self.assertEqual(len(freq), len(a))
         self.assertEqual(len(freq), len(a.gamma))
@@ -245,7 +245,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         """
         test ability to create a Media from vector quantities for gamma/z0
         """
-        freq = Frequency(1,10,101)
+        freq = Frequency(1, 10, 101, unit='GHz')
         a = DefinedGammaZ0(freq,
                            gamma = 1j*npy.ones(len(freq)) ,
                            z0 =  50*npy.ones(len(freq)),
@@ -276,7 +276,7 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.dummy_media = DefinedGammaZ0(
-            frequency=Frequency(1, 100, 21, 'GHz'),
+            frequency=Frequency(1, 100, 21, unit='GHz'),
             gamma=1j,
             z0=50,
             )
@@ -379,7 +379,7 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.dummy_media = DefinedGammaZ0(
-            frequency=Frequency(1, 100, 21,'GHz'),
+            frequency=Frequency(1, 100, 21, unit='GHz'),
             gamma=1j,
             z0=50 ,
             )
@@ -503,7 +503,7 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         alpha = 0.5
         beta = 2.0
         lossy_media = DefinedGammaZ0(
-            frequency=Frequency(1, 100, 21, 'GHz'),
+            frequency=Frequency(1, 100, 21, unit='GHz'),
             gamma=alpha + 1j*beta,
             z0=z0
             )
@@ -519,7 +519,7 @@ class DefinedGammaZ0_s_def(unittest.TestCase):
 
     def test_complex_ports(self):
         m = DefinedGammaZ0(
-            frequency = Frequency(1,1,1,'ghz'),
+            frequency = Frequency(1, 1, 1, unit='ghz'),
             gamma=1j,
             z0 = 50,
             Z0 = 10+20j,

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1387,7 +1387,7 @@ class Network:
         try:
             return self._frequency
         except (AttributeError):
-            self._frequency = Frequency(0, 0, 0)
+            self._frequency = Frequency(0, 0, 0, unit='Hz')
             return self._frequency
 
     @frequency.setter

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -43,7 +43,7 @@ class CircuitTestConstructor(unittest.TestCase):
                        [(_ntwk1, 1), (self.ntwk2, 0)],
                        [(self.ntwk2, 1), (self.port2, 0)]]
 
-        _ntwk1.frequency = rf.Frequency(start=1, stop=1, npoints=1)
+        _ntwk1.frequency = rf.Frequency(start=1, stop=1, npoints=1, unit='GHz')
         self.assertRaises(AttributeError, rf.Circuit, connections)
 
     def test_no_duplicate_node(self):
@@ -75,7 +75,7 @@ class CircuitClassMethods(unittest.TestCase):
     Test the various class methods of Circuit such as Ground, Port, etc.
     """
     def setUp(self):
-        self.freq = rf.Frequency(start=1, stop=2, npoints=101)
+        self.freq = rf.Frequency(start=1, stop=2, npoints=101, unit='GHz')
         self.media = rf.DefinedGammaZ0(self.freq)
 
     def test_ground(self):
@@ -156,7 +156,7 @@ class CircuitTestWilkinson(unittest.TestCase):
         Circuit setup
         """
         self.test_dir = os.path.dirname(os.path.abspath(__file__))+'/'
-        self.freq = rf.Frequency(start=1, stop=2, npoints=101)
+        self.freq = rf.Frequency(start=1, stop=2, npoints=101, unit='GHz')
         # characteristic impedance of the ports
         Z0_ports = 50
 
@@ -370,7 +370,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         """
         Connect a matched load directly to the port
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         port1 = rf.Circuit.Port(freq,  name='port1')
         line = rf.media.DefinedGammaZ0(frequency=freq)
         match_load = line.match(name='match_load')
@@ -386,7 +386,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         """
         Connect a short directly to the port
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         port1 = rf.Circuit.Port(freq,  name='port1')
         line = rf.media.DefinedGammaZ0(frequency=freq)
         short = line.short(name='short')
@@ -409,7 +409,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         """
         Connect a random load directly to the port
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         port1 = rf.Circuit.Port(freq,  name='port1')
         line = rf.media.DefinedGammaZ0(frequency=freq)
         gamma = np.random.rand(1,1) + 1j*np.random.rand(1,1)
@@ -426,7 +426,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         """
         Connect a random 2 port network connected to a matched load
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(4).reshape(2, 2)
@@ -449,7 +449,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         Both ports are complex.
         """
         z01, z02 = 1-1j, 2+4j
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(4).reshape(2, 2)
@@ -472,7 +472,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         Connect two 2-ports networks in a resulting  2-ports network,
         same default charact impedance (50 Ohm) for all ports
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(4).reshape(2, 2)
@@ -501,7 +501,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         same complex charact impedance (1+1j) for all ports
         """
         z0 = 1 + 1j
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(4).reshape(2, 2)
@@ -531,7 +531,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         Connect two 2-ports networks in a resulting  2-ports network,
         different characteristic impedances for each network ports
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(4).reshape(2,2)
@@ -561,7 +561,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         Connect two 4-ports networks in a resulting 4-ports network,
         with default characteristic impedances
         """
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(16).reshape(4, 4)
@@ -595,7 +595,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         with same complex characteristic impedances
         """
         z0 = 5 + 4j
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(16).reshape(4, 4)
@@ -631,7 +631,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         with different characteristic impedances
         """
         z0 = [1, 2, 3, 4]
-        freq = rf.Frequency(start=1, npoints=1)
+        freq = rf.Frequency(start=1, npoints=1, unit='GHz')
         a = rf.Network(name='a')
         a.frequency = freq
         a.s = np.random.rand(16).reshape(4, 4)
@@ -666,7 +666,7 @@ class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
         """
         Compare a shunt element network (here a capacitor)
         """
-        freq = rf.Frequency(start=1, stop=2, npoints=101)
+        freq = rf.Frequency(start=1, stop=2, npoints=101, unit='GHz')
         line = rf.media.DefinedGammaZ0(frequency=freq, z0=50)
         # usual way
         cap_shunt_manual = line.shunt_capacitor(50e-12)
@@ -819,7 +819,7 @@ class CircuitTestGraph(unittest.TestCase):
 
         Setup a circuit which has various interconnections (2 or 3)
         """
-        self.freq = rf.Frequency(start=1, stop=2, npoints=101)
+        self.freq = rf.Frequency(start=1, stop=2, npoints=101, unit='GHz')
 
         # dummy components
         self.R = 100

--- a/skrf/tests/test_frequency.py
+++ b/skrf/tests/test_frequency.py
@@ -56,7 +56,7 @@ class FrequencyTestCase(unittest.TestCase):
             npy.array([1,4,10,20])).all())
 
     def test_slicer(self):
-        a = rf.Frequency.from_f([1,2,4,5,6])
+        a = rf.Frequency.from_f([1,2,4,5,6], unit='GHz')
 
         b = a['2-5ghz']
         tinyfloat = 1e-12
@@ -64,13 +64,13 @@ class FrequencyTestCase(unittest.TestCase):
 
     def test_frequency_check(self):
         with self.assertWarns(InvalidFrequencyWarning):
-            freq = rf.Frequency.from_f([2,1])
+            freq = rf.Frequency.from_f([2,1], unit='Hz')
 
         with self.assertWarns(InvalidFrequencyWarning):
-            freq = rf.Frequency.from_f([1,2,2])
+            freq = rf.Frequency.from_f([1,2,2], unit='Hz')
         
         with self.assertWarns(InvalidFrequencyWarning):
-            freq = rf.Frequency.from_f([1,2,2], unit="Hz")
+            freq = rf.Frequency.from_f([1,2,2], unit='Hz')
             inv = freq.drop_non_monotonic_increasing()
             self.assertListEqual(inv, [2])
             self.assertTrue(npy.allclose(freq.f, [1,2]))
@@ -80,7 +80,7 @@ class FrequencyTestCase(unittest.TestCase):
         To avoid corner cases, it is not be possible to change the
         frequency points directly.
         """
-        a = rf.Frequency.from_f([1,2,4,5,6])
+        a = rf.Frequency.from_f([1,2,4,5,6], unit='Hz')
         # TODO : assertRaises(AttributeError) in next release
         with self.assertWarns(DeprecationWarning):
             a.f = [1, 2]

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -360,7 +360,7 @@ class NetworkTestCase(unittest.TestCase):
             self.ntwk3)
 
         xformer = rf.Network()
-        xformer.frequency=(1,)
+        xformer.frequency=rf.Frequency(1, 1, 1, unit='GHz')
         xformer.s = ((0,1),(1,0))  # connects thru
         xformer.z0 = (50,25)  # transforms 50 ohm to 25 ohm
         c = rf.connect(xformer,0,xformer,1)  # connect 50 ohm port to 25 ohm port
@@ -542,12 +542,12 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_connect_multiports(self):
         a = rf.Network()
-        a.frequency=(1,)
+        a.frequency = rf.Frequency(1, 1, 1, unit='GHz')
         a.s = npy.arange(16).reshape(4,4)
         a.z0 = npy.arange(4) + 1 #  Z0 should never be zero
 
         b = rf.Network()
-        b.frequency=(1,)
+        b.frequency = rf.Frequency(1, 1, 1, unit='GHz')
         b.s = npy.arange(16).reshape(4,4)
         b.z0 = npy.arange(4)+10
 
@@ -563,7 +563,7 @@ class NetworkTestCase(unittest.TestCase):
             self.ntwk3)
 
         xformer = rf.Network()
-        xformer.frequency=(1,)
+        xformer.frequency = rf.Frequency(1, 1, 1, unit='GHz')
         xformer.s = ((0,1),(1,0))  # connects thru
         xformer.z0 = (50,25)  # transforms 50 ohm to 25 ohm
         c = rf.connect_fast(xformer,0,xformer,1)  # connect 50 ohm port to 25 ohm port
@@ -574,7 +574,7 @@ class NetworkTestCase(unittest.TestCase):
             self.ntwk3)
 
         gain = rf.Network()
-        gain.frequency=(1,)
+        gain.frequency = rf.Frequency(1, 1, 1, unit='GHz')
         gain.s = ((0,2),(0.5,0))  # connects thru with gain of 2.0
         gain.z0 = (37,82)
         flipped = gain.copy()
@@ -883,7 +883,7 @@ class NetworkTestCase(unittest.TestCase):
         for s_def in S_DEFINITIONS:
             ntwk = rf.Network(s_def=s_def)
             ntwk.z0 = rf.fix_z0_shape(z0, 2, 3)
-            ntwk.frequency = Frequency.from_f(freqs)
+            ntwk.frequency = Frequency.from_f(freqs, unit='GHz')
             # test #1: define the network directly from z
             ntwk.z = z_ref
             npy.testing.assert_allclose(ntwk.z, z_ref)
@@ -903,7 +903,7 @@ class NetworkTestCase(unittest.TestCase):
         for s_def in S_DEFINITIONS:
             ntwk = rf.Network(s_def=s_def)
             ntwk.z0 = npy.array([50j, -50j])
-            ntwk.frequency = Frequency.from_f(npy.array([1000]))
+            ntwk.frequency = Frequency.from_f(npy.array([1000]), unit='GHz')
             ntwk.s = npy.random.rand(1,2,2) + npy.random.rand(1,2,2)*1j
             self.assertFalse(npy.any(npy.isnan(ntwk.z)))
             self.assertFalse(npy.any(npy.isnan(ntwk.y)))
@@ -940,7 +940,7 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.s = npy.random.rand(3,2,2)
         ntwk.z0 = z0[::-1]
 
-        ntwk.frequency = Frequency.from_f([1,2,3])
+        ntwk.frequency = Frequency.from_f([1,2,3], unit='GHz')
         self.assertTrue(npy.allclose(ntwk.z0, npy.array([z0[::-1], z0[::-1]], dtype=complex).T))
 
     def test_z0_matrix(self):
@@ -954,7 +954,7 @@ class NetworkTestCase(unittest.TestCase):
         # Setting the frequency is required to be set, as the matrix size is checked against the
         # frequency vector
         ntwk.s = npy.random.rand(1,2,2)
-        ntwk.frequency = Frequency.from_f([1])
+        ntwk.frequency = Frequency.from_f([1], unit='GHz')
         ntwk.z0 = z0
         self.assertTrue(npy.allclose(ntwk.z0, npy.array(z0, dtype=complex)))
 
@@ -977,7 +977,7 @@ class NetworkTestCase(unittest.TestCase):
         tinyfloat = 1e-12
         ntwk = rf.Network()
         ntwk.z0 = npy.array([28,75+3j])
-        ntwk.frequency = Frequency.from_f(npy.array([1000, 2000]))
+        ntwk.frequency = Frequency.from_f(npy.array([1000, 2000]), unit='GHz')
         ntwk.s = rf.z2s(npy.array([[[1+1j,5,11],[40,5,3],[16,8,9+8j]],
                                    [[1,20,3],[14,10,16],[27,18,-19-2j]]]))
         self.assertTrue((abs(rf.y2z(ntwk.y)-ntwk.z) < tinyfloat).all())
@@ -1031,7 +1031,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_interpolate_rational(self):
         a = rf.N(f=npy.linspace(1,2,5),s=npy.linspace(0,1,5)*(1+1j),z0=1)
-        freq = rf.F.from_f(npy.linspace(1,2,6,endpoint=True))
+        freq = rf.F.from_f(npy.linspace(1,2,6,endpoint=True), unit='GHz')
         b = a.interpolate(freq, kind='rational')
         self.assertFalse(any(npy.isnan(b.s)))
         # Test that the endpoints are the equal
@@ -1043,7 +1043,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_interpolate_linear(self):
         a = rf.N(f=[1,2],s=[1+2j, 3+4j],z0=[1,2])
-        freq = rf.F.from_f(npy.linspace(1,2,3,endpoint=True))
+        freq = rf.F.from_f(npy.linspace(1,2,3,endpoint=True), unit='GHz')
         b = a.interpolate(freq, kind='linear')
         self.assertFalse(any(npy.isnan(b.s)))
         # Test that the endpoints are the equal
@@ -1356,7 +1356,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_se2gmm_renorm(self):
         # Test that se2gmm renormalization is compatible with network renormalization
-
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
         # Single-ended ports
         for s_def in rf.S_DEFINITIONS:
             for ports in range(2, 10):
@@ -1365,7 +1365,7 @@ class NetworkTestCase(unittest.TestCase):
                     # Create a random network, z0=50
                     s_random = npy.random.uniform(-1, 1, (1, ports, ports)) +\
                                 1j * npy.random.uniform(-1, 1, (1, ports, ports))
-                    net = rf.Network(s=s_random, frequency=[1], z0=50)
+                    net = rf.Network(s=s_random, frequency=freq, z0=50)
                     net_original = net.copy()
                     net_renorm = net.copy()
 

--- a/skrf/tests/test_networkSet.py
+++ b/skrf/tests/test_networkSet.py
@@ -337,7 +337,7 @@ class NetworkSetTestCase(unittest.TestCase):
         self.assertIsInstance(self.ns_params.interpolate_from_params('a', 0.5, {'X':10}), rf.Network)
         
         # test interpolated values
-        f1 = rf.Frequency(1, 1, 1)
+        f1 = rf.Frequency(1, 1, 1, unit='GHz')
         ntwk0 = rf.Network(frequency=f1, s=[[0]], params={'s': 0})
         ntwk1 = rf.Network(frequency=f1, s=[[1]], params={'s': 1})
         ns2 = rf.NetworkSet([ntwk0, ntwk1])


### PR DESCRIPTION
Future versions of scikit-rf (cf dicussions in #718 and #692) will use SI units, so "Hz" a the default unit and not "GHz" as it is currently.

Before making the change, one or few intermediate versions should warn users of the future change to come, and recommend passing the unit explicitly to avoid future compatibility problems in their codes.