### PR TITLE
Vector Fitting: Custom pole initialization

### DIFF
--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -11,10 +11,6 @@ import warnings
 
 class VectorFittingTestCase(unittest.TestCase):
 
-    msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider running ' \
-                              '`passivity_enforce()` to enforce passivity before using this model.'
-
-    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_with_proportional(self):
         # perform the fit
         nw = skrf.data.ring_slot
@@ -22,7 +18,6 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
-    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_default_log(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
@@ -30,21 +25,14 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    @pytest.mark.filterwarnings(f'ignore:*passivity_enforce()*:UserWarning')
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
-        self.assertLess(vf.get_rms_error(), 0.01)
+        with pytest.warns(UserWarning, match="The fitted network is passive, but the vector fit is not passive") as record:
+            vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
 
-    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
-    def test_ringslot_custompoles(self):
-        # perform the fit with custom initial poles
-        nw = skrf.data.ring_slot
-        vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.poles = 2 * np.pi * np.array([-100e9, -10e9 + 100e9j])
-        vf.vector_fit(init_pole_spacing='custom')
+        assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -24,7 +24,7 @@ class VectorFittingTestCase(unittest.TestCase):
         with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
             vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
 
-        assert len(record) == 1
+        assert len(record) <= 1
         self.assertLess(vf.get_rms_error(), 0.02)
 
     def test_ringslot_default_log(self):
@@ -36,7 +36,7 @@ class VectorFittingTestCase(unittest.TestCase):
         with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
             vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
 
-        assert len(record) == 1
+        assert len(record) <= 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_ringslot_without_prop_const(self):
@@ -48,7 +48,7 @@ class VectorFittingTestCase(unittest.TestCase):
         with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
             vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
 
-        assert len(record) == 1
+        assert len(record) <= 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_ringslot_custompoles(self):
@@ -61,7 +61,7 @@ class VectorFittingTestCase(unittest.TestCase):
         with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
             vf.vector_fit(init_pole_spacing='custom')
 
-        assert len(record) == 1
+        assert len(record) <= 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -35,6 +35,14 @@ class VectorFittingTestCase(unittest.TestCase):
         assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
+    def test_ringslot_custompoles(self):
+        # perform the fit with custom initial poles
+        nw = skrf.data.ring_slot
+        vf = skrf.vectorFitting.VectorFitting(nw)
+        vf.poles = 2 * np.pi * np.array([-100e9, -10e9+100e9j])
+        vf.vector_fit(init_pole_spacing='custom')
+        self.assertLess(vf.get_rms_error(), 0.01)
+
     def test_190ghz_measured(self):
         # perform the fit without proportional term
         nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -14,7 +14,7 @@ class VectorFittingTestCase(unittest.TestCase):
     msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider running ' \
                               '`passivity_enforce()` to enforce passivity before using this model.'
 
-    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
+    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_with_proportional(self):
         # perform the fit
         nw = skrf.data.ring_slot
@@ -22,7 +22,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
-    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
+    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_default_log(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
@@ -30,7 +30,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
+    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
@@ -38,7 +38,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
+    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_custompoles(self):
         # perform the fit with custom initial poles
         nw = skrf.data.ring_slot

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -11,25 +11,41 @@ import warnings
 
 class VectorFittingTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider ' \
+                                       'running `passivity_enforce()` to enforce passivity before using this model.'
+
     def test_ringslot_with_proportional(self):
         # perform the fit
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
+
+        # catch UserWarning about non-passive model
+        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
+            vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
+
+        assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.02)
 
     def test_ringslot_default_log(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
+
+        # catch UserWarning about non-passive model
+        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
+            vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
+
+        assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        with pytest.warns(UserWarning, match="The fitted network is passive, but the vector fit is not passive") as record:
+
+        # catch UserWarning about non-passive model
+        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
             vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
 
         assert len(record) == 1
@@ -39,8 +55,13 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit with custom initial poles
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.poles = 2 * np.pi * np.array([-100e9, -10e9+100e9j])
-        vf.vector_fit(init_pole_spacing='custom')
+        vf.poles = 2 * np.pi * np.array([-100e9, -10e9 + 100e9j])
+
+        # catch UserWarning about non-passive model
+        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
+            vf.vector_fit(init_pole_spacing='custom')
+
+        assert len(record) == 1
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -11,57 +11,40 @@ import warnings
 
 class VectorFittingTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider ' \
-                                       'running `passivity_enforce()` to enforce passivity before using this model.'
+    msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider running ' \
+                              '`passivity_enforce()` to enforce passivity before using this model.'
 
+    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
     def test_ringslot_with_proportional(self):
         # perform the fit
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-
-        # catch UserWarning about non-passive model
-        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
-            vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
-
-        assert len(record) <= 1
+        vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
+    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
     def test_ringslot_default_log(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-
-        # catch UserWarning about non-passive model
-        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
-            vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
-
-        assert len(record) <= 1
+        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
+    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-
-        # catch UserWarning about non-passive model
-        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
-            vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
-
-        assert len(record) <= 1
+        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
         self.assertLess(vf.get_rms_error(), 0.01)
 
+    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
     def test_ringslot_custompoles(self):
         # perform the fit with custom initial poles
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
         vf.poles = 2 * np.pi * np.array([-100e9, -10e9 + 100e9j])
-
-        # catch UserWarning about non-passive model
-        with pytest.warns(UserWarning, match=self.msg_passivity_violation) as record:
-            vf.vector_fit(init_pole_spacing='custom')
-
-        assert len(record) <= 1
+        vf.vector_fit(init_pole_spacing='custom')
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -14,7 +14,7 @@ class VectorFittingTestCase(unittest.TestCase):
     msg_passivity_violation = 'The fitted network is passive, but the vector fit is not passive. Consider running ' \
                               '`passivity_enforce()` to enforce passivity before using this model.'
 
-    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
+    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_with_proportional(self):
         # perform the fit
         nw = skrf.data.ring_slot
@@ -22,7 +22,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
-    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
+    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_default_log(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
@@ -30,7 +30,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
+    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
@@ -38,7 +38,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    @pytest.mark.filterwarnings(f'ignore:{msg_passivity_violation}:UserWarning')
+    @pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
     def test_ringslot_custompoles(self):
         # perform the fit with custom initial poles
         nw = skrf.data.ring_slot

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -30,7 +30,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
-    #@pytest.mark.filterwarnings(f'ignore:*{msg_passivity_violation}*:UserWarning')
+    @pytest.mark.filterwarnings(f'ignore:*passivity_enforce()*:UserWarning')
     def test_ringslot_without_prop_const(self):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -248,8 +248,7 @@ class VectorFitting:
         # responses will be weighted according to their norm;
         # alternative: equal weights with weight_response = 1.0
         # or anti-proportional weights with weight_response = 1 / np.linalg.norm(freq_response)
-        weights_responses = 10 / np.exp(np.mean(np.log(np.abs(freq_responses)), axis=1))
-        #weights_responses = np.linalg.norm(freq_responses, axis=1)
+        weights_responses = np.linalg.norm(freq_responses, axis=1)
         #weights_responses = np.ones(self.network.nports ** 2)
 
         # weight of extra equation to avoid trivial solution

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -166,7 +166,8 @@ class VectorFitting:
 
         # create initial poles and space them across the frequencies in the provided Touchstone file
         # use normalized frequencies during the iterations (seems to be more stable during least-squares fit)
-        norm = np.average(self.network.f)
+        #norm = np.average(self.network.f)
+        norm = np.exp(np.mean(np.log(self.network.f)))
         freqs_norm = np.array(self.network.f) / norm
 
         fmin = np.amin(freqs_norm)
@@ -187,7 +188,11 @@ class VectorFitting:
         elif init_pole_spacing == 'custom':
             pole_freqs_real = None
             pole_freqs_cmplx = None
-            poles = self.poles / norm
+            if self.poles is not None and len(self.poles) > 0:
+                poles = self.poles / norm
+            else:
+                raise ValueError('Initial poles must be provided in `self.poles` when calling with '
+                                 '`init_pole_spacing == \'custom\'`.')
         else:
             warnings.warn('Invalid choice of initial pole spacing; proceeding with linear spacing.', UserWarning,
                           stacklevel=2)
@@ -243,7 +248,8 @@ class VectorFitting:
         # responses will be weighted according to their norm;
         # alternative: equal weights with weight_response = 1.0
         # or anti-proportional weights with weight_response = 1 / np.linalg.norm(freq_response)
-        weights_responses = np.linalg.norm(freq_responses, axis=1)
+        weights_responses = 10 / np.exp(np.mean(np.log(np.abs(freq_responses)), axis=1))
+        #weights_responses = np.linalg.norm(freq_responses, axis=1)
         #weights_responses = np.ones(self.network.nports ** 2)
 
         # weight of extra equation to avoid trivial solution

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -250,6 +250,7 @@ class VectorFitting:
         # or anti-proportional weights with weight_response = 1 / np.linalg.norm(freq_response)
         weights_responses = np.linalg.norm(freq_responses, axis=1)
         #weights_responses = np.ones(self.network.nports ** 2)
+        #weights_responses = 10 / np.exp(np.mean(np.log(np.abs(freq_responses)), axis=1))
 
         # weight of extra equation to avoid trivial solution
         weight_extra = np.linalg.norm(weights_responses[:, None] * freq_responses) / n_samples

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -130,15 +130,16 @@ class VectorFitting:
             Number of initial complex conjugate poles. See notes.
 
         init_pole_spacing : str, optional
-            Type of initial pole spacing across the frequency interval of the S-matrix. Either linear (lin) or
-            logarithmic (log).
+            Type of initial pole spacing across the frequency interval of the S-matrix. Either *linear* (`'lin'`),
+            *logarithmic* (`'log'`), or `custom`. In case of `custom`, the initial poles must be stored in :attr:`poles`
+            as a NumPy array before calling this method. They will be overwritten by the final poles. The
+            initialization parameters `n_poles_real` and `n_poles_cmplx` will be ignored in case of `'custom'`.
 
         parameter_type : str, optional
-            Representation type of the frequency responses to be fitted. Either *scattering* (:attr:`s` or :attr:`S`),
-            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`). As scikit-rf can currently
-            only read S parameters from a Touchstone file, the fit should also be performed on the original S
-            parameters. Otherwise, scikit-rf will convert the responses from S to Z or Y, which might work for the fit
-            but can cause other issues.
+            Representation type of the frequency responses to be fitted. Either *scattering* (`'s'` or `'S'`),
+            *impedance* (`'z'` or `'Z'`) or *admittance* (`'y'` or `'Y'`). As scikit-rf can currently only read S parameters
+            from a Touchstone file, the fit should also be performed on the original S parameters. Otherwise, scikit-rf
+            will convert the responses from S to Z or Y, which might work for the fit but can cause other issues.
 
         fit_constant : bool, optional
             Include a constant term **d** in the fit.
@@ -176,31 +177,37 @@ class VectorFitting:
             # random choice: use 1/1000 of first non-zero frequency
             fmin = freqs_norm[1] / 1000
 
+        init_pole_spacing = init_pole_spacing.lower()
         if init_pole_spacing == 'log':
             pole_freqs_real = np.geomspace(fmin, fmax, n_poles_real)
             pole_freqs_cmplx = np.geomspace(fmin, fmax, n_poles_cmplx)
         elif init_pole_spacing == 'lin':
             pole_freqs_real = np.linspace(fmin, fmax, n_poles_real)
             pole_freqs_cmplx = np.linspace(fmin, fmax, n_poles_cmplx)
+        elif init_pole_spacing == 'custom':
+            pole_freqs_real = None
+            pole_freqs_cmplx = None
+            poles = self.poles / norm
         else:
             warnings.warn('Invalid choice of initial pole spacing; proceeding with linear spacing.', UserWarning,
                           stacklevel=2)
             pole_freqs_real = np.linspace(fmin, fmax, n_poles_real)
             pole_freqs_cmplx = np.linspace(fmin, fmax, n_poles_cmplx)
 
-        # init poles array of correct length
-        poles = np.zeros(n_poles_real + n_poles_cmplx, dtype=complex)
+        if pole_freqs_real is not None and pole_freqs_cmplx is not None:
+            # init poles array of correct length
+            poles = np.zeros(n_poles_real + n_poles_cmplx, dtype=complex)
 
-        # add real poles
-        for i, f in enumerate(pole_freqs_real):
-            omega = 2 * np.pi * f
-            poles[i] = -1 * omega
+            # add real poles
+            for i, f in enumerate(pole_freqs_real):
+                omega = 2 * np.pi * f
+                poles[i] = -1 * omega
 
-        # add complex-conjugate poles (store only positive imaginary parts)
-        i_offset = len(pole_freqs_real)
-        for i, f in enumerate(pole_freqs_cmplx):
-            omega = 2 * np.pi * f
-            poles[i_offset + i] = (-0.01 + 1j) * omega
+            # add complex-conjugate poles (store only positive imaginary parts)
+            i_offset = len(pole_freqs_real)
+            for i, f in enumerate(pole_freqs_cmplx):
+                omega = 2 * np.pi * f
+                poles[i_offset + i] = (-0.01 + 1j) * omega
 
         # save initial poles (un-normalize first)
         initial_poles = poles * norm

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -166,8 +166,8 @@ class VectorFitting:
 
         # create initial poles and space them across the frequencies in the provided Touchstone file
         # use normalized frequencies during the iterations (seems to be more stable during least-squares fit)
-        #norm = np.average(self.network.f)
-        norm = np.exp(np.mean(np.log(self.network.f)))
+        norm = np.average(self.network.f)
+        #norm = np.exp(np.mean(np.log(self.network.f)))
         freqs_norm = np.array(self.network.f) / norm
 
         fmin = np.amin(freqs_norm)


### PR DESCRIPTION
As [requested in the mailing list](https://groups.google.com/g/scikit-rf/c/VrX80hlDxx4), this PR adds an option for custom pole spacing by the user.

The pole spacing is a delicate part of the fitting process and this option is supposed to be used by advanced users only.

The goal was to keep the API unchanged, and I hope this is an elegant and usable way to do it.