### PR TITLE
Multi-port calibration

### DIFF
--- a/doc/source/examples/metrology/Multi-port Calibration.ipynb
+++ b/doc/source/examples/metrology/Multi-port Calibration.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c37a5436-ede4-4155-8bc5-371a2db2dc95",
+   "metadata": {},
+   "source": [
+    "# Multi-port calibration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d129477-219e-467b-98d4-a6dac16e798f",
+   "metadata": {},
+   "source": [
+    "This example demonstrates how `MultiportSOLT` calibration class can be used to calibrate multi-port S-parameter measurement with three or more ports."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c758e1ad-2964-4a09-84be-4617360a1fad",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd5871dc-c4f4-4770-8380-5eca5ce8df37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import skrf\n",
+    "from skrf.media import Coaxial\n",
+    "import numpy as np\n",
+    "skrf.stylely()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81667dc5-a04f-45b1-9303-e3a225d8060d",
+   "metadata": {},
+   "source": [
+    "## Creating synthetic data\n",
+    "\n",
+    "First we create a synthetic error network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6eaaf9bd-4371-4c34-91d4-8c7a38e4d205",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freq = skrf.F(1,100,100, unit='GHz')\n",
+    "nports = 3\n",
+    "# 1.0 mm coaxial media for calibration error boxes\n",
+    "coax = Coaxial(freq, z0=50, Dint=0.44e-3, Dout=1.0e-3, sigma=1e8)\n",
+    "\n",
+    "# Create random error network\n",
+    "# First 'nports' ports will connect to an ideal VNA\n",
+    "# and the last 'nports' ports will connect to the DUT. \n",
+    "Z = coax.random(n_ports = 2*nports, name = 'Z')\n",
+    "\n",
+    "# Zero leakage terms in the error network.\n",
+    "port_type = lambda n: 'VNA' if n < nports else 'DUT'\n",
+    "port_number = lambda n: n if n < nports else n - nports\n",
+    "for i in range(2*nports):\n",
+    "    for j in range(i+1, 2*nports):\n",
+    "        # No connection between different VNA/DUT ports.\n",
+    "        # No connection between VNA and DUT ports with different number.\n",
+    "        if port_type(i) == port_type(j) or port_number(i) != port_number(j):\n",
+    "            Z.s[:,i,j] = 0\n",
+    "            Z.s[:,j,i] = 0\n",
+    "\n",
+    "# VNA switch terms. This is the termination impedance of each port\n",
+    "# when the source is not connected to that port.\n",
+    "gammas = []\n",
+    "for i in range(nports):\n",
+    "    gammas.append(coax.random(n_ports=1, name=f'gamma_{i}'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "404efab2-d9e7-486e-9a15-8d8ebe78dd7a",
+   "metadata": {},
+   "source": [
+    "Function for measuring a network through the error network. Simply connects error network to DUT network and adds the termination impedances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6256f193-ac9e-437a-b2b0-892abd50a820",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def measure(ntwk, Z, gammas, nports):\n",
+    "    out = skrf.terminate_nport(skrf.connect(Z, nports, ntwk, 0, num=nports), gammas)\n",
+    "    out.name = ntwk.name\n",
+    "    return out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e43b76c4-07d2-4778-b166-0669121030ed",
+   "metadata": {},
+   "source": [
+    "Next, create calibration standards. They should be multi-port networks. With real VNA measurement it might be necessary to manually combine two-port standard measurements to N-ports.\n",
+    "\n",
+    "The required standard are open, short and match on each port and thru measurement from the first port to all the other ports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50791a98-45f8-4645-b267-0ac92ba77c5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o = coax.open(nports=nports, name='open')\n",
+    "s = coax.short(nports=nports, name='short')\n",
+    "m = coax.match(nports=nports, name='load')\n",
+    "\n",
+    "thru = coax.thru(name='thru')\n",
+    "\n",
+    "ideals = []\n",
+    "# nports-1 thrus from port 0 to all other ports.\n",
+    "for i in range(1, nports):\n",
+    "    thru_i = skrf.twoport_to_nport(thru, 0, i, nports)\n",
+    "    ideals.append(thru_i)\n",
+    "\n",
+    "ideals.extend([o,s,m])\n",
+    "measured = [measure(k, Z, gammas, nports) for k in ideals]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d461dda7-6bac-412d-9ec3-ec72dbc0a3fe",
+   "metadata": {},
+   "source": [
+    "Device to test the calibration. A simple three-way junction. Because error network is randomly generated and have very high reflections, the plotted S-parameters of the uncalibrated network are unrecognizable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6d8da86-7c50-4e62-a388-3ce4ca859d94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dut = coax.tee(name='dut')\n",
+    "dut_meas = measure(dut, Z, gammas, nports)\n",
+    "dut_meas.plot_s_db()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae888d31-b231-4ee7-843a-cbcf22105f8d",
+   "metadata": {},
+   "source": [
+    "## Calibration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a348ead-25f6-496c-ab94-0e7d37261e6a",
+   "metadata": {},
+   "source": [
+    "Create `MultiportSOLT` calibration class. The first parameter is a two-port calibration method that the class uses for calibrating the multi-port. In this case we use simple SOLT calibration. Other possibilites are for example `UnknownThru` and `LRRM`. Note that different calibration algorithms might require standards to be given in specific order and might require additional inputs such as `switch_terms`. Refer to the two-port calibration documentation for the required inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a7b0c7a-a6fe-4081-bde3-6a2237ac3e4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal = skrf.MultiportSOLT(method=skrf.SOLT, measured=measured, ideals=ideals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95547c57-8974-4fee-b3c8-f4d2606137dc",
+   "metadata": {},
+   "source": [
+    "Calibrate the DUT and plot the calibrated S-parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c37d730d-ac70-4224-95e8-aa36d472bd8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dut_cal = cal.apply_cal(dut_meas)\n",
+    "dut_cal.plot_s_db()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "764c809a-c212-4ce7-8e67-8e2cd0472720",
+   "metadata": {},
+   "source": [
+    "The difference between corrected and original dut S-parameters should be small."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d46fb3d-bdae-41b1-b155-efaf800b3b65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.max(np.abs(dut_cal.s - dut.s))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f97e71e2-560b-480a-b012-c7f69cee9a95",
+   "metadata": {},
+   "source": [
+    "## MultiportCal\n",
+    "\n",
+    "The above `MultiportSOLT` class can only be used for SOLT style two-port calibrations that require only one transmissive standard between the two ports. Multi-port TRL requires thru and one or more lines between the ports which doesn't fit the above class interface. Also if for some reason different two-port calibration methods should be used for the port pairs the `MultiportSOLT` class is not able to do it. For those cases there is a lower level `MultiportCal`.\n",
+    "\n",
+    "This calibration requires dictionary of port pairs as input. 'method' key is the two-port calibration class and 'measured' are the measured networks. They can be either two-ports or N-ports. Other keys are passed to the two-port calibration routine. In this case we are using `UnknownThru` class which requires additional `switch_term` arguments. Note that two-port switch terms are in the reverse order from multi-port switch terms. Two-port switch terms are listed in the order of where the source is connected, but this is unspecified in case of multi-port switch terms and they are listed in the order of which port they terminate. It's also important to list the ideals and measured networks in the correct order required by the two-port calibration. `UnknownThru` assumes that thru should be listed last and order of the other standards doesn't matter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31f54189-c4ba-485f-a904-896d588f62c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ideals_01 = ideals[2:] + [ideals[0]]\n",
+    "ideals_02 = ideals[2:] + [ideals[1]]\n",
+    "meas_01 = measured[2:] + [measured[0]]\n",
+    "meas_02 = measured[2:] + [measured[1]]\n",
+    "\n",
+    "cal_dict = {(0, 1): {'method': skrf.UnknownThru, 'ideals': ideals_01, 'measured': meas_01, 'switch_terms':[gammas[1], gammas[0]]},\n",
+    "            (0, 2): {'method': skrf.UnknownThru, 'ideals': ideals_02, 'measured': meas_02, 'switch_terms':[gammas[2], gammas[0]]}}\n",
+    "\n",
+    "cal2 = skrf.MultiportCal(cal_dict)\n",
+    "\n",
+    "dut_cal2 = cal2.apply_cal(dut_meas)\n",
+    "dut_cal2.plot_s_db()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5322,8 +5322,7 @@ class MultiportCal():
 
 class MultiportSOLT(MultiportCal):
     """
-    Multi-port VNA calibration using two-port calibration method with one
-    transmissive standard for each two-port pair.
+    Multi-port VNA calibration using two-port calibration method with one transmissive standard for each two-port pair.
 
     `method` should be a two-port calibration method such as `EightTerm`,
     `UnknownThru` or `SOLT`. This class calibrates a multi-port network using

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -47,7 +47,16 @@ Two-port
    SixteenTerm
    LMR16
    Normalization
-   
+
+Multi-port
+--------
+
+.. autosummary::
+   :toctree: generated/
+
+   MultiportCal
+   MultiportSOLT
+
 Three Receiver (1.5 port)
 -------------------------
 
@@ -96,7 +105,8 @@ from ..networkSet import NetworkSet
 from .. import util
 from ..io.touchstone import read_zipped_touchstones
 from .. import __version__ as skrf__version__
-
+from collections import defaultdict
+from itertools import combinations
 
 global coefs_list_12term
 coefs_list_12term =[
@@ -4934,6 +4944,482 @@ class Normalization(Calibration):
     def apply_cal(self, input_ntwk):
         return input_ntwk/average(self.measured)
 
+class MultiportCal():
+    """
+    Multi-port VNA calibration using two-port calibration method.
+
+    cal_dict should be a dictionary with key being two-tuples of port numbers,
+    such as (0, 1), (0, 2), ...
+
+    For each key it should have another dictionary as value. The two required
+    keys are 'method' that should be the two-port calibration class that is used
+    to calibrate that two-port combination (for example SOLT, EightTerm, TRL)
+    and 'measured' which is a list of measured Networks. Other inputs required
+    by the two-port calibration should be given as additional keys (for example
+    'ideals', 'switch_terms', ...).
+
+    There should be one common port in all measurements. For example in case of
+    4-port calibration one possible choice would be to make three measurements
+    between ports: 0-1, 0-2, and 0-3.
+
+    The list of measured networks can be given as either two-ports, in which
+    case it's assumed that the two ports corresponds to the ports in the key, or
+    multi-ports in which case a subnetwork is taken for calibration according to
+    the key.
+
+    Example cal_dict for three port measurement:
+        {(0,1): {'method':SOLT, 'measured': [list of measured networks], 'ideals': [list of ideal networks]},
+         (0,2): {'method':SOLT, 'measured': [list of measured networks], 'ideals': [list of ideal networks]}
+        }
+
+    `isolation` is optional N-port network of all ports matched for isolation
+    calibration. If None, no isolation calibration is performed.
+
+    Parameters
+    --------------
+    cal_dict : dictionary
+        Dictionary of port pair keys as specified above.
+    isolation: :class:`~skrf.network.Network` or None
+        N-port measurement of all matched ports for isolation calibration.
+        None to skip isolation calibration.
+
+    See Also
+    --------
+    calibration.MultiportSOLT
+    """
+
+    family = 'Multiport'
+    def __init__(self, cal_dict, isolation=None, *args, **kwargs):
+        if type(cal_dict) != dict:
+            raise ValueError("cal_dict not dictionary.")
+        nports = None
+        max_key_nports = 0
+        min_key_nports = float('inf')
+        z0 = None
+        frequency = None
+        for k, c in cal_dict.items():
+            if len(k) != 2:
+                raise ValueError("Invalid cal_dict key {}. Expected tuple of length two.".format(k))
+            if type(k[0]) != int or type(k[1]) != int:
+                raise ValueError("cal_dict key should be tuple of ints.")
+            max_key_nports = max(max_key_nports, max(k[0], k[1]))
+            min_key_nports = min(min_key_nports, min(k[0], k[1]))
+            if type(c) != dict:
+                raise ValueError("cal_dict[{}] not dictionary.".format(k))
+            if 'method' not in c:
+                raise ValueError("cal_dict[{}] missing key 'method'.".format(k))
+            if 'measured' not in c:
+                raise ValueError("cal_dict[{}] missing key 'measured'.".format(k))
+            for m in c['measured']:
+                if type(m) != Network:
+                    raise ValueError("Expected Network in cal_dict[{}]['measured']".format(k))
+                if nports is None:
+                    nports = m.nports
+                if m.nports not in [2, nports]:
+                    raise ValueError("Measurement have inconsistent number of ports.")
+                if z0 is None:
+                    z0 = m.z0[0,0]
+                elif m.z0[0,0] != z0:
+                    raise ValueError("Inconsistent z0 in measured.")
+                if frequency is None:
+                    frequency = m.frequency
+                elif m.frequency != frequency:
+                    raise ValueError("Inconsistent frequency in measured.")
+        self.nports = max_key_nports + 1
+        if min_key_nports < 0:
+            raise ValueError("Negative port number found. Minimum should be zero.")
+        if min_key_nports != 0:
+            raise ValueError("Missing port 0. Make sure that ports are zero-indexed.")
+        if max_key_nports < 2:
+            raise ValueError("Less than three ports found. Use two-port or one-port calibration directly.")
+
+        if isolation is not None:
+            # Zero diagonal so that network can be simply subtracted
+            isolation = isolation.copy()
+            for i in range(nports):
+                isolation.s[:,i,i] = 0
+        else:
+            s = npy.zeros((len(frequency), nports, nports), dtype=complex)
+            isolation = Network(s=s, z0=z0, frequency=frequency)
+        self.isolation = isolation
+        self.cal_dict = cal_dict
+        self.z0 = z0
+        self.frequency = frequency
+        self.cals = {}
+
+    def run(self):
+        nports = self.nports
+        p_count = defaultdict(int)
+        self.terminations = [None for i in range(nports)]
+        self._coefs = [{} for i in range(nports)]
+        for p in self.cal_dict.keys():
+            p_count[p[0]] += 1
+            p_count[p[1]] += 1
+        port_multiples = sorted(p_count.values())
+        if port_multiples[-2] != 1:
+            # It's easy to put `k` in non-repeated ports if one port is always used.
+            # I think this limitation could be removed if the `k` would be
+            # solved to be consistent in repeated ports.
+            raise ValueError("Invalid thru port combinations. One port should be common in all thru measurements.")
+        for e, p in enumerate(self.cal_dict.keys()):
+            c = self.cal_dict[p].copy()
+            if 'ideals' in c:
+                ideals = [i if i.nports == 2 else subnetwork(i, p) for i in c['ideals']]
+                c['ideals'] = ideals
+            c['measured'] = [m - subnetwork(self.isolation, p) if m.nports == 2 else subnetwork(m - self.isolation, p) for m in c['measured']]
+            k_side = 0
+            if p_count[p[0]] > p_count[p[1]]:
+                k_side = 1
+            method = c.pop('method')
+            self.run_2port(method, p, k_side, **c)
+
+    def run_2port(self, method, p, k_side, **kwargs):
+        cal = method(**kwargs)
+        cal.run()
+        self.cals[p] = cal
+
+        coefs = cal.coefs_8term
+        S1, S2 = self.coefs_to_ntwks(coefs, k_side=k_side)
+        one = npy.ones(coefs['k'].shape, dtype=complex)
+        for c in cal.coefs_8term:
+            if 'forward' in c:
+                c2 = c.replace('forward ', '')
+                if 'switch term' in c:
+                    self._coefs[p[1]][c2] = coefs[c]
+                else:
+                    self._coefs[p[0]][c2] = coefs[c]
+            elif 'reverse' in c:
+                c2 = c.replace('reverse ', '')
+                if 'switch term' in c:
+                    self._coefs[p[0]][c2] = coefs[c]
+                else:
+                    self._coefs[p[1]][c2] = coefs[c]
+            elif c == 'k':
+                self._coefs[p[k_side]][c] = coefs[c]
+                if 'k' not in self._coefs[p[not k_side]].keys():
+                    self._coefs[p[not k_side]][c] = one
+            else:
+                warn('Unknown coefficient in calibration {}'.format(c))
+
+        term1 = self.dut_termination(S1, coefs['reverse switch term'])
+        term2 = self.dut_termination(S2, coefs['forward switch term'])
+        f = self.frequency
+        self.terminations[p[0]] = Network(s=term1, z0=self.z0, frequency=f)
+        self.terminations[p[1]] = Network(s=term2, z0=self.z0, frequency=f)
+
+    @property
+    def coefs(self):
+        try:
+            return self._coefs
+        except(AttributeError):
+            self.run()
+            return self._coefs
+
+    @coefs.setter
+    def coefs(self, d):
+        self._coefs = d
+
+    def unterminate_2port(self, ntwk, p1, p2):
+        """
+        Unterminates switch terms from a raw measurement.
+
+        See Also
+        --------
+        calibration.unterminate
+        """
+        gamma_f = Network(s=self.coefs[p2]['switch term'])
+        gamma_r = Network(s=self.coefs[p1]['switch term'])
+        return unterminate(ntwk, gamma_f, gamma_r)
+
+    def terminate_2port(self, ntwk, p1, p2):
+        """
+        Terminate a network with switch terms.
+
+        See Also
+        --------
+        calibration.terminate
+        """
+        gamma_f = self.coefs[p2]['switch term']
+        gamma_r = self.coefs[p1]['switch term']
+        return terminate(ntwk, gamma_f, gamma_r)
+
+    def T_matrices(self, p1, p2):
+        """
+        Intermediate matrices used for embedding and de-embedding.
+
+        Returns
+        -------
+        T1,T2,T3,T4 : numpy ndarray
+
+        """
+        npoints = len(self.coefs[0]['k'])
+        one = npy.ones(npoints, dtype=complex)
+        zero = npy.zeros(npoints, dtype=complex)
+
+        Edf = self.coefs[p1]['directivity']
+        Esf = self.coefs[p1]['source match']
+        Erf = self.coefs[p1]['reflection tracking']
+        Edr = self.coefs[p2]['directivity']
+        Esr = self.coefs[p2]['source match']
+        Err = self.coefs[p2]['reflection tracking']
+        k1 = self.coefs[p1]['k']
+        k2 = self.coefs[p2]['k']
+
+        detX = Edf*Esf-Erf
+        detY = Edr*Esr-Err
+
+        T1 = npy.array([
+                [ -k1*detX, zero    ],
+                [ zero,  -k2*detY ]
+                ]).transpose(2,0,1)
+        T2 = npy.array([
+                [ k1*Edf,    zero ],
+                [ zero,  k2*Edr ]
+                ]).transpose(2,0,1)
+        T3 = npy.array([
+                [ -k1*Esf,   zero ],
+                [ zero, -k2*Esr ]
+                ]).transpose(2,0,1)
+        T4 = npy.array([
+                [ k1, zero ],
+                [ zero, k2   ]
+                ]).transpose(2,0,1)
+
+        return T1, T2, T3, T4
+
+    def apply_cal(self, ntwk):
+        # Need to copy original to not modify the original after subtracting the
+        # isolation.
+        ntwk = ntwk.copy()
+        ntwk = ntwk - self.isolation
+        caled = ntwk.copy()
+        # Use traveling definition since it can renormalize to negative real part impedance.
+        s_def = caled.s_def
+        caled.s_def = 'traveling'
+
+        fpoints = len(ntwk.frequency)
+        ports = npy.arange(self.nports)
+        port_combos = list(combinations(ports, 2))
+        for p in port_combos:
+            T1, T2, T3, T4 = self.T_matrices(p[0], p[1])
+
+            caled_2p = subnetwork(ntwk, p).copy()
+            caled_2p.s_def = 'traveling'
+
+            caled_2p = self.unterminate_2port(caled_2p, p[0], p[1])
+            caled_2p.s = linalg.inv(-caled_2p.s @ T3 + T1) @ (caled_2p.s @ T4 - T2)
+            z = npy.zeros((fpoints, 2), dtype=complex)
+            z[:,0] = self.terminations[p[0]].z[:,0,0]
+            z[:,1] = self.terminations[p[1]].z[:,0,0]
+            caled_2p.renormalize(z)
+            for ei, i in enumerate(p):
+                for ej, j in enumerate(p):
+                    caled.s[:, i, j] = caled_2p.s[:, ei, ej]
+
+        for i in range(self.nports):
+            caled.z0[:,i] = self.terminations[i].z[:,0,0]
+        caled.renormalize(ntwk.z0, s_def=s_def)
+
+        return caled
+
+    def embed(self, ntwk):
+        fpoints = len(self.coefs[0]['k'])
+        nports = self.nports
+        nout = ntwk.copy()
+
+        Z = npy.zeros((fpoints, 2*nports, 2*nports), dtype=complex)
+
+        gammas = []
+        for e, c in enumerate(self.coefs):
+            gammas.append(Network(s=c['switch term'], frequency=nout.frequency, z0=50))
+            Z[:, e, e] = c['directivity']
+            Z[:, nports+e, nports+e] = c['source match']
+            Z[:, e, nports+e] = c['reflection tracking'] * c['k'] / self.coefs[0]['k']
+            Z[:, nports+e, e] = self.coefs[0]['k'] / c['k']
+
+        # Consistent internal port Z0.
+        nout.z0 = 50
+        Z = Network(s=Z, frequency=nout.frequency, z0=50)
+        nout = connect(Z, nports, nout, 0, nports)
+        nout = terminate_nport(nout, gammas)
+        nout += self.isolation
+        nout.z0 = ntwk.z0
+        return nout
+
+    def coefs_to_ntwks(self, coefs, k_side=0):
+        npoints = len(coefs['k'])
+        one = npy.ones(npoints, dtype=complex)
+
+        Edf = coefs['forward directivity']
+        Esf = coefs['forward source match']
+        Erf = coefs['forward reflection tracking']
+        Edr = coefs['reverse directivity']
+        Esr = coefs['reverse source match']
+        Err = coefs['reverse reflection tracking']
+        k = coefs['k']
+
+        if k_side == 0:
+            S1 = npy.array([
+                    [ Edf,  Erf/k ],
+                    [ k,    Esf ]
+                    ]).transpose(2,0,1)
+
+            S2 = npy.array([
+                    [ Edr,  one ],
+                    [ Err,  Esr ]
+                    ]).transpose(2,0,1)
+        elif k_side == 1:
+            S1 = npy.array([
+                    [ Edf,  Erf ],
+                    [ one,    Esf ]
+                    ]).transpose(2,0,1)
+
+            S2 = npy.array([
+                    [ Edr,  one/k ],
+                    [ Err*k,  Esr ]
+                    ]).transpose(2,0,1)
+        else:
+            raise ValueError("Invalid k_side {}, expected 0 or 1.".format(k_side))
+        return (S1, S2)
+
+    def dut_termination(self, S, gamma):
+        """Impedance looking from DUT to VNA terminated with switch term."""
+        term = S[:,1,1] + (S[:,0,1] * S[:,1,0] * gamma) / (1 - S[:,0,0] * gamma)
+        return term
+
+class MultiportSOLT(MultiportCal):
+    """
+    Multi-port VNA calibration using two-port calibration method with one
+    transmissive standard for each two-port pair.
+
+    `method` should be a two-port calibration method such as `EightTerm`,
+    `UnknownThru` or `SOLT`. This class calibrates a multi-port network using
+    the given two-port calibration method.
+
+    There should be `Nports - 1` thru standards and the number of other
+    standards depending on the number of standards required by the chosen
+    calibration method. Standards should be always given thrus first. Thru
+    standards are used to find the port connections during the calibration and
+    all standards should be N-ports.
+
+    There should be one common port in all thru measurements. For
+    example in case of 4-port calibration one possible choice would be to make
+    three thru measurements between ports: 0-1, 0-2, and 0-3.
+
+    If isolation calibration is used it should be not passed as an argument to
+    the two-port calibration and N-port isolation measurement should be instead
+    given as an argument for this class.
+
+    `switch_terms` should be a list of switch terms with nth entry being the
+    switch term an/bn with source from any other port. Note that in case of
+    two-port this is the reversed order than what two-port calibration would
+    require. If calibration is a 12-term calibration such as `SOLT` or
+    `TwelveTerm` no switch terms are required.
+
+    `thru_pos` argument can be used to change the order of thru given to the
+    calibration method. `auto` will try to determine it automatically from the
+    calibration method. Other options are `first` and `last`. Other standards
+    are given in the same order they are given to this class.
+
+    `cal_args` can be used to give addition arguments to the calibration method.
+    If no arguments are given it should be None, otherwise a dictionary of
+    arguments and values.
+
+    See Also
+    --------
+    calibration.MultiportCal
+        Lower level multi-port calibration class. This needs to be used for TRL
+        calibration as it has also lines between ports which doesn't fit the
+        interface of this class.
+    """
+
+    family = 'Multiport'
+    def __init__(self, method, measured, ideals, isolation=None, switch_terms=None, thru_pos='auto', cal_args=None, *args, **kwargs):
+        self.ideals = ideals
+        self.measured = measured
+        self.nports = ideals[0].nports
+        nports = self.nports
+        if nports < 3:
+            raise ValueError("Too few ports in input networks. At least 3 required.")
+
+        self.switch_terms = switch_terms
+
+        if thru_pos == 'auto':
+            if method in [LRM, LRRM]:
+                thru_pos = 'first'
+            elif method in [SOLT, EightTerm, UnknownThru, MRC, TwelveTerm]:
+                thru_pos = 'last'
+            else:
+                raise ValueError("Unable to determine 'thru_pos' automatically. Set it manually to either 'first' or 'last'")
+        if thru_pos not in ['last', 'first']:
+            raise ValueError("thru_pos must be either 'first' or 'last'")
+
+        if cal_args is None:
+            cal_args = {}
+
+        for i in ideals:
+            if i.nports != self.nports:
+                raise ValueError("Inconsistent number of ports in ideals.")
+
+        if not issubclass(method, Calibration):
+            raise ValueError("method must be Calibration subclass.")
+        if issubclass(method, SixteenTerm):
+            warn("SixteenTerm calibration is reduced to 8-terms.")
+
+        if isolation is None:
+            isolation = ideals[-1].copy()
+            for i in range(nports):
+                for j in range(nports):
+                    isolation.s[:,i,j] = 0
+        else:
+            # Zero diagonal so that network can be simply subtracted
+            isolation = isolation.copy()
+            for i in range(nports):
+                isolation.s[:,i,i] = 0
+
+        if len(ideals) < nports - 1:
+            raise ValueError("Invalid number of ideals. Expected at least {} but got {}.".format(nports-1, len(ideals)))
+
+        self.thru_ports = []
+        for thru in ideals[:nports-1]:
+            nonzero = []
+            for i in range(nports):
+                for j in range(i+1, nports):
+                    if thru.s[-1, i, j] != 0:
+                        nonzero.append([i, j])
+            if len(nonzero) != 1:
+                raise ValueError("Invalid thru ideal. Thru should connect exactly two ports.")
+
+            self.thru_ports.append(tuple(nonzero[0]))
+
+        #Generate cal_dict in the format required by MultiportCal.
+        nports = self.nports
+        nthrus = nports - 1
+        cal_dict = {}
+        for e, p in enumerate(self.thru_ports):
+            ideals = [subnetwork(self.ideals[e], p)]
+            ideals_sol = [subnetwork(i, p) for i in self.ideals[nthrus:]]
+            ideals.extend(ideals_sol)
+            measured = [subnetwork(self.measured[e], p)]
+            measured_sol = [subnetwork(i, p) for i in self.measured[nthrus:]]
+            measured.extend(measured_sol)
+            if self.switch_terms is None:
+                sw_terms = None
+            else:
+                sw_terms = [self.switch_terms[i] for i in p][::-1]
+            if thru_pos == 'last':
+                ideals = ideals[1:] + [ideals[0]]
+                measured = measured[1:] + [measured[0]]
+            cal_dict[p] = {}
+            cal_dict[p]['method'] = method
+            cal_dict[p]['ideals'] = ideals
+            cal_dict[p]['measured'] = measured
+            if sw_terms is not None:
+                cal_dict[p]['switch_terms'] = sw_terms
+            for k, v in cal_args.items():
+                cal_dict[p][k] = v
+
+        super().__init__(cal_dict=cal_dict, isolation=isolation)
 
 ## Functions
 
@@ -5072,6 +5558,64 @@ def terminate(ntwk, gamma_f, gamma_r):
     m.s[:,1,0] = ntwk.s[:,1,0]/(1-ntwk.s[:,1,1]*gamma_f.s[:,0,0])
     m.s[:,0,1] = ntwk.s[:,0,1]/(1-ntwk.s[:,0,0]*gamma_r.s[:,0,0])
     return m
+
+def terminate_nport(ntwk, gammas):
+    """
+    Terminate N-port network with switch terms.
+
+    Note that for 2-port the order `gammas` is opposite of terminate.
+    Correct order for 2-port is [gamma_r, gamma_f].
+
+    See [1]_
+
+
+    Parameters
+    ----------
+    two_port : Network
+        an unterminated network.
+    gammas : list of 1-port Network
+        measured switch term.
+        gammas[i] = ai/bi sourced by any other port.
+
+    Returns
+    -------
+    ntwk :  Network object
+
+    See Also
+    --------
+    terminate
+
+    References
+    ----------
+
+    .. [1] "Formulations of the Basic Vector Network Analyzer Error
+            Model including Switch Terms" by Roger B. Marks
+    """
+    nin = ntwk.copy()
+    # Assign fixed z0 for connections for inner ports.
+    nin.z0 = 50
+    nout = ntwk.copy()
+    nports = ntwk.nports
+    fpoints = len(ntwk.frequency)
+    if len(gammas) != ntwk.nports:
+        raise ValueError("len(gammas) doesn't match the number of network ports")
+    zeros = npy.zeros(len(ntwk.s))
+    ones = npy.ones(len(ntwk.s))
+    for i in range(nports):
+        term = npy.zeros((fpoints, 2*nports, 2*nports), dtype=complex)
+        for j in range(nports):
+            if i == j:
+                term[:,nports+j,j] = ones
+                term[:,j,j+nports] = ones
+                continue
+            term[:,j,j] = gammas[j].s[:,0,0]
+            term[:,nports+j,j] = ones
+        net = Network(s=term, frequency=nin.frequency, z0=50)
+        net = connect(nin, 0, net, 0, nports)
+        for j in range(nports):
+            nout.s[:,j,i] = net.s[:,j,i]
+    nout.z0 = ntwk.z0
+    return nout
 
 def determine_line(thru_m, line_m, line_approx=None):
     r"""

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -7264,3 +7264,35 @@ def s2vswr_active(s: npy.ndarray, a: npy.ndarray) -> npy.ndarray:
     vswr_act = npy.einsum('fp,fp->fp', (1 + npy.abs(s_act)), npy.reciprocal(1 - npy.abs(s_act)))
     return vswr_act
 
+def twoport_to_nport(ntwk, port1, port2, nports, **kwargs):
+    r"""
+    Add ports to two-port. S-parameters of added ports are all zeros.
+
+    Parameters
+    ----------
+    ntwk : Two-port Network object
+    port1: int
+        First port of the two-port in the resulting N-port.
+    port2: int
+        Second port of the two-port in the resulting N-port.
+    nports: int
+        Number of ports in the N-port network.
+    \*\*kwargs:
+        Passed to :func:`Network.__init__` for resultant network.
+
+    Returns
+    -------
+    nport: N-port Network object
+    """
+    fpoints = len(ntwk.frequency)
+    nport = Network(frequency=ntwk.frequency,
+                    s=npy.zeros(shape=(fpoints, nports, nports)),
+                    name=ntwk.name,
+                    **kwargs)
+    nport.s[:,port1,port1] = ntwk.s[:,0,0]
+    nport.s[:,port2,port1] = ntwk.s[:,1,0]
+    nport.s[:,port1,port2] = ntwk.s[:,0,1]
+    nport.s[:,port2,port2] = ntwk.s[:,1,1]
+    nport.z0[:,port1] = ntwk.z0[:,0]
+    nport.z0[:,port2] = ntwk.z0[:,1]
+    return nport

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1459,6 +1459,21 @@ class NetworkTestCase(unittest.TestCase):
         # vswr_act should be equal to vswr22 if a = [0,1]
         npy.testing.assert_array_almost_equal(self.ntwk1.vswr_active([0, 1])[:,1], vswr_ref[:,1,1])
 
+    def test_twport_to_nport(self):
+        fpoints = 2
+        nports = 4
+        s = npy.ones((fpoints, 2, 2), dtype=complex)
+        f = rf.F(1, 10, fpoints, unit='GHz')
+        twoport = rf.Network(s=s, frequency=f)
+        nport = rf.twoport_to_nport(twoport, 0, 1, nports)
+        zeros = npy.zeros(fpoints, dtype=complex)
+        for i in range(nports):
+            for j in range(nports):
+                if i in [0, 1] and j in [0, 1]:
+                    npy.testing.assert_array_almost_equal(nport.s[:,i,j], twoport.s[:,i,j])
+                else:
+                    npy.testing.assert_array_almost_equal(nport.s[:,i,j], zeros)
+
 
     def test_generate_subnetworks_nportsbelow10(self):
         """


### PR DESCRIPTION
Adds code for calibrating multi-port S-parameter measurements using any two-port calibration method. Internally it works very similarly to [measuring multi-port network with two-port VNA example](https://scikit-rf.readthedocs.io/en/latest/examples/metrology/Measuring%20a%20Mutiport%20Device%20with%20a%202-Port%20Network%20Analyzer.html).