### PR TITLE
Draft: Set subnetwork properties on instance instead of the class

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -208,7 +208,6 @@ class Frequency:
         if isinstance(key, str):
 
             # they passed a string try and do some interpretation
-            re_numbers = re.compile(r'.*\d')
             re_hyphen = re.compile(r'\s*-\s*')
             re_letters = re.compile('[a-zA-Z]+')
 
@@ -279,7 +278,7 @@ class Frequency:
         if npy.isscalar(f):
             f = [f]
         temp_freq =  cls(0,0,0,*args, **kwargs)
-        temp_freq._f = npy.array(f) * temp_freq.multiplier
+        temp_freq._f = npy.asarray(f) * temp_freq.multiplier
         temp_freq.check_monotonic_increasing()
 
         return temp_freq

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -188,10 +188,17 @@ from .constants import S_DEFINITIONS, S_DEF_DEFAULT
 if TYPE_CHECKING:
     import pandas as pd
 
-#from matplotlib import cm
-#import matplotlib.pyplot as plt
-#import matplotlib.tri as tri
-#from scipy.interpolate import interp1d
+def add_property(inst : object, name : str, method : Callable, doc : Optional[str] = None):
+    """ Add a property to an instance
+    
+    Adapted from: https://stackoverflow.com/a/2954373/19469050
+    """
+    cls = type(inst)
+    if not hasattr(cls, '__perinstance'):
+      cls = type(cls.__name__, (cls,), {})
+      cls.__perinstance = True
+      inst.__class__ = cls
+    setattr(cls, name, property(method, doc=doc))
 
 class Network:
     r"""
@@ -962,11 +969,9 @@ class Network:
                 doc = """
                 one-port sub-network.
                 """
-                setattr(self, 's%i_%i'%(m+1, n+1),
-                        property(fget, doc=doc))
+                add_property(self, f's{m+1}_{n+1}', fget, doc=doc)
                 if m < 9 and n < 9:
-                    setattr(self, 's%i%i' % (m + 1, n + 1),
-                            getattr(self, 's%i_%i'%(m+1, n+1)))
+                    add_property(self, f's{m+1}{n+1}', fget, doc=doc)
 
 
     # PRIMARY PROPERTIES

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -935,14 +935,14 @@ class Network:
                 else:
                     def fget(self: 'Network', f: Callable = func, p: str = prop_name) -> npy.ndarray:
                         return f(getattr(self, p))
-                doc = """
-                The {} component of the {}-matrix
+                doc = f"""
+                The {func_name} component of the {prop_name}-matrix
 
 
                 See Also
                 --------
-                {}
-                """.format(func_name, prop_name, prop_name)
+                {prop_name}
+                """
 
                 setattr(self.__class__, f'{prop_name}_{func_name}', \
                         property(fget, doc=doc))
@@ -962,11 +962,11 @@ class Network:
                 doc = """
                 one-port sub-network.
                 """
-                setattr(self.__class__, 's%i_%i'%(m+1, n+1),
+                setattr(self, 's%i_%i'%(m+1, n+1),
                         property(fget, doc=doc))
                 if m < 9 and n < 9:
-                    setattr(self.__class__, 's%i%i' % (m + 1, n + 1),
-                            getattr(self.__class__, 's%i_%i'%(m+1, n+1)))
+                    setattr(self, 's%i%i' % (m + 1, n + 1),
+                            getattr(self, 's%i_%i'%(m+1, n+1)))
 
 
     # PRIMARY PROPERTIES


### PR DESCRIPTION
After importing skrf and creating a 1-port network, the network as attributes `s13', `s3_3` which it should not have (since it is a 1-port network). A minimal example:
```
import numpy as np
import skrf as rf

f = rf.Frequency.from_f(np.linspace(2e6, 3e6, 10), unit="Hz")
self=n=rf.Network(frequency=f, s=np.random.rand(10,)*1j, name='test')
# now n has properties s_12, which it should not have

w=[p for p in dir(self) if p.startswith('s') and p[-1] in ['0', '1','2','3','4']]
print(w)
```
has output
```
['s11', 's12', 's13', 's1_1', 's1_2', 's1_3', 's21', 's22', 's23', 's2_1', 's2_2', 's2_3', 's31', 's32', 's33', 's3_1', 's3_2', 's3_3', 's_db10']
```

This PR fixes that by setting the attributes on the instance, instead of the class.
