### PR TITLE
Time ns warning

### DIFF
--- a/doc/source/examples/networktheory/Time Domain.ipynb
+++ b/doc/source/examples/networktheory/Time Domain.ipynb
@@ -54,7 +54,7 @@
     "s11 = probe.s11 \n",
     "\n",
     "#  time-gate the first largest reflection\n",
-    "s11_gated = s11.time_gate(center=0, span=.2)\n",
+    "s11_gated = s11.time_gate(center=0, span=.2, t_unit='ns')\n",
     "s11_gated.name='gated probe'\n",
     "\n",
     "# plot frequency and time-domain s-parameters\n",
@@ -193,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "probe_s11_gated = probe_s11.time_gate(center=0, span=.2)\n",
+    "probe_s11_gated = probe_s11.time_gate(center=0, span=.2, t_unit='ns')\n",
     "probe_s11_gated.name='gated probe'\n",
     "\n",
     "s11.plot_s_db_time()\n",

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -72,11 +72,30 @@ class NetworkTestCase(unittest.TestCase):
         t = self.ntwk1.s11.s_time
         s = self.ntwk1.s11.s
         self.assertTrue(len(t)== len(s))
+    
     def test_time_gate(self):
         ntwk = self.ntwk1
-        gated = self.ntwk1.s11.time_gate(0,.2)
+        gated = self.ntwk1.s11.time_gate(0,.2, t_unit='ns')
+        self.assertTrue(len(gated)== len(ntwk))
+
+    def test_time_gate_raises(self):
+        ntwk = self.ntwk1
+        with pytest.warns(DeprecationWarning, match="Time unit not passed"):
+            gated = self.ntwk1.s11.time_gate(0,.2)
 
         self.assertTrue(len(gated)== len(ntwk))
+
+        with pytest.warns(DeprecationWarning, match="Time unit not passed"):
+            gated = self.ntwk1.s11.time_gate(0,.2, t_unit='')
+        self.assertTrue(len(gated)== len(ntwk))
+
+    def test_autogate(self):
+        ntwk = self.Meas
+        # Auto gate should not raise
+        gated = ntwk.s11.time_gate()
+        self.assertTrue(len(gated)== len(ntwk))
+
+    
     def test_time_transform(self):
         spb = (4, 5)
         data_rate = 5e9

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -90,7 +90,12 @@ class NetworkTestCase(unittest.TestCase):
         self.assertTrue(len(gated)== len(ntwk))
 
     def test_autogate(self):
-        ntwk = self.Meas
+        l1 = self.cpw.line(0.1, 'm', z0=50)
+        l2 = self.cpw.line(0.1, 'm', z0=30)
+        l3 = self.cpw.line(0.1, 'm', z0=50)
+
+        ntwk = l1 ** l2 ** l3
+
         # Auto gate should not raise
         gated = ntwk.s11.time_gate()
         self.assertTrue(len(gated)== len(ntwk))

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -175,7 +175,7 @@ def find_n_peaks(x: npy.ndarray, n: int, thres: float = 0.9, **kwargs) -> List[i
     raise ValueError('Couldnt find %i peaks' % n)
 
 
-def detect_span(ntwk) -> float:
+def detect_span(ntwk: 'Network') -> float:
     """
     Detect the correct time-span between two largest peaks.
 
@@ -194,10 +194,19 @@ def detect_span(ntwk) -> float:
     span = abs(ntwk.frequency.t_ns[p1]-ntwk.frequency.t_ns[p2])
     return span
 
+time_lookup_dict = {
+    "s": 1,
+    "ms": 1e-3,
+    "us": 1e-6,
+    "µs": 1e-6,
+    "ns": 1e-9,
+    "ps": 1e-12
+}
+
 
 def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: float = None, span: float = None,
               mode: str = 'bandpass', window=('kaiser', 6),
-              method: str ='fft', fft_window='hann', conv_mode='wrap') -> 'Network':
+              method: str ='fft', fft_window: str='hann', conv_mode: str='wrap', t_unit: str = "") -> 'Network':
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
@@ -217,14 +226,14 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     ntwk : :class:`~skrf.network.Network`
         network to operate on
     start : number, or None
-        start of time gate, (ns).
+        start of time gate in t_unit.
     stop : number, or None
-        stop of time gate (ns).
+        stop of time gate in t_unit.
     center : number, or None
-        center of time gate, (ns). If None, and span is given,
+        center of time gate, in t_unit. If None, and span is given,
         the gate will be centered on the peak.
     span : number, or None
-        span of time gate, (ns).  If None span will be half of the
+        span of time gate, in t_unit.  If None span will be half of the
         distance to the second tallest peak
     mode : ['bandpass', 'bandstop']
         mode of gate
@@ -260,6 +269,16 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         the boundaries. This has a large effect on the generation of gating artefacts due to boundary effects. The
         optimal mode depends on the data. See the parameter description of `scipy.ndimage.convolve1d` for the available
         options.
+    
+    t_unit : str
+        Time unit for start, stop, center and span arguments, defaults to nanoseconds (ns).
+        Possible values: 
+            's': seconds
+            'ms': milliseconds
+            'µs' or 'us': microseconds
+            'ns': nanoseconds (default)
+            'ps': picoseconds
+
 
     Note
     ----
@@ -283,9 +302,23 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     if ntwk.nports >1:
         raise ValueError('Time-gating only works on one-ports. Try passing `ntwk.s11` or `ntwk.s21`.')
 
+    if t_unit == "":
+        if not all([e is None for e in [start, stop, center, span]]):
+            # Do not raise in autogate mode, where all parameters are None
+            warnings.warn('''
+                            Time unit not passed: currently uses 'ns' per default.
+                            The future versions of scikit-rf will use 's' per default instead,
+                            so it is recommended to specify explicitly the time unit
+                            to obtain similar results with future versions.
+                            ''',
+                            DeprecationWarning, stacklevel=2)
+        t_unit = 'ns'
+
+    t_mult = time_lookup_dict[t_unit]
+
     if start is not None and stop is not None:
-        start *= 1e-9
-        stop *= 1e-9
+        start *= t_mult
+        stop *= t_mult
         span = abs(stop-start)
         center = (stop+start)/2.
 
@@ -298,8 +331,8 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
         if span is None:
             span = detect_span(ntwk)
 
-        center *= 1e-9
-        span *= 1e-9
+        center *= t_mult
+        span *= t_mult
         start = center - span / 2.
         stop = center + span / 2.
 

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -210,8 +210,9 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     """
     Time-domain gating of one-port s-parameters with a window function from scipy.signal.windows.
 
-    The gate can be defined with start/stop times, or by center/span. All times are in units of nanoseconds. Common
-    windows are:
+    The gate can be defined with start/stop times, or by center/span. All times are in units of nanoseconds but
+    can be changed using the `t_unit` parameter. The default unit will change to `s` in **scikit-rf** version 1.0.
+    Common windows are:
 
     * ('kaiser', 6)
     * 6 # integers are interpreted as kaiser beta-values

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -194,8 +194,8 @@ def detect_span(ntwk: 'Network', t_unit: str = "") -> float:
     
     t_unit : str
         Time unit for start, stop, center and span arguments, defaults to nanoseconds (ns).
+        
         Possible values:
-
             * 's': seconds
             * 'ms': milliseconds
             * 'µs' or 'us': microseconds
@@ -298,8 +298,8 @@ def time_gate(ntwk: 'Network', start: float = None, stop: float = None, center: 
     
     t_unit : str
         Time unit for start, stop, center and span arguments, defaults to nanoseconds (ns).
+        
         Possible values:
-
             * 's': seconds
             * 'ms': milliseconds
             * 'µs' or 'us': microseconds


### PR DESCRIPTION
Similar to #792 this PR prepares skrf to use seconds instead of nanoseconds by default.