### PR TITLE
Improve performance of Network.copy

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -343,6 +343,8 @@ class Network:
     Default interpolation method.
     """
 
+    _secondary_properties_generated = False
+
     # CONSTRUCTOR
     def __init__(self, file: str = None, name: str = None, params: dict = None,
                  comments: str = None, f_unit: str = None,
@@ -410,7 +412,6 @@ class Network:
         write : write a network to a file, using pickle
         write_touchstone : write a network to a touchstone file
         """
-
         # allow for old kwarg for backward compatibility
         if 'touchstone_filename' in kwargs:
             file = kwargs['touchstone_filename']
@@ -920,32 +921,36 @@ class Network:
         if other.s.shape != self.s.shape:
             raise IndexError('Networks must have same number of ports.')
 
-    def __generate_secondary_properties(self) -> None:
+    @classmethod
+    def __generate_secondary_properties(cls) -> None:
         """
         creates numerous `secondary properties` which are various
         different scalar projects of the primary properties. the primary
         properties are s,z, and y.
+
+        The properties are set on the class, so this method only needs to be called once
         """
+        if cls._secondary_properties_generated:
+            return
         for prop_name in PRIMARY_PROPERTIES:
-            for func_name in COMPONENT_FUNC_DICT:
-                func = COMPONENT_FUNC_DICT[func_name]
+            for func_name, func in COMPONENT_FUNC_DICT.items():
                 if 'gd' in func_name:  # scaling of gradient by frequency
                     def fget(self: 'Network', f: Callable = func, p: str = prop_name) -> npy.ndarray:
                         return f(getattr(self, p)) / (2 * npy.pi * self.frequency.step)
                 else:
                     def fget(self: 'Network', f: Callable = func, p: str = prop_name) -> npy.ndarray:
                         return f(getattr(self, p))
-                doc = """
-                The {} component of the {}-matrix
+                doc = f"""
+                The {func_name} component of the {prop_name}-matrix
 
 
                 See Also
                 --------
-                {}
-                """.format(func_name, prop_name, prop_name)
+                {prop_name}
+                """
 
-                setattr(self.__class__, f'{prop_name}_{func_name}', \
-                        property(fget, doc=doc))
+                setattr(cls, f'{prop_name}_{func_name}', property(fget, doc=doc))
+        cls._secondary_properties_generated = True
 
     def __generate_subnetworks(self) -> None:
         """


### PR DESCRIPTION
In a copy of a `Network` new `s` parameters are assigned. This triggers a call to `__generate_secondary_properties` which is not required as `__generate_secondary_properties` depends only on class properties, not on instance properties (or the values of the s parameters)

On this data
```
import numpy as np
import skrf as rf

f = rf.Frequency.from_f(np.linspace(2e6, 3e6, 10), unit="Hz")
self=n=rf.Network(frequency=f, s=np.random.rand(10,)*1j, name='test')
``` 
a benchmark `%timeit n.copy()` is improved by:
```
Master: 1.06 ms ± 143 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
PR: 217 µs ± 32.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
