### PR TITLE
Remove deprecated setter methods on Frequency

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -165,7 +165,6 @@ class Frequency:
             self._f = geomspace(start, stop, npoints)
         else:
             raise ValueError('Sweep Type not recognized')
-        self._f.setflags(write = False)
 
     def __str__(self) -> str:
         """

--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -165,7 +165,7 @@ class Frequency:
             self._f = geomspace(start, stop, npoints)
         else:
             raise ValueError('Sweep Type not recognized')
-        self._f.flags.writable = False
+        self._f.setflags(write = False)
 
     def __str__(self) -> str:
         """
@@ -386,21 +386,6 @@ class Frequency:
         """
         return len(self.f)
 
-    @npoints.setter
-    def npoints(self, n: int) -> None:
-        """
-        Set the number of points in the frequency.
-        """
-        raise Exception('Possibility to set the npoints parameter has been removed')
-
-        if self.sweep_type == 'lin':
-            self.f = linspace(self.start, self.stop, n)
-        elif self.sweep_type == 'log':
-            self.f = geomspace(self.start, self.stop, n)
-        else:
-            raise ValueError(
-                'Unable to change number of points for sweep type', self.sweep_type)
-
     @property
     def center(self) -> float:
         """
@@ -487,23 +472,6 @@ class Frequency:
         """
 
         return self._f
-
-    @f.setter
-    def f(self,new_f: NumberLike) -> None:
-        """
-        Sets the frequency object by passing a vector in Hz.
-
-        Raises
-        ------
-        InvalidFrequencyWarning:
-            If frequency points are not monotonously increasing
-        """
-        raise Exception('Possibility to set the f parameter has been removed')
-
-        self._f = npy.array(new_f)
-
-        self.check_monotonic_increasing()
-
 
 
     @property

--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -165,6 +165,7 @@ class Frequency:
             self._f = geomspace(start, stop, npoints)
         else:
             raise ValueError('Sweep Type not recognized')
+        self._f.flags.writable = False
 
     def __str__(self) -> str:
         """
@@ -390,8 +391,7 @@ class Frequency:
         """
         Set the number of points in the frequency.
         """
-        warnings.warn('Possibility to set the npoints parameter will removed in the next release.',
-             DeprecationWarning, stacklevel=2)
+        raise Exception('Possibility to set the npoints parameter has been removed')
 
         if self.sweep_type == 'lin':
             self.f = linspace(self.start, self.stop, n)
@@ -498,8 +498,7 @@ class Frequency:
         InvalidFrequencyWarning:
             If frequency points are not monotonously increasing
         """
-        warnings.warn('Possibility to set the f parameter will removed in the next release.',
-             DeprecationWarning, stacklevel=2)
+        raise Exception('Possibility to set the f parameter has been removed')
 
         self._f = npy.array(new_f)
 

--- a/skrf/tests/test_frequency.py
+++ b/skrf/tests/test_frequency.py
@@ -81,10 +81,9 @@ class FrequencyTestCase(unittest.TestCase):
         frequency points directly.
         """
         a = rf.Frequency.from_f([1,2,4,5,6], unit='Hz')
-        # TODO : assertRaises(AttributeError) in next release
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(AttributeError):
             a.f = [1, 2]
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(AttributeError):
             a.npoints = 10
         with self. assertRaises(AttributeError):
             a.start = 2


### PR DESCRIPTION
Remove two deprecated setter methods on the Frequency object.

Note: the Frequency object is now mostly immutable except for the `unit` and a few public methods (e.g. `round_to`).