### PR TITLE
Make Network.copy also copy params dict

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1903,7 +1903,7 @@ class Network:
         ntwk = Network(s=self.s,
                        frequency=self.frequency.copy(),
                        z0=self.z0, s_def=self.s_def,
-                       comments=self.comments, params=self.params
+                       comments=self.comments, params=self.params.copy()
                        )
 
         ntwk.name = self.name

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1903,8 +1903,11 @@ class Network:
         ntwk = Network(s=self.s,
                        frequency=self.frequency.copy(),
                        z0=self.z0, s_def=self.s_def,
-                       comments=self.comments, params=self.params.copy()
+                       comments=self.comments
                        )
+
+        if self.params is not None:
+            ntwk.params = self.params.copy()
 
         ntwk.name = self.name
 


### PR DESCRIPTION
Currently, `Network.copy()` does not copy `params` which was extremely confusing in my case. `copy` should be a full deep copy. This PR makes that the case.