### PR TITLE
Draft: Embed line if impedances differ

### DIFF
--- a/doc/source/examples/metrology/Multiline TRL.ipynb
+++ b/doc/source/examples/metrology/Multiline TRL.ipynb
@@ -446,8 +446,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = coax1mm.line(1, 'm', z0=58, name='X', embed=True)\n",
-    "Y = coax1mm.line(1.1, 'm', z0=40, name='Y', embed=True)\n",
+    "X = coax1mm.line(1, 'm', z0=58, name='X')\n",
+    "Y = coax1mm.line(1.1, 'm', z0=40, name='Y')\n",
     "\n",
     "plt.figure()\n",
     "plt.title('Error networks')\n",
@@ -455,8 +455,8 @@
     "Y.plot_s_db()\n",
     "\n",
     "# Realistic looking switch terms\n",
-    "gamma_f = coax1mm.delay_load(0.2, 21e-3, 'm', z0=60, embed=True)\n",
-    "gamma_r = coax1mm.delay_load(0.25, 16e-3, 'm', z0=56, embed=True)\n",
+    "gamma_f = coax1mm.delay_load(0.2, 21e-3, 'm', z0=60)\n",
+    "gamma_r = coax1mm.delay_load(0.25, 16e-3, 'm', z0=56)\n",
     "\n",
     "plt.figure()\n",
     "plt.title('Switch terms')\n",
@@ -482,7 +482,7 @@
     "lines = [cpw.line(l, 'm') for l in line_len]\n",
     "\n",
     "# Attenuator with mismatched feed lines\n",
-    "dut_feed = cpw.line(1.5e-3, 'm', z0=60, embed=True)\n",
+    "dut_feed = cpw.line(1.5e-3, 'm', z0=60)\n",
     "dut = dut_feed**cpw.attenuator(-10)**dut_feed\n",
     "\n",
     "res_50ohm = cpw.resistor(50) ** cpw.short(nports=2) ** cpw.resistor(50)\n",
@@ -562,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1250,7 +1250,7 @@ class LRRMTest(EightTermTest):
         o_i = wg.load(1, nports=1, name='open')
         s_i = wg.short(nports=1, name='short')
         m_i = wg.load(0.1, nports=1, name='load')
-        with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+        with pytest.warns(FutureWarning, match="`embed` parameter will be"):
             thru = wg.line(d=50, z0=75, unit='um', name='thru', embed=True)
         # Make sure calibration works with non-symmetric thru
         thru.s[:,1,1] += 0.02 + 0.05j

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -11,6 +11,7 @@ Media class.
     DefinedGammaZ0
 
 """
+from typing import Optional
 from numbers import Number
 from pathlib import Path
 import warnings
@@ -850,10 +851,8 @@ class Media(ABC):
                 npy.array([[s11, s21],[s21,s11]]).transpose().reshape(-1,2,2)
 
         if embed is None:
-            if self.z0 != result.z0:
-                result.renormalize(self.z0, s_def=s_def)
-            else:
-                result.renormalize(result.z0, s_def=s_def)
+            # the result.renormalize checks whether we need to renormalize by comparing self.z0 with result.z0
+            result.renormalize(self.z0, s_def=s_def)
         else:
             # warns of future deprecation
             warnings.warn('In a future version, the `embed` parameter will be removed.\n'

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -851,14 +851,17 @@ class Media(ABC):
 
         if embed and self.z0 is not None:
             # warns of future deprecation
-            warnings.warn('In a future version,`embed` will be deprecated.\n'
+            warnings.warn('In a future version, the `embed` parameter will be removed.\n'
                           'The line and media port impedance z0 and '
-                          'characteristic impedance Z0 will be used instead '
+                          'characteristic impedance Z0 are used '
                           'to determine if the line has to be renormalized.',
               FutureWarning, stacklevel = 2)
             result.renormalize(self.z0, s_def=s_def)
         else:
-            result.renormalize(result.z0, s_def=s_def)
+            if self.z0 != result.z0:
+                result.renormalize(self.z0, s_def=s_def)
+            else:
+                result.renormalize(result.z0, s_def=s_def)
 
         return result
 

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -792,7 +792,7 @@ class Media(ABC):
         return self.line(0, **kwargs)
 
     def line(self, d: NumberLike, unit: str = 'deg',
-             z0: Union[NumberLike, str, None] = None, embed: bool = False, **kwargs) -> Network:
+             z0: Union[NumberLike, str, None] = None, embed: Optional[bool] = None, **kwargs) -> Network:
         r"""
         Transmission line of a given length and impedance.
 
@@ -849,16 +849,19 @@ class Media(ABC):
         result.s = \
                 npy.array([[s11, s21],[s21,s11]]).transpose().reshape(-1,2,2)
 
-        if embed and self.z0 is not None:
+        if embed is None:
+            if self.z0 != result.z0:
+                result.renormalize(self.z0, s_def=s_def)
+            else:
+                result.renormalize(result.z0, s_def=s_def)
+        else:
             # warns of future deprecation
             warnings.warn('In a future version, the `embed` parameter will be removed.\n'
-                          'The line and media port impedance z0 and '
-                          'characteristic impedance Z0 are used '
-                          'to determine if the line has to be renormalized.',
-              FutureWarning, stacklevel = 2)
-            result.renormalize(self.z0, s_def=s_def)
-        else:
-            if self.z0 != result.z0:
+                              'The line and media port impedance z0 and '
+                              'characteristic impedance Z0 are used '
+                              'to determine if the line has to be renormalized.',
+                  FutureWarning, stacklevel = 2)
+            if embed and self.z0 is not None:
                 result.renormalize(self.z0, s_def=s_def)
             else:
                 result.renormalize(result.z0, s_def=s_def)

--- a/skrf/media/tests/test_cpw.py
+++ b/skrf/media/tests/test_cpw.py
@@ -108,7 +108,7 @@ class CPWTestCase(unittest.TestCase):
                             tand = self.tand,
                             compatibility_mode = 'qucs',
                             diel = 'frequencyinvariant')
-            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            with pytest.warns(FutureWarning, match="`embed` parameter will be"):
                 line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
             line.name = '`Media.CPW` skrf,qucs'
             
@@ -185,7 +185,7 @@ class CPWTestCase(unittest.TestCase):
                             tand = self.tand,
                             compatibility_mode = 'ads',
                             diel = 'djordjevicsvensson')
-            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            with pytest.warns(FutureWarning, match="`embed` parameter will be"):
                 line = cpw.line(d=self.l, unit='m', embed = True, z0=cpw.Z0)
             line.name = '`Media.CPW` skrf,ads'
             
@@ -290,7 +290,7 @@ class CPWTestCase(unittest.TestCase):
             cpw = CPW(frequency = freq, z0 = 50., w = 3.0e-3, s = 0.3e-3, t = 35e-6,
                        ep_r = 4.5, rho = 1.7e-8)
             
-            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            with pytest.warns(FutureWarning, match="`embed` parameter will be deprecated"):
                 line = cpw.line(d = 25e-3, unit = 'm', embed = True, z0 = cpw.Z0)
             
     def test_zero_thickness(self):

--- a/skrf/media/tests/test_mline.py
+++ b/skrf/media/tests/test_mline.py
@@ -139,7 +139,7 @@ class MLineTestCase(unittest.TestCase):
                             model = ref['model'], disp = ref['disp'],
                             diel = 'frequencyinvariant',
                             compatibility_mode = 'qucs')
-            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            with pytest.warns(FutureWarning, match="`embed` parameter will be"):
                 line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
             line.name = 'skrf,qucs'
             
@@ -211,7 +211,7 @@ class MLineTestCase(unittest.TestCase):
                             tand = self.tand, rough = self.d,
                             model = 'hammerstadjensen', disp = ref['disp'],
                             diel = ref['diel'])
-            with pytest.warns(FutureWarning, match="`embed` will be deprecated"):
+            with pytest.warns(FutureWarning, match="`embed` parameter will be"):
                 line = mline.line(d=self.l, unit='m', embed = True, z0=mline.Z0)
             line.name = 'skrf,ads'
             

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3051,7 +3051,7 @@ class Network:
         out.flip()
         return out
 
-    def renormalize(self, z_new: NumberLike, s_def: str = None) -> None:
+    def renormalize(self, z_new: NumberLike, s_def: Optional[str] = None) -> None:
         """
         Renormalize s-parameter matrix given a new port impedances.
 


### PR DESCRIPTION
@mhuser @jhillairet This is a followup of https://github.com/scikit-rf/scikit-rf/pull/715. The deprecation warning is showing up in some example notebooks (e.g. https://scikit-rf.readthedocs.io/en/latest/examples/metrology/Multiline%20TRL.html) 
It seems there is currently no way to have the desired behaviour, without a warning.

This PR updates the default value of `embed` to `None` with the (I think) intended behaviour . This allows to remove the `embed` option at a later moment.
