### PR TITLE
Fix incorrect z0 handling in SeriesImpedance and ShuntAdmittance

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -82,7 +82,7 @@ Graph representation
    Circuit.edge_labels
 
 """
-from . network import Network, a2s, s2s
+from . network import Network, s2s
 from . media import media
 from . constants import INF, NumberLike, S_DEF_DEFAULT
 
@@ -278,8 +278,7 @@ class Circuit:
         A[:, 0, 1] = Z
         A[:, 1, 0] = 0
         A[:, 1, 1] = 1
-        ntw = Network(frequency=frequency, z0=z0, name=name)
-        ntw.s = a2s(A)
+        ntw = Network(a=A, frequency=frequency, z0=z0, name=name)
         return ntw
 
     @classmethod
@@ -322,8 +321,7 @@ class Circuit:
         A[:, 0, 1] = 0
         A[:, 1, 0] = Y
         A[:, 1, 1] = 1
-        ntw = Network(frequency=frequency, z0=z0, name=name)
-        ntw.s = a2s(A)
+        ntw = Network(a=A, frequency=frequency, z0=z0, name=name)
         return ntw
 
     @classmethod

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -112,12 +112,14 @@ class CircuitClassMethods(unittest.TestCase):
         assert_array_almost_equal(opn.s, opn_ref.s)
 
     def test_series_impedance(self):
+        z0s = [1, 50]
         Zs = [1, 1 + 1j, rf.INF]
-        for Z in Zs:
-            assert_array_almost_equal(
-                rf.Circuit.SeriesImpedance(self.freq, Z, 'imp').s,
-                self.media.resistor(Z).s
-                )
+        for z0 in z0s:
+            for Z in Zs:
+                assert_array_almost_equal(
+                    rf.Circuit.SeriesImpedance(self.freq, Z, 'imp', z0=z0).s,
+                    self.media.resistor(Z, z0=z0).s
+                    )
 
         # Z=0 is a thru
         assert_array_almost_equal(
@@ -126,12 +128,14 @@ class CircuitClassMethods(unittest.TestCase):
             )
 
     def test_shunt_admittance(self):
+        z0s = [1, 50]
         Ys = [1, 1 + 1j, rf.INF]
-        for Y in Ys:
-            assert_array_almost_equal(
-                rf.Circuit.ShuntAdmittance(self.freq, Y, 'imp').s,
-                self.media.shunt(self.media.load(rf.zl_2_Gamma0(self.media.z0, 1/Y))).s
-                )
+        for z0 in z0s:
+            for Y in Ys:
+                assert_array_almost_equal(
+                    rf.Circuit.ShuntAdmittance(self.freq, Y, 'imp', z0=z0).s,
+                    self.media.shunt(self.media.load(rf.zl_2_Gamma0(z0, 1/Y))).s
+                    )
 
         # Y=INF is a a 2-ports short, aka a ground
         assert_array_almost_equal(


### PR DESCRIPTION
Reported on the mailing list. `z0` was not set in `a2s`.