### PR TITLE
Fix get_sparameter_names order for two-port

### DIFF
--- a/skrf/io/tests/test_touchstone.py
+++ b/skrf/io/tests/test_touchstone.py
@@ -139,6 +139,12 @@ class TouchstoneTestCase(unittest.TestCase):
                     msg='Field %s does not match. Expected "%s", got "%s"'%(
                         k, str(expected_sp_db[k]), str(sp_db[k]))  )
 
+        for k, v in zip(touch.get_sparameter_names(), touch.sparameters.T):
+            if k[0] != 'S':
+                # frequency doesn't match because of Hz vs GHz.
+                continue
+            self.assertTrue(npy.all(expected_sp_ri[k] == v))
+
 
     def test_HFSS_touchstone_files(self):
         """

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -398,10 +398,16 @@ class Touchstone:
         if format == 'orig':
             format = self.format
         ext1, ext2 = {'ri':('R','I'),'ma':('M','A'), 'db':('DB','A')}.get(format)
+        file_name_ending = self.filename.split('.')[-1].lower()
         for r1 in range(self.rank):
             for r2 in range(self.rank):
-                names.append("S%i%i%s"%(r1+1,r2+1,ext1))
-                names.append("S%i%i%s"%(r1+1,r2+1,ext2))
+                # Transpose Touchstone V1 2-port files (.2p), as the order is (11) (21) (12) (22)
+                if self.rank == 2 and file_name_ending == "s2p":
+                    names.append(f"S{r2+1}{r1+1}{ext1}")
+                    names.append(f"S{r2+1}{r1+1}{ext2}")
+                else:
+                    names.append(f"S{r1+1}{r2+1}{ext1}")
+                    names.append(f"S{r1+1}{r2+1}{ext2}")
         return names
 
     def get_sparameter_data(self, format='ri'):
@@ -456,14 +462,6 @@ class Touchstone:
 
         for i,n in enumerate(self.get_sparameter_names(format=format)):
             ret[n] = values[:,i]
-
-        # transpose Touchstone V1 2-port files (.2p), as the order is (11) (21) (12) (22)
-        file_name_ending = self.filename.split('.')[-1].lower()
-        if self.rank == 2 and file_name_ending == "s2p":
-            swaps = [ k for k in ret if '21' in k]
-            for s in swaps:
-                true_s = s.replace('21', '12')
-                ret[s], ret[true_s] = ret[true_s], ret[s]
 
         return ret
 


### PR DESCRIPTION
Reported in #821. Move transpose for two-port S-parameters from `get_sparameter_data` to `get_sparameter_names`.