### PR TITLE
Allow NISTMultilineTRL to work with non-exact floats

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -2638,7 +2638,7 @@ class NISTMultilineTRL(EightTerm):
         self.refl_offset = refl_offset
         self.ref_plane = ref_plane
         self.er_est = er_est
-        self.l = l
+        self.l = [float(v) for v in l] # cast to float, see gh-
         self.Grefls = Grefls
         self.gamma_root_choice = gamma_root_choice
         self.k_method = k_method

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -2638,7 +2638,7 @@ class NISTMultilineTRL(EightTerm):
         self.refl_offset = refl_offset
         self.ref_plane = ref_plane
         self.er_est = er_est
-        self.l = [float(v) for v in l] # cast to float, see gh-
+        self.l = [float(v) for v in l] # cast to float, see gh-895
         self.Grefls = Grefls
         self.gamma_root_choice = gamma_root_choice
         self.k_method = k_method

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -3234,9 +3234,7 @@ class NISTMultilineTRL(EightTerm):
         #Reference impedance renormalization
         if self.z0_ref is not None and npy.any(z0 != self.z0_ref):
             powerwave = self.kwargs.get('powerwave', False)
-            if npy.shape(self.z0_ref) != (fpoints,):
-                z0_ref = self.z0_ref*npy.ones(fpoints, dtype=complex)
-            self.renormalize(z0, z0_ref, powerwave=powerwave)
+            self.renormalize(z0, self.z0_ref, powerwave=powerwave)
 
     @classmethod
     def from_coefs(cls, frequency, coefs, **kwargs):

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -3146,7 +3146,7 @@ class NISTMultilineTRL(EightTerm):
                 try:
                     shift1 = exp(-2*gamma[m]*self.ref_plane[0])
                     shift2 = exp(-2*gamma[m]*self.ref_plane[1])
-                except TypeError:
+                except (TypeError, IndexError):
                     shift1 = exp(-2*gamma[m]*self.ref_plane)
                     shift2 = exp(-2*gamma[m]*self.ref_plane)
                 A1 *= shift1
@@ -3163,7 +3163,7 @@ class NISTMultilineTRL(EightTerm):
                     raise ValueError('Only one of c0 or z0_line can be given.')
                 try:
                     c0m = self.c0[m]
-                except TypeError:
+                except (TypeError, IndexError):
                     c0m = self.c0
                 z0[m] = gamma[m]/(1j*2*npy.pi*freqs[m]*c0m)
             else:
@@ -3171,12 +3171,12 @@ class NISTMultilineTRL(EightTerm):
                 if self.z0_line is not None:
                     try:
                         z0[m] = self.z0_line[m]
-                    except TypeError:
+                    except (TypeError, IndexError):
                         z0[m] = self.z0_line
                 else:
                     try:
                         z0[m] = self.z0_ref[m]
-                    except TypeError:
+                    except (TypeError, IndexError):
                         z0[m] = self.z0_ref
 
             #Error matrices

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -2340,13 +2340,16 @@ class TRL(EightTerm):
         used if more than one line is passed. A multi-reflect algorithm
         is used if multiple reflects are passed, see `n_reflects` argument.
 
-        All of the `ideals` can be individually set to None, or the entire
-        list set to None (`ideals=None`). For each ideal set to None
+        The algorithm requires a flush thru. For a TRL calibration with a
+        non-flush thru, use :class:`NISTMultilineTRL`.
+
+        All of the `ideals` can be individually set to `None`, or the entire
+        list set to `None` (`ideals=None`). For each ideal set to `None`,
         the following assumptions are made:
 
         * thru : flush thru
         * reflect : flush shorts
-        * line : and approximately  90deg  matched line (can be lossy)
+        * line : an approximately 90deg matched line (can be lossy)
 
         The reflect ideals can also be given as a +-1.
 
@@ -2410,6 +2413,7 @@ class TRL(EightTerm):
         --------
         determine_line
         determine_reflect
+        NISTMultilineTRL
 
         """
         #warn('Value of Reflect is not solved for yet.')
@@ -5647,8 +5651,8 @@ def determine_line(thru_m, line_m, line_approx=None):
     Given raw measurements of a `thru` and a matched `line` with unknown
     s21, this will calculate the response of the line. This works for
     lossy lines, and attenuators. The `line_approx`
-    is an approximation to line, this used  to choose the correct
-    root sign. If left as None, it will be estimated from raw measurements,
+    is an approximation to line, this used to choose the correct
+    root sign. If left as `None`, it will be estimated from raw measurements,
     which requires your error networks to be well matched  (S_ij >>S_ii).
 
 
@@ -5677,7 +5681,7 @@ def determine_line(thru_m, line_m, line_approx=None):
     Parameters
     ----------
     thru_m : :class:`~skrf.network.Network`
-        raw measurement of a thru
+        raw measurement of a flush thru
     line_m : :class:`~skrf.network.Network`
         raw measurement of a matched transmissive standard
     line_approx : :class:`~skrf.network.Network`

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -761,7 +761,7 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
             self.assertTrue(all(npy.abs(self.cal.coefs[k] - self.cal_shift.coefs[k]) < 1e-9))
 
 
-    def test_non_exact_float(self):
+    def test_numpy_float_arguments(self):
         # see gh-895
         cal= NISTMultilineTRL(
             measured = self.measured[:3],

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -761,6 +761,16 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
             self.assertTrue(all(npy.abs(self.cal.coefs[k] - self.cal_shift.coefs[k]) < 1e-9))
 
 
+    def test_non_exact_float(self):
+        cal= NISTMultilineTRL(
+            measured = self.measured[:3],
+            Grefls = [-1],
+            l = [npy.float64(1000e-6), 1010e-6],
+            switch_terms = (self.gamma_f, self.gamma_r),
+            )
+        cal.run()
+        cal.apply_cal(self.measured[0])
+
 @pytest.mark.skip()
 class TREightTermTest(unittest.TestCase, CalibrationTest):
     def setUp(self):

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -763,7 +763,7 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
 
     def test_numpy_float_arguments(self):
         # see gh-895
-        cal= NISTMultilineTRL(
+        cal = NISTMultilineTRL(
             measured = self.measured[:3],
             Grefls = [-1],
             l = [npy.float64(1000e-6), 1010e-6],
@@ -772,12 +772,12 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
         cal.run()
         cal.apply_cal(self.measured[0])
 
-        cal= NISTMultilineTRL(
+        cal = NISTMultilineTRL(
             measured = self.measured[:3],
             Grefls = [-1],
             l = [1000e-6, 1010e-6],
-            z0_ref=npy.float64(50),
-            z0_line=npy.float64(50),
+            z0_ref = npy.float64(50),
+            z0_line = npy.float64(50),
             switch_terms = (self.gamma_f, self.gamma_r),
             )
         cal.run()

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -771,6 +771,18 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
         cal.run()
         cal.apply_cal(self.measured[0])
 
+        cal= NISTMultilineTRL(
+            measured = self.measured[:3],
+            Grefls = [-1],
+            l = [1000e-6, 1010e-6],
+            z0_ref=npy.float64(50),
+            z0_line=npy.float64(50),
+            switch_terms = (self.gamma_f, self.gamma_r),
+            )
+        cal.run()
+        cal.apply_cal(self.measured[0])
+
+
 @pytest.mark.skip()
 class TREightTermTest(unittest.TestCase, CalibrationTest):
     def setUp(self):

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -762,6 +762,7 @@ class NISTMultilineTRLTest2(NISTMultilineTRLTest):
 
 
     def test_non_exact_float(self):
+        # see gh-895
         cal= NISTMultilineTRL(
             measured = self.measured[:3],
             Grefls = [-1],

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5620,7 +5620,7 @@ def s2t(s: npy.ndarray) -> npy.ndarray:
     # test here for even number of ports.
     # s-parameter networks are square matrix, so x and y are equal.
     if(x % 2 != 0):
-        raise IndexError('Network don\'t have an even number of ports')
+        raise IndexError('Network does not have an even number of ports')
     t = npy.zeros((z, y, x), dtype=complex)
     yh = int(y/2)
     xh = int(x/2)
@@ -5628,12 +5628,13 @@ def s2t(s: npy.ndarray) -> npy.ndarray:
     sinv = npy.linalg.inv(s[:, yh:y, 0:xh])
     # np.linalg.inv test for singularity (matrix not invertible)
     for k in range(len(s)):
-    # T_I,I = S_I,II - S_I,I . S_II,I^-1 . S_II,II
-        t[k, 0:yh, 0:xh] = s[k, 0:yh, xh:x] - s[k, 0:yh, 0:xh].dot(sinv[k].dot(s[k, yh:y, xh:x]))
+        w = sinv[k].dot(s[k, yh:y, xh:x])
+        # T_I,I = S_I,II - S_I,I . S_II,I^-1 . S_II,II
+        t[k, 0:yh, 0:xh] = s[k, 0:yh, xh:x] - s[k, 0:yh, 0:xh].dot(w)
         # T_I,II = S_I,I . S_II,I^-1
         t[k, 0:yh, xh:x] = s[k, 0:yh, 0:xh].dot(sinv[k])
         # T_II,I = -S_II,I^-1 . S_II,II
-        t[k, yh:y, 0:xh] = -sinv[k].dot(s[k, yh:y, xh:x])
+        t[k, yh:y, 0:xh] = -w
         # T_II,II = S_II,I^-1
         t[k, yh:y, xh:x] = sinv[k]
     return t
@@ -6343,7 +6344,7 @@ def t2s(t: npy.ndarray) -> npy.ndarray:
     # test here for even number of ports.
     # t-parameter networks are square matrix, so x and y are equal.
     if(x % 2 != 0):
-        raise IndexError('Network don\'t have an even number of ports')
+        raise IndexError('Network does not have an even number of ports')
     s = npy.zeros((z, y, x), dtype=complex)
     yh = int(y/2)
     xh = int(x/2)


### PR DESCRIPTION
The `NISTMultilineTRL` checks whether variables are scalar with the construction
``` 
try:
   v = x[0]
except TypeError:
    # treat x as scalar
    ...
```
This works for float, since `v = 1.0; v[0]` results in a `TypeError`. But for `v = npy.float64(1.0); v[0]` an `IndexError` is raised. This PR allows `NISTMultilineTRL` to work with numpy scalars by checking arguments with `numpy.isscalar`  and converting if required. The PR also improves performance of `s2t`  by factoring out a common expression.
