### PR TITLE
Fix doc links from Circuit tutorial to Circuit convenience methods

### DIFF
--- a/doc/source/tutorials/Circuit.ipynb
+++ b/doc/source/tutorials/Circuit.ipynb
@@ -53,9 +53,9 @@
     "\n",
     "* [Circuit.Port()](../api/generated/skrf.circuit.Circuit.Port.html#skrf.circuit.Circuit.Port)\n",
     "* [Circuit.Ground()](../api/generated/skrf.circuit.Circuit.Ground.html#skrf.circuit.Circuit.Ground)\n",
-    "* [Circuit.SeriesImpedance()](../api/generated/skrf.circuit.Circuit.Ground.html#skrf.circuit.Circuit.SeriesImpedance)\n",
-    "* [Circuit.ShuntAdmittance()](../api/generated/skrf.circuit.Circuit.Ground.html#skrf.circuit.Circuit.ShuntAdmittance)\n",
-    "* [Circuit.Open()](../api/generated/skrf.circuit.Circuit.Ground.html#skrf.circuit.Circuit.Open)"
+    "* [Circuit.SeriesImpedance()](../api/generated/skrf.circuit.Circuit.SeriesImpedance.html#skrf.circuit.Circuit.SeriesImpedance)\n",
+    "* [Circuit.ShuntAdmittance()](../api/generated/skrf.circuit.Circuit.ShuntAdmittance.html#skrf.circuit.Circuit.ShuntAdmittance)\n",
+    "* [Circuit.Open()](../api/generated/skrf.circuit.Circuit.Open.html#skrf.circuit.Circuit.Open)"
    ]
   },
   {


### PR DESCRIPTION
Currently they all link to `Circuit.Ground`