### PR TITLE
version 25.0

### DIFF
--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python. 
 """
 
-__version__ = '0.24.1'
+__version__ = '0.25.0'
 ## Import all  module names for coherent reference of name-space
 #import io
 


### PR DESCRIPTION
## What's Changed
* Remove unneeded print by @FranzForstmayr in https://github.com/scikit-rf/scikit-rf/pull/801
* Use fft_window when specified and not window by @FranzForstmayr in https://github.com/scikit-rf/scikit-rf/pull/802
* Misc fixes by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/808
* Fix Python 3.7 flake8 by @Ttl in https://github.com/scikit-rf/scikit-rf/pull/820
* Multi-port calibration by @Ttl in https://github.com/scikit-rf/scikit-rf/pull/818
* Fix get_sparameter_names order for two-port by @Ttl in https://github.com/scikit-rf/scikit-rf/pull/822
* Adding parameter `draw_labels` to `plot_smith()`. by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/826
* Improve error message in NIST TRL calibration by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/827
* Fix inductor units in media docstrings by @ericwrice in https://github.com/scikit-rf/scikit-rf/pull/835
* Add name argument to two_port_reflect by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/829
* Fix shade_bands overwriting y_range (#742) by @ericwrice in https://github.com/scikit-rf/scikit-rf/pull/838
* Small cleanup in calibration methods by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/836
* Dynamically load version from __init__.py by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/837
* Improve performance of Network.copy by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/828
* Fix NetworkSet division by @cafeclimber in https://github.com/scikit-rf/scikit-rf/pull/843
* Add test for input networks of OnePort calibration by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/844
* Increasing rtol for sweep type tests by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/847
* Vector Fitting: Custom pole initialization by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/845
* Vector Fitting: Tests by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/850
* Overlap dut and dummy networks in deembedding by @ericwrice in https://github.com/scikit-rf/scikit-rf/pull/834

## New Contributors
* @eendebakpt made their first contribution in https://github.com/scikit-rf/scikit-rf/pull/808
* @ericwrice made their first contribution in https://github.com/scikit-rf/scikit-rf/pull/835

**Full Changelog**: https://github.com/scikit-rf/scikit-rf/compare/v0.24.1...v0.25.0