### PR TITLE
Fix division by zero warnings in determine_line

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5698,15 +5698,16 @@ def determine_line(thru_m, line_m, line_approx=None):
     if line_approx is None:
         # estimate line length, by assuming error networks are well
         # matched
-        line_approx = line_m/thru_m
-
+        line_approx_s21 = line_m.s[:,1,0] / thru_m.s[:,1,0]
+    else:
+        line_approx_s21 = line_approx.s[:,1,0]
 
     C = thru_m.inv**line_m
     # the eigen values of the matrix C, are equal to s12,s12^-1)
     # we need to choose the correct one
     w,v = linalg.eig(C.t)
     s12_0, s12_1 = w[:,0], w[:,1]
-    s12 = find_correct_sign(s12_0, s12_1, line_approx.s[:,1,0])
+    s12 = find_correct_sign(s12_0, s12_1, line_approx_s21)
     found_line = line_m.copy()
     found_line.s = npy.array([[zero, s12],[s12,zero]]).transpose(2,0,1)
     return found_line

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5725,10 +5725,10 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     ----------
     thru_m : :class:`~skrf.network.Network`
         raw measurement of a thru
-    line_m : :class:`~skrf.network.Network`
-        raw measurement of a matched transmissive standard
     reflect_m: :class:`~skrf.network.Network`
         raw measurement of a reflect standard
+    line_m : :class:`~skrf.network.Network`
+        raw measurement of a matched transmissive standard
     reflect_approx : :class:`~skrf.network.Network`
         approximate One-port network for the reflect.  if None, then
         we assume its a flush short (gamma=-1)

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5741,6 +5741,9 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     -------
     reflect : :class:`~skrf.network.Network`
         a One-port network for the found reflect.
+
+    The equations are from "Thru-Reflect-Line: An Improved Technique for Calibrating the Dual Six-Port Automatic Network Analyzer", G.F. Engen et al., 1979
+    
     """
 
     #Call determine_line first to solve root choice of the propagation constant
@@ -5749,12 +5752,16 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     inv = linalg.inv
     rt = thru_m.t
     rd = line_m.t
+
+    # tt is equal to T from equation (24) in the paper
     tt = einsum('ijk,ikl -> ijl', rd, inv(rt))
 
     a = tt[:,1,0]
     b = tt[:,1,1]-tt[:,0,0]
     c = -tt[:,0,1]
 
+    # the sol1 and sol2 correspond to the ratios (r11/r21) and (r12/r22) from 
+    # equations (30) and (31) in the paper
     sol1 = (-b-sqrt(b*b-4*a*c))/(2*a)
     sol2 = (-b+sqrt(b*b-4*a*c))/(2*a)
 

--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -208,7 +208,6 @@ class Frequency:
         if isinstance(key, str):
 
             # they passed a string try and do some interpretation
-            re_numbers = re.compile(r'.*\d')
             re_hyphen = re.compile(r'\s*-\s*')
             re_letters = re.compile('[a-zA-Z]+')
 
@@ -279,7 +278,7 @@ class Frequency:
         if npy.isscalar(f):
             f = [f]
         temp_freq =  cls(0,0,0,*args, **kwargs)
-        temp_freq._f = npy.array(f) * temp_freq.multiplier
+        temp_freq._f = npy.asarray(f) * temp_freq.multiplier
         temp_freq.check_monotonic_increasing()
 
         return temp_freq

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -862,8 +862,7 @@ def suppress_warning_decorator(msg):
     def suppress_warnings_decorated(func):
         @wraps(func)
         def suppressed_func(*k, **kw):
-            show_warnings = []
-            with warnings.catch_warnings() as wlist:
+            with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=f"{msg}.*")
                 res = func(*k, **kw)
             return res


### PR DESCRIPTION
* Fix division by zero warnings in `determine_line`
* Add documentation for `determine_reflect` (see https://github.com/scikit-rf/scikit-rf/issues/865)
* Remove unused variables

The division by zero warnings are caused by the elementwise division of networks S parameters in `line_m/thru_m`, where only the result for S21 is required.