### PR TITLE
Fix Python 3.7 flake8

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions flake8
+        pip install .[test] tox-gh-actions
 
     # code quality check (linting)
     - name: Lint with flake8

--- a/.github/workflows/testing_notebooks.yml
+++ b/.github/workflows/testing_notebooks.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions flake8
+        pip install .[test] tox-gh-actions
 
     # test code *and* notebooks (tutorials and examples)
     - name: Test the code, tutorials and examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "tox >= 3.26.0",
     "pytest ~=7.0",
     "coverage ~=6.0",
     "flake8 ~=5.0",


### PR DESCRIPTION
Recent versions of Tox require recent version of importlib_metadata but flake8 needs older version of it. Add tox to list of dependencies so that pip can find versions that work together. Fixes #819.