### PR TITLE
Increasing rtol for sweep type tests

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -697,9 +697,9 @@ class Frequency:
             'lin' if linearly increasing, 'log' or 'unknown'.
 
         """
-        if npy.allclose(self.f, linspace(self.f[0], self.f[-1], self.npoints)):
+        if npy.allclose(self.f, linspace(self.f[0], self.f[-1], self.npoints), rtol=0.05):
             sweep_type = 'lin'
-        elif self.f[0] and npy.allclose(self.f, geomspace(self.f[0], self.f[-1], self.npoints)):
+        elif self.f[0] and npy.allclose(self.f, geomspace(self.f[0], self.f[-1], self.npoints), rtol=0.05):
             sweep_type = 'log'
         else:
             sweep_type = 'unknown'


### PR DESCRIPTION
In issue #846, the logarithmic sweep type was not detected correctly due to minor deviations from the ideal curve (< 1.5%). This PR increases the relative tolerance in `np.allclose()` to 5%.

![logspacing](https://user-images.githubusercontent.com/63644854/218572849-e5d335d2-2277-4b65-9b79-9d9e94d546dc.png)
