### PR TITLE
Add noise data to write_touchstone

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2363,8 +2363,10 @@ class Network:
 
                 # write noise data if it exists
                 if ntwk.noisy:
-                   for f, nf, g_opt, rn, z0 in zip(ntwk.f_noise.f_scaled, ntwk.nfmin_db, ntwk.g_opt, ntwk.rn, ntwk.z0):
-                       output.write(f"{f} {nf} {mf.complex_2_magnitude(g_opt)} {mf.complex_2_degree(g_opt)} {rn/z0[0].real}\n") 
+                    new = ntwk.copy()
+                    new.resample(ntwk.f_noise) # only write data from original noise freqs
+                    for f, nf, g_opt, rn, z0 in zip(new.f_noise.f_scaled, new.nfmin_db, new.g_opt, new.rn, new.z0):
+                        output.write(f"{f} {nf} {mf.complex_2_magnitude(g_opt)} {mf.complex_2_degree(g_opt)} {rn/z0[0].real}\n") 
 
             elif ntwk.number_of_ports == 3:
                 # 3-port is written over 3 lines / matrix order

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2361,6 +2361,11 @@ class Network:
                             output.write(f' {ntwk.z0[f, n].real:.14f} {ntwk.z0[f, n].imag:.14f}')
                         output.write('\n')
 
+                # write noise data if it exists
+                if ntwk.noisy:
+                   for f, nf, g_opt, rn, z0 in zip(ntwk.f_noise.f_scaled, ntwk.nfmin_db, ntwk.g_opt, ntwk.rn, ntwk.z0):
+                       output.write(f"{f} {nf} {mf.complex_2_magnitude(g_opt)} {mf.complex_2_degree(g_opt)} {rn/z0[0].real}\n") 
+
             elif ntwk.number_of_ports == 3:
                 # 3-port is written over 3 lines / matrix order
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -370,6 +370,27 @@ class NetworkTestCase(unittest.TestCase):
         # Writing complex characteristic impedance should fail
         with pytest.raises(ValueError) as e_info:
             snp = ntwk.write_touchstone(return_string=True)
+        
+    def test_write_touchstone_noisy(self):
+        ntwk = rf.Network(os.path.join(self.test_dir,'ntwk_noise.s2p'))
+
+        # Read back the written touchstone
+        ntwkstr = ntwk.write_touchstone(return_string=True)
+        strio = io.StringIO(ntwkstr)
+        strio.name = f'StringIO.s2p'
+        new_ntwk = rf.Network(strio)
+
+        # Only compare to original noise data, not interpolated
+        ntwk.resample(ntwk.f_noise)
+        new_ntwk.resample(new_ntwk.f_noise)
+        
+        # Newly written noise properties should match the original
+        npy.testing.assert_allclose(ntwk.f_noise.f_scaled, new_ntwk.f_noise.f_scaled)
+        npy.testing.assert_allclose(ntwk.nfmin, new_ntwk.nfmin)
+        npy.testing.assert_allclose(ntwk.nfmin_db, new_ntwk.nfmin_db)
+        npy.testing.assert_allclose(ntwk.g_opt, new_ntwk.g_opt)
+        npy.testing.assert_allclose(ntwk.rn, new_ntwk.rn)
+        npy.testing.assert_allclose(ntwk.z0, new_ntwk.z0)
 
     def test_pickling(self):
         original_ntwk = self.ntwk1


### PR DESCRIPTION
Quick addition to write noise data to touchstone files as raised in #379. This follows the touchstone 1.1 [specification](https://ibis.org/connector/touchstone_spec11.pdf). Tested by reading in the following transistor touchstone and writing out the test file.

[LN300.s2p.txt](https://github.com/scikit-rf/scikit-rf/files/11377006/LN300.s2p.txt)
[test.s2p.txt](https://github.com/scikit-rf/scikit-rf/files/11377016/test.s2p.txt)
