### PR TITLE
Version 0.26.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-rf" %}
-{% set version = "0.24.1" %}
+{% set version = "0.26.0" %}
 {% set hash_val = "8223204281599ba14b685d7e28b7e361" %}
 
 package:

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python.
 """
 
-__version__ = '0.25.0'
+__version__ = '0.26.0'
 ## Import all  module names for coherent reference of name-space
 #import io
 


### PR DESCRIPTION
## New Features
* Add shunt_resistor by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/853
* Create variables to modify nudge_eig thresholds by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/859

## Improvements
* Do not generate subnetworks all the time but provide them dynamically by @FranzForstmayr in https://github.com/scikit-rf/scikit-rf/pull/810
* improve performance of Coaxial.from_attenuation by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/871

## Bug Fix
* Fix CITI parser by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/854
* Fix division by zero warnings in determine_line by @eendebakpt in https://github.com/scikit-rf/scikit-rf/pull/868
* Fix reading/writing HFSS Touchstone files using the 'power' S-param definition by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/869

## Community, Code Quality and Continuous Integration
* Adding issue templates by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/862
* [pre-commit] trailing spaces and end lines by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/867
* [pre-commit] pre-commit configuration: blank lines and trailing spaces by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/863

## Documentation
* Remove duplicate files in documentation by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/861


**Full Changelog**: https://github.com/scikit-rf/scikit-rf/compare/v0.25.0...v.0.26.0