### PR TITLE
Add test for input networks of OnePort calibration

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1041,6 +1041,11 @@ class OnePort(Calibration):
         mList = [self.measured[k].s.reshape((-1,1)) for k in range(numStds)]
         iList = [self.ideals[k].s.reshape((-1,1)) for k in range(numStds)]
 
+        if not all([n.number_of_ports==1 for n in self.ideals]):
+            raise RuntimeError('ideals for {self.family} should be 1-port Networks')
+        if not all([n.number_of_ports==1 for n in self.measured]):
+            raise RuntimeError('measured networks for {self.family} should be 1-port Networks')
+
         # ASSERT: mList and aList are now kx1x1 matrices, where k in frequency
         fLength = len(mList[0])
 

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1042,9 +1042,9 @@ class OnePort(Calibration):
         iList = [self.ideals[k].s.reshape((-1,1)) for k in range(numStds)]
 
         if not all([n.number_of_ports==1 for n in self.ideals]):
-            raise RuntimeError('ideals for {self.family} should be 1-port Networks')
+            raise RuntimeError(f'ideals for {self.family} should be 1-port Networks')
         if not all([n.number_of_ports==1 for n in self.measured]):
-            raise RuntimeError('measured networks for {self.family} should be 1-port Networks')
+            raise RuntimeError(f'measured networks for {self.family} should be 1-port Networks')
 
         # ASSERT: mList and aList are now kx1x1 matrices, where k in frequency
         fLength = len(mList[0])

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -146,6 +146,23 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
             measured = measured,
             )
         
+    def test_input_networks_1port(self):
+        # test users do not enter 2-port networks by accident
+        with self.assertRaises(Exception):
+            wg = self.wg
+            ideals = [
+                    two_port_reflect(wg.short( name='short'), wg.short( name='short')),
+                    wg.delay_short( 45.,'deg',name='ew'),
+                    wg.delay_short( 90.,'deg',name='qw'),
+                    wg.match( name='load'),
+                    ]
+            measured = [self.measure(k) for k in ideals]
+            rf.OnePort(
+               is_reciprocal = True, 
+               ideals = ideals, 
+               measured = measured,
+               )
+
     def measure(self, ntwk):
         out = self.E**ntwk
         out.name = ntwk.name

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -148,7 +148,7 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
         
     def test_input_networks_1port(self):
         # test users do not enter 2-port networks by accident
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             wg = self.wg
             ideals = [
                     two_port_reflect(wg.short( name='short'), wg.short( name='short')),
@@ -157,11 +157,12 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
                     wg.match( name='load'),
                     ]
             measured = [self.measure(k) for k in ideals]
-            rf.OnePort(
+            cal = rf.OnePort(
                is_reciprocal = True, 
                ideals = ideals, 
                measured = measured,
                )
+            cal.run()
 
     def measure(self, ntwk):
         out = self.E**ntwk


### PR DESCRIPTION
If for a `OnePort` calibration by accident the standards are entered as `[two_port_reflect(short, short), two_port_reflect(open, open), two_port_reflect(load, load)]` the calibration succeeds, but it cannot be applied (error: `LinAlgError: Singular matrix`).
Also expressions like `calibration.coefs_ntwks['reflection tracking'].plot_s_db()` fail. 

This PR adds a check on the input networks and a test.