### PR TITLE
Improve performance network.copy

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1901,7 +1901,7 @@ class Network:
 
         """
         ntwk = Network(s=self.s,
-                       frequency=self.frequency.copy(),
+                       frequency=self.frequency,
                        z0=self.z0, s_def=self.s_def,
                        comments=self.comments, params=self.params
                        )
@@ -1909,9 +1909,6 @@ class Network:
         ntwk.name = self.name
 
         if self.noise is not None and self.noise_freq is not None:
-          if False :
-              ntwk.noise = npy.copy(self.noise)
-              ntwk.noise_freq = npy.copy(self.noise_freq)
           ntwk.noise = self.noise.copy()
           ntwk.noise_freq = self.noise_freq.copy()
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -68,6 +68,12 @@ class NetworkTestCase(unittest.TestCase):
         self.DUT2 = rf.concat_ports([l2, l2, l2, l2], port_order='first')
         self.Meas2 = rf.concat_ports([l3, l3, l3, l3], port_order='first')
 
+    def test_network_copy(self):
+        n = self.ntwk1
+        n2 = n.copy()
+        self.assertEqual( n.frequency, n2.frequency)
+        self.assertNotEqual( id(n.frequency), id(n2.frequency))
+
     def test_two_port_reflect(self):
         number_of_data_points = 10
         f = rf.Frequency.from_f(np.linspace(2e6, 3e6, number_of_data_points), unit="Hz")


### PR DESCRIPTION
The `network.copy` makes a deep copy of the frequency object, and this copy happens again in the `Network`  constructor.
This PR removes the explicit copy of the frequency object and adds a test.

Note: are the copies at https://github.com/scikit-rf/scikit-rf/blob/master/skrf/calibration/calibration.py#L245 required? If not, we could remove them as well
