### PR TITLE
Dynamically load version from __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scikit-rf"
-version = "0.24.1"
+dynamic = "version"
 description = "Object Oriented Microwave Engineering"
 requires-python = ">=3.7"
 authors = [
@@ -96,6 +96,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 license-files = ["LICENSE.txt"]
+
+[tool.setuptools.dynamic]
+version = {attr = "skrf.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["skrf*", "skrf_qtapps*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scikit-rf"
-dynamic = "version"
+dynamic = ["version"]
 description = "Object Oriented Microwave Engineering"
 requires-python = ">=3.7"
 authors = [


### PR DESCRIPTION
Changes `pyproject.toml` so it dynamically loads the version number for a build from `skrf/__init__.py`. That way, the version number only has to be defined once (in `__init__.py`).

https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html