### PR TITLE
improve performance of Coaxial.from_attenuation

### DIFF
--- a/skrf/media/coaxial.py
+++ b/skrf/media/coaxial.py
@@ -121,7 +121,7 @@ class Coaxial(DistributedCircuit, Media):
 
         """
         # test size of parameters
-        if size(array(att, dtype="object")) not in (1, size(array(frequency, dtype="object"))):
+        if size(array(att, dtype="object")) not in (1, size(frequency.f)):
             raise ValueError('Attenuation should be scalar or of same size that the frequency.')
 
         # create gamma

--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -71,6 +71,12 @@ class MediaTestCase(unittest.TestCase):
         coax = Coaxial.from_attenuation_VF(frequency=frequency, VF=1, att=_att, unit='Np/feet')
         assert_almost_equal(coax.gamma.real,  _att*rf.meter_2_feet())
 
+        with self.assertRaises(ValueError):
+            coax = Coaxial.from_attenuation_VF(frequency=frequency, VF=1, att=npy.array([.1, .2]), unit='Np/feet')
+        frequency = rf.Frequency(1., 1.1, unit='GHz', npoints=2)
+        coax = Coaxial.from_attenuation_VF(frequency=frequency, VF=1, att=npy.array([.1, .2]), unit='Np/feet')
+        self.assertEqual( coax.frequency.f.shape, (2,))
+
 
     def test_init_from_attenuation_VF_array_att(self):
         """


### PR DESCRIPTION
The `Coaxial.from_attenuation`  check on input sizes converted the `Frequency`  argument to an array with a very slow loop including a call to `__getattr__` on each element. We replace the conversion with a lookup of `Frequency.f` 

Benchmark:
```
freq = skrf.F(.15,1.7,801, unit='GHz') # fails   
att_db_per_meter = 3.0
medium=Coaxial.from_attenuation_VF(freq, att=att_db_per_meter, VF=.69)
```
Master: 3.5 seconds, this PR: < 0.1 seconds.

@FranzForstmayr
