### PR TITLE
Resolve singularities for matched thru and line in determine_reflect

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -109,7 +109,7 @@ from .. import __version__ as skrf__version__
 from collections import defaultdict
 from itertools import combinations
 
-FloatArray = npy.typing.NDArray[npy.float_]
+ComplexArray = npy.typing.NDArray[complex]
 
 global coefs_list_12term
 coefs_list_12term =[
@@ -5716,10 +5716,10 @@ def determine_line(thru_m, line_m, line_approx=None):
     return found_line
 
 
-def _regularize_inplace(z : FloatArray, epsilon : float=1e-7) -> FloatArray:
+def _regularize_inplace(z : ComplexArray, epsilon : float=1e-7) -> ComplexArray:
     """ Regularize an array inplace around zero """
     zero_idx = npy.abs(z)<epsilon
-    z[zero_idx] = .5*(epsilon * npy.exp(npy.angle(z[zero_idx])*1j)+z[zero_idx]) 
+    z[zero_idx] = .5*(epsilon * npy.exp(npy.angle(z[zero_idx])*1j)+z[zero_idx])
     return z
 
 def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
@@ -5777,21 +5777,21 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     # The variables a, b, c define a quadratic equation for which the solutions sol1 and sol2 correspond to the
     # ratios (r11/r21) and (r12/r22) from equations (30) and (31) in the paper
     # The quadratic equation has solutions sol1 = (-b-sqrt(b*b-4*a*c))/(2*a), sol2 = (-b+sqrt(b*b-4*a*c))/(2*a)
-    # For a=0 these become degenerate. Also the consequtive equations for x1 and x2 contain singularities for a=0 or c=0    
+    # For a=0 these become degenerate. Also the consequtive equations for x1 and x2 contain singularities for a=0 or c=0
     # We address this by regularizing small values of a and the candidate solutions.
     # The impact on the final solution is small as for small a one root of the equation goes to infinity,
     # for the other the series expension in a is -c/b  - a c^2/b^3 + O(a^2)
-    
+
     denom = 2*a
     sol1 = (-b-sqrtD)/denom
     sol2 = (-b+sqrtD)/denom
-   
+
     x1 = (tt[:,1,0]*sol1 + tt[:,1,1])/(tt[:,0,1]/sol2 + tt[:,0,0])
     x2 = (tt[:,1,0]*sol2 + tt[:,1,1])/(tt[:,0,1]/sol1 + tt[:,0,0])
-       
+
     e2 = line.s[:,0,1]**2
-    rootChoice = abs(x1 - e2) < abs(x2 - e2) 
-        
+    rootChoice = abs(x1 - e2) < abs(x2 - e2)
+
     y = sol1*invert(rootChoice) + sol2*rootChoice
     x = sol1*rootChoice + sol2*invert(rootChoice)
     b = y
@@ -5800,7 +5800,7 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     d = -det(thru_m.s)
     f = -thru_m.s[:,1,1]
 
-    gam = (f-d/x)/(1-e/x) # equation (40) 
+    gam = (f-d/x)/(1-e/x) # equation (40)
     b_A = (e-b)/(d-b*f)  # equation (41): beta/alpha
 
     w1 = reflect_m.s[:,0,0]
@@ -5809,9 +5809,9 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     # equation (45)
     a = sqrt(((w1-b)*(1+w2*b_A)*(d-b*f))/\
             ((w2+gam)*(1-w1/x)*(1-e/x)))
-        
+
     out = [(w1-b)/(a*(1-w1/x)), (w1-b)/(-a*(1-w1/x))] # equation (47)
-        
+
     if return_all:
         return [Network(frequency=thru_m.frequency, s = k) for k in out]
 
@@ -5822,7 +5822,7 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     closer = find_closest(out[0], out[1], reflect_approx.s11.s.flatten())
     reflect = reflect_approx.copy()
     reflect.s[:,0,0]=closer
-    
+
     return reflect.s11
 
 

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5786,8 +5786,8 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     sol1 = (-b-sqrtD)/denom
     sol2 = (-b+sqrtD)/denom
    
-    x1 = (tt[:,1,0]*sol1*sol2 + tt[:,1,1]*sol2)/(tt[:,0,1] + tt[:,0,0]*sol2)
-    x2 = (tt[:,1,0]*sol2*sol1 + tt[:,1,1]*sol1)/(tt[:,0,1] + tt[:,0,0]*sol1)
+    x1 = (tt[:,1,0]*sol1 + tt[:,1,1])/(tt[:,0,1]/sol2 + tt[:,0,0])
+    x2 = (tt[:,1,0]*sol2 + tt[:,1,1])/(tt[:,0,1]/sol1 + tt[:,0,0])
        
     e2 = line.s[:,0,1]**2
     rootChoice = abs(x1 - e2) < abs(x2 - e2) 

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5784,9 +5784,8 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     # The impact on the final solution is small as for small a one root of the equation goes to infinity,
     # for the other the series expension in a is -c/b  - a c^2/b^3 + O(a^2)
 
-    denom = 2*a
-    sol1 = (-b-sqrtD)/denom
-    sol2 = (-b+sqrtD)/denom
+    sol1 = (-b-sqrtD)/(2*a)
+    sol2 = (-b+sqrtD)/(2*a)
 
     # equation (32)
     x1 = (tt[:,1,0]*sol1 + tt[:,1,1])/(tt[:,0,1]/sol2 + tt[:,0,0])
@@ -5794,7 +5793,6 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
 
     e2 = line.s[:,0,1]**2
     rootChoice = abs(x1 - e2) < abs(x2 - e2) # see gh-870
-    #rootChoice = npy.abs(x1) < npy.abs(x2) # criterium from eq (55)
 
     y = sol1*invert(rootChoice) + sol2*rootChoice
     x = sol1*rootChoice + sol2*invert(rootChoice)

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5756,6 +5756,11 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
 
     """
 
+    # regularize the parameters in case of matched thru and line. see gh-870
+    thru_m = thru_m.copy()
+    thru_m.s[:, 0, 0] = _regularize_inplace(thru_m.s[:, 0, 0])
+    thru_m.s[:, 1, 1] = _regularize_inplace(thru_m.s[:, 1, 1])
+
     #Call determine_line first to solve root choice of the propagation constant
     line = determine_line(thru_m, line_m, line_approx)
 
@@ -5765,10 +5770,6 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
 
     # tt is equal to T from equation (24) in the paper
     tt = einsum('ijk,ikl -> ijl', rd, inv(rt))
-
-    # regularize the parameters in case of matched thru and line. see gh-870
-    tt[:,1,0] = _regularize_inplace(tt[:,1,0])
-    tt[:,0,1] = _regularize_inplace(tt[:,0,1])
 
     a = tt[:,1,0]
     b = tt[:,1,1]-tt[:,0,0]

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5780,9 +5780,6 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     # ratios (r11/r21) and (r12/r22) from equations (30) and (31) in the paper
     # The quadratic equation has solutions sol1 = (-b-sqrt(b*b-4*a*c))/(2*a), sol2 = (-b+sqrt(b*b-4*a*c))/(2*a)
     # For a=0 these become degenerate. Also the consequtive equations for x1 and x2 contain singularities for a=0 or c=0
-    # We address this by regularizing small values of a and the candidate solutions.
-    # The impact on the final solution is small as for small a one root of the equation goes to infinity,
-    # for the other the series expension in a is -c/b  - a c^2/b^3 + O(a^2)
 
     sol1 = (-b-sqrtD)/(2*a)
     sol2 = (-b+sqrtD)/(2*a)
@@ -5823,7 +5820,7 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
 
     closer = find_closest(out[0], out[1], reflect_approx.s11.s.flatten())
     reflect = reflect_approx.copy()
-    reflect.s[:,0,0]=closer
+    reflect.s[:,0,0] = closer
 
     return reflect.s11
 

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5792,8 +5792,8 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     x2 = (tt[:,1,0]*sol2 + tt[:,1,1])/(tt[:,0,1]/sol1 + tt[:,0,0])
 
     e2 = line.s[:,0,1]**2
-    rootChoice0 = abs(x1 - e2) < abs(x2 - e2) # original choice for the root. see gh-870
-    rootChoice = npy.abs(x1) < npy.abs(x2) # criterium from eq (55)
+    rootChoice = abs(x1 - e2) < abs(x2 - e2) # see gh-870
+    #rootChoice = npy.abs(x1) < npy.abs(x2) # criterium from eq (55)
 
     y = sol1*invert(rootChoice) + sol2*rootChoice
     x = sol1*rootChoice + sol2*invert(rootChoice)

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -95,6 +95,7 @@ import json
 from numbers import Number
 from collections import OrderedDict
 from copy import copy
+import warnings
 from warnings import warn
 
 from ..mathFunctions import sqrt_phase_unwrap, \
@@ -5786,11 +5787,13 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     sol1 = (-b-sqrtD)/denom
     sol2 = (-b+sqrtD)/denom
 
+    # equation (32)
     x1 = (tt[:,1,0]*sol1 + tt[:,1,1])/(tt[:,0,1]/sol2 + tt[:,0,0])
     x2 = (tt[:,1,0]*sol2 + tt[:,1,1])/(tt[:,0,1]/sol1 + tt[:,0,0])
 
     e2 = line.s[:,0,1]**2
-    rootChoice = abs(x1 - e2) < abs(x2 - e2)
+    rootChoice0 = abs(x1 - e2) < abs(x2 - e2) # original choice for the root. see gh-870
+    rootChoice = npy.abs(x1) < npy.abs(x2) # criterium from eq (55)
 
     y = sol1*invert(rootChoice) + sol2*rootChoice
     x = sol1*rootChoice + sol2*invert(rootChoice)

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -101,12 +101,15 @@ from ..mathFunctions import sqrt_phase_unwrap, \
     find_correct_sign, find_closest,  ALMOST_ZERO, rand_c, cross_ratio
 from ..frequency import *
 from ..network import *
+from ..network import Network
 from ..networkSet import NetworkSet
 from .. import util
 from ..io.touchstone import read_zipped_touchstones
 from .. import __version__ as skrf__version__
 from collections import defaultdict
 from itertools import combinations
+
+FloatArray = npy.typing.NDArray[npy.float_]
 
 global coefs_list_12term
 coefs_list_12term =[
@@ -5713,6 +5716,12 @@ def determine_line(thru_m, line_m, line_approx=None):
     return found_line
 
 
+def _regularize_inplace(z : FloatArray, epsilon : float=1e-7) -> FloatArray:
+    """ Regularize an array inplace around zero """
+    zero_idx = npy.abs(z)<epsilon
+    z[zero_idx] = .5*(epsilon * npy.exp(npy.angle(z[zero_idx])*1j)+z[zero_idx]) 
+    return z
+
 def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
                      line_approx=None, return_all=False):
     """
@@ -5756,22 +5765,33 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     # tt is equal to T from equation (24) in the paper
     tt = einsum('ijk,ikl -> ijl', rd, inv(rt))
 
+    # regularize the parameters in case of matched thru and line. see gh-870
+    tt[:,1,0] = _regularize_inplace(tt[:,1,0])
+    tt[:,0,1] = _regularize_inplace(tt[:,0,1])
+
     a = tt[:,1,0]
     b = tt[:,1,1]-tt[:,0,0]
     c = -tt[:,0,1]
+    sqrtD = sqrt(b*b-4*a*c)
 
-    # the sol1 and sol2 correspond to the ratios (r11/r21) and (r12/r22) from
-    # equations (30) and (31) in the paper
-    sol1 = (-b-sqrt(b*b-4*a*c))/(2*a)
-    sol2 = (-b+sqrt(b*b-4*a*c))/(2*a)
-
+    # The variables a, b, c define a quadratic equation for which the solutions sol1 and sol2 correspond to the
+    # ratios (r11/r21) and (r12/r22) from equations (30) and (31) in the paper
+    # The quadratic equation has solutions sol1 = (-b-sqrt(b*b-4*a*c))/(2*a), sol2 = (-b+sqrt(b*b-4*a*c))/(2*a)
+    # For a=0 these become degenerate. Also the consequtive equations for x1 and x2 contain singularities for a=0 or c=0    
+    # We address this by regularizing small values of a and the candidate solutions.
+    # The impact on the final solution is small as for small a one root of the equation goes to infinity,
+    # for the other the series expension in a is -c/b  - a c^2/b^3 + O(a^2)
+    
+    denom = 2*a
+    sol1 = (-b-sqrtD)/denom
+    sol2 = (-b+sqrtD)/denom
+   
+    x1 = (tt[:,1,0]*sol1*sol2 + tt[:,1,1]*sol2)/(tt[:,0,1] + tt[:,0,0]*sol2)
+    x2 = (tt[:,1,0]*sol2*sol1 + tt[:,1,1]*sol1)/(tt[:,0,1] + tt[:,0,0]*sol1)
+       
     e2 = line.s[:,0,1]**2
-
-    x1 = (tt[:,1,0]*sol1 + tt[:,1,1])/(tt[:,0,1]/sol2 + tt[:,0,0])
-    x2 = (tt[:,1,0]*sol2 + tt[:,1,1])/(tt[:,0,1]/sol1 + tt[:,0,0])
-
-    rootChoice = [abs(x1[i] - e2[i]) < abs(x2[i] - e2[i]) for i in range(len(x1))]
-
+    rootChoice = abs(x1 - e2) < abs(x2 - e2) 
+        
     y = sol1*invert(rootChoice) + sol2*rootChoice
     x = sol1*rootChoice + sol2*invert(rootChoice)
     b = y
@@ -5780,21 +5800,18 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     d = -det(thru_m.s)
     f = -thru_m.s[:,1,1]
 
-    gam = (f-d/x)/(1-e/x)
-    b_A = (e-y)/(d-b*f)
+    gam = (f-d/x)/(1-e/x) # equation (40) 
+    b_A = (e-b)/(d-b*f)  # equation (41): beta/alpha
 
     w1 = reflect_m.s[:,0,0]
     w2 = reflect_m.s[:,1,1]
 
-    a = sqrt(((w1-y)*(1+w2*b_A)*(d-y*f))/\
+    # equation (45)
+    a = sqrt(((w1-y)*(1+w2*b_A)*(d-b*f))/\
             ((w2+gam)*(1-w1/x)*(1-e/x)))
-
-    out = []
-    for rootChoice2 in [1,-1] :
-        a= a*rootChoice2
-        unknownReflectS = (w1-y)/(a*(1-w1/x))
-        out.append(unknownReflectS)
-
+        
+    out = [(w1-b)/(a*(1-w1/x)), (w1-b)/(-a*(1-w1/x))] # equation (47)
+        
     if return_all:
         return [Network(frequency=thru_m.frequency, s = k) for k in out]
 
@@ -5803,15 +5820,10 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
         reflect_approx.s[:,0,0]=-1
 
     closer = find_closest(out[0], out[1], reflect_approx.s11.s.flatten())
-
     reflect = reflect_approx.copy()
     reflect.s[:,0,0]=closer
-
+    
     return reflect.s11
-
-
-
-
 
 
 def convert_12term_2_8term(coefs_12term, redundant_k = False):

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5807,7 +5807,7 @@ def determine_reflect(thru_m, reflect_m, line_m, reflect_approx=None,
     w2 = reflect_m.s[:,1,1]
 
     # equation (45)
-    a = sqrt(((w1-y)*(1+w2*b_A)*(d-b*f))/\
+    a = sqrt(((w1-b)*(1+w2*b_A)*(d-b*f))/\
             ((w2+gam)*(1-w1/x)*(1-e/x)))
         
     out = [(w1-b)/(a*(1-w1/x)), (w1-b)/(-a*(1-w1/x))] # equation (47)

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -6,7 +6,8 @@ import numpy as npy
 from numpy.random  import uniform
 
 import skrf as rf
-from skrf.calibration import PHN, SOLT, UnknownThru, TwoPortOnePath, TwelveTerm,  terminate, terminate_nport, determine_line, determine_reflect, NISTMultilineTRL, MultiportCal, MultiportSOLT, Coaxial
+from skrf.media import Coaxial
+from skrf.calibration import PHN, SOLT, UnknownThru, TwoPortOnePath, TwelveTerm,  terminate, terminate_nport, determine_line, determine_reflect, NISTMultilineTRL, MultiportCal, MultiportSOLT
 
 from skrf import two_port_reflect
 from skrf.networkSet import NetworkSet

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -104,7 +104,7 @@ class DetermineTest(unittest.TestCase):
         medium = Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
         thru= medium.line(0, 'm')
         line = medium.line(0.12, 'm')
-        short = rf.Network(f=freq.f, s=[[[(-1.+0.017870117714376983j)] ] ])
+        short = rf.Network(frequency=freq, s=[[[(-1.+0.017870117714376983j)] ] ])
 
         r = determine_reflect(thru, rf.two_port_reflect(short, short), line)
         npy.testing.assert_array_almost_equal( r.s, short.s)

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -67,34 +67,34 @@ class DetermineTest(unittest.TestCase):
                    for k,l in zip(self.R_m, self.r_estimate)]
 
         [ self.assertEqual(k,l) for k,l in zip(self.r, r_found)]
-        
+
     def test_determine_reflect_matched_thru_and_line_ideal_reflect(self):
-        freq = rf.F(.25,.7,801, unit='GHz')
-        medium=Coaxial.from_attenuation_VF(freq, att=3.0, VF=.69)
-    
+        freq = rf.F(.25, .7, 21, unit = 'GHz')
+        medium=Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
+
         thru = medium.line(0, 'm')
         line = medium.line(0.12, 'm')
-    
+
         short = rf.two_port_reflect(medium.short(), medium.short())
-        r=determine_reflect(thru, short, line)
+        r = determine_reflect(thru, short, line)
         npy.testing.assert_array_almost_equal( r.s, -npy.ones_like(r.s))
-    
+
         reflect = rf.two_port_reflect(medium.open(), medium.open())
-        r=determine_reflect(thru, reflect, line, reflect_approx = medium.open())
-        npy.testing.assert_array_almost_equal( r.s, npy.ones_like(r.s))
-    
+        r = determine_reflect(thru, reflect, line, reflect_approx = medium.open())
+        npy.testing.assert_array_almost_equal(r.s, npy.ones_like(r.s))
+
     def test_determine_reflect_matched_thru_and_line(self):
-        freq = rf.F(.25,.7,100, unit='GHz')
-        medium=Coaxial.from_attenuation_VF(freq, att=3.0, VF=.69)
-    
+        freq = rf.F(.25, .7, 40, unit = 'GHz')
+        medium = Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
+
         thru = medium.line(0, 'm')
         line = medium.line(0.12, 'm')
-        short=medium.short()
-        
-        rng=npy.random.default_rng(12)
-        short.s[:,0,0] = short.s[:,0,0]+rng.uniform(-.02, 0.02, freq.f.size)+rng.uniform(-.02, 0.02, freq.f.size)*1j
-        
-        r=determine_reflect(thru, rf.two_port_reflect(short, short), line)
+        short = medium.short()
+
+        rng = npy.random.default_rng(12)
+        short.s[:, 0, 0] = short.s[:, 0, 0]+rng.uniform(-.02, 0.02, freq.f.size) + rng.uniform(-.02, 0.02, freq.f.size)*1j
+
+        r = determine_reflect(thru, rf.two_port_reflect(short, short), line)
         npy.testing.assert_array_almost_equal( r.s, short.s)
 
 

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -98,6 +98,18 @@ class DetermineTest(unittest.TestCase):
         npy.testing.assert_array_almost_equal( r.s, short.s)
 
 
+    def test_determine_reflect_regression(self):
+        freq = rf.F(434615384.6153846, .7e9, 1, unit = 'Hz')
+
+        thru = rf.Network(f=freq.f, s=[[[0,1] ,[1,0]] ], f_unit='Hz')
+        s=npy.array([[[ 0.+0.j, (-0.012811542676311568-0.9593150869904133j)],
+                [ (-0.012811542676311568-0.9593150869904133j), 0.+0.j]]])
+        line = rf.Network(f=freq.f, s=s, f_unit='Hz')
+        short = rf.Network(f=freq.f, s=[[[(-1.0099670216756622+0.017870117714376983j)] ] ],f_unit='Hz')
+
+        r = determine_reflect(thru, rf.two_port_reflect(short, short), line)
+        npy.testing.assert_array_almost_equal( r.s, short.s)
+
 class CalibrationTest:
     """
     This is the generic Calibration test case which all Calibration

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -99,7 +99,7 @@ class DetermineTest(unittest.TestCase):
 
 
     def test_determine_reflect_regression(self):
-        # this test case fails without the root choice abs(x1 - e2) < abs(x2 - e2), see gh-870
+        # this test case fails with only regularization on the t-parameters of thru ** line.inv, see gh-870
         freq = rf.F(434615384.6153846e-9, .7, 1, unit = 'GHz')
         medium = Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
         thru= medium.line(0, 'm')

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -100,13 +100,11 @@ class DetermineTest(unittest.TestCase):
 
     def test_determine_reflect_regression(self):
         # this test case fails without the root choice abs(x1 - e2) < abs(x2 - e2), see gh-870
-        freq = rf.F(434615384.6153846, .7e9, 1, unit = 'Hz')
-
-        thru = rf.Network(freq=freq, s=[[[0,1] ,[1,0]] ])
-        s = npy.array([[[ 0.+0.j, (-0.012811542676311568-0.9593150869904133j)],
-                [ (-0.012811542676311568-0.9593150869904133j), 0.+0.j]]])
-        line = rf.Network(freq=freq, s=s)
-        short = rf.Network(freq=freq, s=[[[(-1.0099670216756622+0.017870117714376983j)] ] ])
+        freq = rf.F(434615384.6153846e-9, .7, 1, unit = 'GHz')
+        medium=Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
+        thru= medium.line(0, 'm')
+        line = medium.line(0.12, 'm')
+        short = rf.Network(f=freq.f, s=[[[(-1.+0.017870117714376983j)] ] ])
 
         r = determine_reflect(thru, rf.two_port_reflect(short, short), line)
         npy.testing.assert_array_almost_equal( r.s, short.s)

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -7,7 +7,7 @@ from numpy.random  import uniform
 
 import skrf as rf
 from skrf.media import Coaxial
-from skrf.calibration import PHN, SOLT, UnknownThru, TwoPortOnePath, TwelveTerm,  terminate, terminate_nport, determine_line, determine_reflect, NISTMultilineTRL, MultiportCal, MultiportSOLT
+from skrf.calibration import PHN, SOLT, UnknownThru, TwoPortOnePath, TwelveTerm, terminate, terminate_nport, determine_line, determine_reflect, NISTMultilineTRL, MultiportCal, MultiportSOLT
 
 from skrf import two_port_reflect
 from skrf.networkSet import NetworkSet
@@ -69,33 +69,33 @@ class DetermineTest(unittest.TestCase):
         [ self.assertEqual(k,l) for k,l in zip(self.r, r_found)]
         
     def test_determine_reflect_matched_thru_and_line_ideal_reflect(self):
-        freq = skrf.F(.25,.7,801, unit='GHz') 
+        freq = rf.F(.25,.7,801, unit='GHz')
         medium=Coaxial.from_attenuation_VF(freq, att=3.0, VF=.69)
     
         thru = medium.line(0, 'm')
         line = medium.line(0.12, 'm')
     
-        short = skrf.two_port_reflect(medium.short(), medium.short())    
+        short = rf.two_port_reflect(medium.short(), medium.short())
         r=determine_reflect(thru, short, line)
-        np.testing.assert_array_almost_equal( r.s, -np.ones_like(r.s))
+        npy.testing.assert_array_almost_equal( r.s, -npy.ones_like(r.s))
     
-        reflect = skrf.two_port_reflect(medium.open(), medium.open())    
+        reflect = rf.two_port_reflect(medium.open(), medium.open())
         r=determine_reflect(thru, reflect, line, reflect_approx = medium.open())
-        np.testing.assert_array_almost_equal( r.s, np.ones_like(r.s))
+        npy.testing.assert_array_almost_equal( r.s, npy.ones_like(r.s))
     
     def test_determine_reflect_matched_thru_and_line(self):
-        freq = skrf.F(.25,.7,100, unit='GHz') # works
+        freq = rf.F(.25,.7,100, unit='GHz')
         medium=Coaxial.from_attenuation_VF(freq, att=3.0, VF=.69)
     
         thru = medium.line(0, 'm')
         line = medium.line(0.12, 'm')
         short=medium.short()
         
-        rng=np.random.default_rng(12)    
+        rng=npy.random.default_rng(12)
         short.s[:,0,0] = short.s[:,0,0]+rng.uniform(-.02, 0.02, freq.f.size)+rng.uniform(-.02, 0.02, freq.f.size)*1j
         
-        r=determine_reflect(thru, skrf.two_port_reflect(short, short), line)
-        np.testing.assert_array_almost_equal( r.s, short.s)
+        r=determine_reflect(thru, rf.two_port_reflect(short, short), line)
+        npy.testing.assert_array_almost_equal( r.s, short.s)
 
 
 class CalibrationTest:

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -70,7 +70,7 @@ class DetermineTest(unittest.TestCase):
 
     def test_determine_reflect_matched_thru_and_line_ideal_reflect(self):
         freq = rf.F(.25, .7, 21, unit = 'GHz')
-        medium=Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
+        medium = Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
 
         thru = medium.line(0, 'm')
         line = medium.line(0.12, 'm')
@@ -99,13 +99,14 @@ class DetermineTest(unittest.TestCase):
 
 
     def test_determine_reflect_regression(self):
+        # this test case fails without the root choice abs(x1 - e2) < abs(x2 - e2), see gh-870
         freq = rf.F(434615384.6153846, .7e9, 1, unit = 'Hz')
 
-        thru = rf.Network(f=freq.f, s=[[[0,1] ,[1,0]] ], f_unit='Hz')
-        s=npy.array([[[ 0.+0.j, (-0.012811542676311568-0.9593150869904133j)],
+        thru = rf.Network(freq=freq, s=[[[0,1] ,[1,0]] ])
+        s = npy.array([[[ 0.+0.j, (-0.012811542676311568-0.9593150869904133j)],
                 [ (-0.012811542676311568-0.9593150869904133j), 0.+0.j]]])
-        line = rf.Network(f=freq.f, s=s, f_unit='Hz')
-        short = rf.Network(f=freq.f, s=[[[(-1.0099670216756622+0.017870117714376983j)] ] ],f_unit='Hz')
+        line = rf.Network(freq=freq, s=s)
+        short = rf.Network(freq=freq, s=[[[(-1.0099670216756622+0.017870117714376983j)] ] ])
 
         r = determine_reflect(thru, rf.two_port_reflect(short, short), line)
         npy.testing.assert_array_almost_equal( r.s, short.s)

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -101,7 +101,7 @@ class DetermineTest(unittest.TestCase):
     def test_determine_reflect_regression(self):
         # this test case fails without the root choice abs(x1 - e2) < abs(x2 - e2), see gh-870
         freq = rf.F(434615384.6153846e-9, .7, 1, unit = 'GHz')
-        medium=Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
+        medium = Coaxial.from_attenuation_VF(freq, att = 3.0, VF = .69)
         thru= medium.line(0, 'm')
         line = medium.line(0.12, 'm')
         short = rf.Network(f=freq.f, s=[[[(-1.+0.017870117714376983j)] ] ])


### PR DESCRIPTION
Fixes https://github.com/scikit-rf/scikit-rf/issues/865

This PR allows the `determine_reflect` (used in TRL calibration) to run a matched thru and line. The approach is inspired by the comment https://github.com/scikit-rf/scikit-rf/issues/865#issuecomment-1488582620 from @Ttl 
