### PR TITLE
Formatting API documents

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5,7 +5,7 @@ network (:mod:`skrf.network`)
 ========================================
 
 
-Provides an n-port network class and associated functions.
+Provide an n-port network class and associated functions.
 
 Much of the functionality in this module is provided as methods and
 properties of the :class:`Network` Class.
@@ -796,7 +796,7 @@ class Network:
 
     def __getitem__(self, key:Union[str, int, slice, Sized]) -> 'Network':
         """
-        Slices a Network object based on an index, or human readable string.
+        Slice a Network object based on an index, or human readable string.
 
         Parameters
         ----------
@@ -915,7 +915,7 @@ class Network:
     # INTERNAL CODE GENERATION METHODS
     def __compatable_for_scalar_operation_test(self, other:'Network') -> None:
         """
-        tests to make sure other network's s-matrix is of same shape
+        test to make sure other network's s-matrix is of same shape
         """
         if other.frequency != self.frequency:
             raise IndexError('Networks must have same frequency. See `Network.interpolate`')
@@ -1372,7 +1372,7 @@ class Network:
     @frequency.setter
     def frequency(self, new_frequency: Union[Frequency, int, Sequence[float], npy.ndarray]) -> None:
         """
-        takes a Frequency object, see  frequency.py
+        take a Frequency object, see frequency.py
         """
         if isinstance(new_frequency, Frequency):
             self._frequency = new_frequency.copy()
@@ -1874,7 +1874,7 @@ class Network:
 
     def is_symmetric(self, n: int = 1, port_order: Dict[int, int] = {}, tol: float = mf.ALMOST_ZERO) -> bool:
         """
-        Returns whether the 2N-port network has n-th order reflection symmetry by checking.
+        Return whether the 2N-port network has n-th order reflection symmetry by checking.
         :math:`S_{i,i} == S_{j,j}` for appropriate pair(s) of :math:`i` and :math:`j`.
 
         Parameters
@@ -1993,7 +1993,7 @@ class Network:
     ## CLASS METHODS
     def copy(self) -> 'Network':
         """
-        Returns a copy of this Network.
+        Return a copy of this Network.
 
         Needed to allow pass-by-value for a Network instead of
         pass-by-reference
@@ -2027,7 +2027,7 @@ class Network:
 
     def copy_from(self, other: 'Network') -> None:
         """
-        Copies the contents of another Network into self.
+        Copy the contents of another Network into self.
 
         Uses copy, so that the data is passed-by-value, not reference
 
@@ -2047,7 +2047,7 @@ class Network:
 
     def copy_subset(self, key: npy.ndarray) -> 'Network':
         """
-        Returns a copy of a frequency subset of this Network.
+        Return a copy of a frequency subset of this Network.
 
         Needed to allow pass-by-value for a subset Network instead of
         pass-by-reference
@@ -2121,7 +2121,7 @@ class Network:
     def set_noise_a(self, noise_freq: Frequency = None, nfmin_db: float = 0,
         gamma_opt: float = 0, rn: NumberLike = 1 ) -> None:
           """
-          Sets the "A" (ie cascade) representation of the correlation matrix, based on the
+          Set the "A" (ie cascade) representation of the correlation matrix, based on the
           noise frequency and input parameters.
           """
           sh_fr = noise_freq.f.shape
@@ -2147,7 +2147,7 @@ class Network:
     def read_touchstone(self, filename: Union[str, TextIO],
                         encoding: Union[str, None] = None) -> None:
         """
-        Loads values from a touchstone file.
+        Load values from a touchstone file.
 
         The work of this function is done through the
         :class:`~skrf.io.touchstone` class.
@@ -2972,7 +2972,7 @@ class Network:
 
     def subnetwork(self, ports: Sequence[int], offby: int = 1) -> 'Network':
         """
-        Returns a subnetwork of a the Network from a list of port numbers.
+        Return a subnetwork of a the Network from a list of port numbers.
 
         A subnetwork is Network which S-parameters corresponds to selected ports,
         with all non-selected ports considered matched.
@@ -3093,7 +3093,7 @@ class Network:
 
     def flip(self) -> None:
         """
-        Swaps the ports of a 2n-port Network (inplace).
+        Swap the ports of a 2n-port Network (inplace).
 
         In case the network is 2n-port and n > 1, 'second' numbering scheme is
         assumed to be consistent with the ** cascade operator::
@@ -3190,7 +3190,7 @@ class Network:
 
     def renumber(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> None:
         """
-        Renumbers ports of a Network (inplace).
+        Renumber ports of a Network (inplace).
 
         Parameters
         ----------
@@ -3293,7 +3293,7 @@ class Network:
 
     def renumbered(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> 'Network':
         """
-        Returns a renumbered Network, leave self alone.
+        Return a renumbered Network, leave self alone.
 
         Parameters
         ----------
@@ -3490,9 +3490,9 @@ class Network:
 
     def multiply_noise(self, mag_dev: float, phase_dev: float, **kwargs) -> None:
         """
-        Multiplies a complex bivariate gaussian white-noise signal
+        Multiply a complex bivariate gaussian white-noise signal
         of given standard deviations for magnitude and phase.
-        magnitude mean is 1, phase mean is 0.
+        The mean of the magnitude is 1, and the mena of the phase is 0.
 
         Parameters
         ----------
@@ -3538,7 +3538,7 @@ class Network:
     # other
     def func_on_parameter(self, func: Callable, attr: str = 's', *args, **kwargs) -> 'Network':
         r"""
-        Applies a function parameter matrix, one frequency slice at a time.
+        Apply a function parameter matrix, one frequency slice at a time.
 
         This is useful for functions that can only operate on 2d arrays,
         like numpy.linalg.inv. This loops over f and calls
@@ -3984,7 +3984,7 @@ class Network:
 
     def impulse_response(self, window: str = 'hamming', n: int = None, pad: int = 1000,
                         bandpass: bool = None, squeeze: bool = True) -> Tuple[npy.ndarray, npy.ndarray]:
-        """Calculates time-domain impulse response of one-port.
+        """Calculate time-domain impulse response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
         the frequency step must be uniform. Positions of the reflections are
@@ -4057,7 +4057,7 @@ class Network:
     def step_response(
             self, window: str = 'hamming', n: int = None, pad: int = 1000, squeeze: bool = True
             ) -> Tuple[npy.ndarray, npy.ndarray]:
-        """Calculates time-domain step response of one-port.
+        """Calculate time-domain step response of one-port.
 
         First frequency must be 0 Hz for the transformation to be accurate and
         the frequency step must be uniform.
@@ -4161,7 +4161,7 @@ class Network:
 
     def z_active(self, a: npy.ndarray) -> npy.ndarray:
         r"""
-        Returns the active Z-parameters of the network for a defined wave excitation a.
+        Return the active Z-parameters of the network for a defined wave excitation a.
 
         The active Z-parameters are defined by:
 
@@ -4192,7 +4192,7 @@ class Network:
 
     def y_active(self, a: npy.ndarray) -> npy.ndarray:
         r"""
-        Returns the active Y-parameters of the network for a defined wave excitation a.
+        Return the active Y-parameters of the network for a defined wave excitation a.
 
         The active Y-parameters are defined by:
 
@@ -4223,7 +4223,7 @@ class Network:
 
     def vswr_active(self, a: npy.ndarray) -> npy.ndarray:
         r"""
-        Returns the active VSWR of the network for a defined wave excitation a.
+        Return the active VSWR of the network for a defined wave excitation a.
 
         The active VSWR is defined by :
 
@@ -4710,7 +4710,7 @@ def de_embed(ntwkA: Network, ntwkB: Network) -> Network:
 
 def stitch(ntwkA: Network, ntwkB: Network, **kwargs) -> Network:
     r"""
-    Stitches ntwkA and ntwkB together.
+    Stitch ntwkA and ntwkB together.
 
     Concatenates two networks' data. Given two networks that cover
     different frequency bands this can be used to combine their data
@@ -4750,7 +4750,7 @@ def stitch(ntwkA: Network, ntwkB: Network, **kwargs) -> Network:
 
 def overlap(ntwkA: Network, ntwkB: Network) -> Tuple[Network, Network]:
     """
-    Returns the overlapping parts of two Networks, interpolating if needed.
+    Return the overlapping parts of two Networks, interpolating if needed.
 
     If frequency vectors for each ntwk don't perfectly overlap, then
     ntwkB is interpolated so that the resultant networks have identical
@@ -4784,7 +4784,7 @@ def overlap(ntwkA: Network, ntwkB: Network) -> Tuple[Network, Network]:
 
 def overlap_multi(ntwk_list: Sequence[Network]):
     """
-    Returns the overlapping parts of multiple Networks, interpolating if needed.
+    Return the overlapping parts of multiple Networks, interpolating if needed.
 
     If frequency vectors for each ntwk don't perfectly overlap, then
     all networks after the first are interpolated so that the resultant networks
@@ -4907,7 +4907,7 @@ def concat_ports(ntwk_list: Sequence[Network], port_order: str = 'second',
 
 def average(list_of_networks: Sequence[Network], polar: bool = False) -> Network:
     """
-    Calculates the average network from a list of Networks.
+    Calculate the average network from a list of Networks.
 
     This is complex average of the s-parameters for a  list of Networks.
 
@@ -4952,7 +4952,7 @@ def average(list_of_networks: Sequence[Network], polar: bool = False) -> Network
 
 def stdev(list_of_networks: Sequence[Network], attr: str = 's') -> npy.ndarray:
     """
-    Calculates the standard deviation of a network attribute from a list of Networks.
+    Calculate the standard deviation of a network attribute from a list of Networks.
 
     This is the standard deviation for complex values of the s-parameters and other related attributes
     for a list of Networks.
@@ -4981,7 +4981,7 @@ def stdev(list_of_networks: Sequence[Network], attr: str = 's') -> npy.ndarray:
 
 def one_port_2_two_port(ntwk: Network) -> Network:
     """
-    Calculates the 2-port network given a symmetric, reciprocal and lossless 1-port network.
+    Calculate the 2-port network given a symmetric, reciprocal and lossless 1-port network.
 
     Parameters
     ----------
@@ -5010,7 +5010,7 @@ def one_port_2_two_port(ntwk: Network) -> Network:
 
 def chopinhalf(ntwk: Network, *args, **kwargs) -> Network:
     r"""
-    Chops a sandwich of identical, reciprocal 2-ports in half.
+    Chop a sandwich of identical, reciprocal 2-ports in half.
 
     Given two identical, reciprocal 2-ports measured in series,
     this returns one.
@@ -5121,7 +5121,7 @@ def evenodd2delta(n: Network, z0: NumberLike = 50, renormalize: bool = True,
 
 def subnetwork(ntwk: Network, ports: int, offby:int = 1) -> Network:
     """
-    Returns a subnetwork of a given Network from a list of port numbers.
+    Return a subnetwork of a given Network from a list of port numbers.
 
     A subnetwork is Network which S-parameters corresponds to selected ports,
     with all non-selected ports considered matched.
@@ -5174,7 +5174,7 @@ def subnetwork(ntwk: Network, ports: int, offby:int = 1) -> Network:
 ## Building composit networks from sub-networks
 def n_oneports_2_nport(ntwk_list: Sequence[Network], *args, **kwargs) -> Network:
     r"""
-    Builds an N-port Network from list of N one-ports.
+    Build an N-port Network from list of N one-ports.
 
     Parameters
     ----------
@@ -5204,7 +5204,7 @@ def n_oneports_2_nport(ntwk_list: Sequence[Network], *args, **kwargs) -> Network
 def n_twoports_2_nport(ntwk_list: Sequence[Network], nports: int,
         offby:int = 1, **kwargs) -> Network:
     r"""
-    Builds an N-port Network from list of two-ports.
+    Build an N-port Network from list of two-ports.
 
     This  method was made to reconstruct an n-port network from 2-port
     subnetworks as measured by a 2-port VNA. So, for example, given a
@@ -5260,7 +5260,7 @@ def n_twoports_2_nport(ntwk_list: Sequence[Network], nports: int,
 
 def four_oneports_2_twoport(s11: Network, s12: Network, s21: Network, s22: Network, *args, **kwargs) -> Network:
     r"""
-    Builds a 2-port Network from list of four 1-ports.
+    Build a 2-port Network from list of four 1-ports.
 
     Parameters
     ----------
@@ -5291,7 +5291,7 @@ def four_oneports_2_twoport(s11: Network, s12: Network, s21: Network, s22: Netwo
 def three_twoports_2_threeport(ntwk_triplet: Sequence[Network], auto_order:bool = True, *args,
                                **kwargs) -> Network:
     r"""
-    Creates 3-port from  three 2-port Networks.
+    Create 3-port from  three 2-port Networks.
 
     This function provides a convenient way to build a 3-port Network
     from a set of 2-port measurements. Which may occur when measuring
@@ -5706,7 +5706,7 @@ def s2y(s: npy.ndarray, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.n
 
 def s2t(s: npy.ndarray) -> npy.ndarray:
     """
-    Converts scattering parameters [#]_ to scattering transfer parameters [#]_.
+    Convert scattering parameters [#]_ to scattering transfer parameters [#]_.
 
     transfer parameters are also referred to as
     'wave cascading matrix' [#]_, this function only operates on 2N-ports
@@ -6108,7 +6108,7 @@ def a2s(a: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def a2z(a: npy.ndarray) -> npy.ndarray:
     """
-    Converts abcd parameters to z parameters [#]_.
+    Convert abcd parameters to z parameters [#]_.
 
 
     Parameters
@@ -6201,7 +6201,7 @@ def z2a(z: npy.ndarray) -> npy.ndarray:
 
 def s2a(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
     """
-    Converts scattering parameters to abcd parameters [#]_.
+    Convert scattering parameters to abcd parameters [#]_.
 
     Parameters
     ----------
@@ -6605,7 +6605,7 @@ def t2y(t: npy.ndarray) -> NoReturn:
 
 def h2z(h: npy.ndarray) -> npy.ndarray:
     """
-    Converts hybrid parameters to z parameters [#]_.
+    Convert hybrid parameters to z parameters [#]_.
 
 
     Parameters
@@ -6698,7 +6698,7 @@ def s2h(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def z2h(z: npy.ndarray) -> npy.ndarray:
     """
-    Converts impedance parameters to hybrid parameters [#]_.
+    Convert impedance parameters to hybrid parameters [#]_.
 
 
     Parameters
@@ -6926,7 +6926,7 @@ def renormalize_s(
 
 def fix_param_shape(p: NumberLike):
     """
-    Attempts to broadcast p to satisfy.
+    Attempt to broadcast p to satisfy.
         npy.shape(p) == (nfreqs, nports, nports)
 
     Parameters
@@ -7024,7 +7024,7 @@ def fix_z0_shape(z0: NumberLike, nfreqs: int, nports: int) -> npy.ndarray:
 ## cascading assistance functions
 def inv(s: npy.ndarray) -> npy.ndarray:
     """
-    Calculates 'inverse' s-parameter matrix, used for de-embedding.
+    Calculate 'inverse' s-parameter matrix, used for de-embedding.
 
     This is not literally the inverse of the s-parameter matrix.
     Instead, it is defined such that the inverse of the s-matrix cascaded
@@ -7117,7 +7117,7 @@ def flip(a: npy.ndarray) -> npy.ndarray:
 ## COMMON CHECKS (raise exceptions)
 def check_frequency_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    Checks if two Networks have same frequency.
+    Check if two Networks have same frequency.
     """
     if assert_frequency_equal(ntwkA, ntwkB) is False:
         raise IndexError('Networks don\'t have matching frequency. See `Network.interpolate`')
@@ -7133,7 +7133,7 @@ def check_frequency_exist(ntwk) -> None:
 
 def check_z0_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    Checks if two Networks have same port impedances.
+    Check if two Networks have same port impedances.
     """
     # note you should check frequency equal before you call this
     if assert_z0_equal(ntwkA, ntwkB) is False:
@@ -7142,7 +7142,7 @@ def check_z0_equal(ntwkA: Network, ntwkB: Network) -> None:
 
 def check_nports_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    Checks if two Networks have same number of ports.
+    Check if two Networks have same number of ports.
     """
     if assert_nports_equal(ntwkA, ntwkB) is False:
         raise ValueError('Networks don\'t have matching number of ports.')
@@ -7190,7 +7190,7 @@ def assert_nports_equal(ntwkA: Network, ntwkB: Network) -> bool:
 # this is needed for port impedance mismatches
 def impedance_mismatch(z1: NumberLike, z2: NumberLike, s_def: str = 'traveling') -> npy.ndarray:
     """
-    Creates a two-port s-matrix for a impedance mis-match.
+    Create a two-port s-matrix for a impedance mis-match.
 
     Parameters
     ----------
@@ -7243,7 +7243,7 @@ def impedance_mismatch(z1: NumberLike, z2: NumberLike, s_def: str = 'traveling')
 
 def two_port_reflect(ntwk1: Network, ntwk2: Network = None, name : Optional[str] = None) -> Network:
     """
-    Generates a two-port reflective two-port, from two one-ports.
+    Generate a two-port reflective two-port, from two one-ports.
 
 
     Parameters
@@ -7295,7 +7295,7 @@ def two_port_reflect(ntwk1: Network, ntwk2: Network = None, name : Optional[str]
 
 def s2s_active(s: npy.ndarray, a:npy.ndarray) -> npy.ndarray:
     r"""
-    Returns active s-parameters for a defined wave excitation a.
+    Return active s-parameters for a defined wave excitation a.
 
     The active s-parameter at a port is the reflection coefficients
     when other ports are excited. It is an important quantity for active
@@ -7342,7 +7342,7 @@ def s2s_active(s: npy.ndarray, a:npy.ndarray) -> npy.ndarray:
 
 def s2z_active(s: npy.ndarray, z0: NumberLike, a: npy.ndarray) -> npy.ndarray:
     r"""
-    Returns the active Z-parameters for a defined wave excitation a.
+    Return the active Z-parameters for a defined wave excitation a.
 
     The active Z-parameters are defined by:
 
@@ -7385,7 +7385,7 @@ def s2z_active(s: npy.ndarray, z0: NumberLike, a: npy.ndarray) -> npy.ndarray:
 
 def s2y_active(s: npy.ndarray, z0: NumberLike, a: npy.ndarray) -> npy.ndarray:
     r"""
-    Returns the active Y-parameters for a defined wave excitation a.
+    Return the active Y-parameters for a defined wave excitation a.
 
     The active Y-parameters are defined by:
 
@@ -7426,7 +7426,7 @@ def s2y_active(s: npy.ndarray, z0: NumberLike, a: npy.ndarray) -> npy.ndarray:
 
 def s2vswr_active(s: npy.ndarray, a: npy.ndarray) -> npy.ndarray:
     r"""
-    Returns the active VSWR for a defined wave excitation a..
+    Return the active VSWR for a defined wave excitation a..
 
     The active VSWR is defined by :
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -202,9 +202,9 @@ class Network:
     =====================  =============================================
     Property               Meaning
     =====================  =============================================
-    :attr:`s`              scattering parameter matrix
-    :attr:`z0`             characteristic impedance matrix
-    :attr:`f`              frequency vector
+    :attr:`s`              Scattering parameter matrix.
+    :attr:`z0`             Characteristic impedance matrix.
+    :attr:`f`              Frequency vector.
     =====================  =============================================
 
     Although these docs focus on s-parameters, other equivalent network
@@ -216,11 +216,11 @@ class Network:
     =====================  =============================================
     Property               Meaning
     =====================  =============================================
-    :attr:`s_re`           real part of the s-matrix
-    :attr:`s_im`           imaginary part of the s-matrix
-    :attr:`s_mag`          magnitude of the s-matrix
-    :attr:`s_db`           magnitude in log scale of the s-matrix
-    :attr:`s_deg`          phase of the s-matrix in degrees
+    :attr:`s_re`           Real part of the s-matrix.
+    :attr:`s_im`           Imaginary part of the s-matrix.
+    :attr:`s_mag`          Magnitude of the s-matrix.
+    :attr:`s_db`           Magnitude in log scale of the s-matrix.
+    :attr:`s_deg`          Phase of the s-matrix in degrees.
     =====================  =============================================
 
     The following operations act on the networks s-matrix.
@@ -228,12 +228,12 @@ class Network:
     =====================  =============================================
     Operator               Function
     =====================  =============================================
-    \+                     element-wise addition of the s-matrix
-    \-                     element-wise difference of the s-matrix
-    \*                     element-wise multiplication of the s-matrix
-    \/                     element-wise division of the s-matrix
-    \*\*                   cascading (only for 2-ports)
-    \//                    de-embedding (for 2-ports, see :attr:`inv`)
+    \+                     Element-wise addition of the s-matrix.
+    \-                     Element-wise difference of the s-matrix.
+    \*                     Element-wise multiplication of the s-matrix.
+    \/                     Element-wise division of the s-matrix.
+    \*\*                   Cascading (only for 2-ports).
+    \//                    De-embedding (for 2-ports, see :attr:`inv`).
     =====================  =============================================
 
     Different components of the :class:`Network` can be visualized
@@ -244,17 +244,17 @@ class Network:
     =========================  =============================================
     Method                     Meaning
     =========================  =============================================
-    :func:`plot_s_smith`       plot complex s-parameters on smith chart
-    :func:`plot_s_re`          plot real part of s-parameters vs frequency
-    :func:`plot_s_im`          plot imaginary part of s-parameters vs frequency
-    :func:`plot_s_mag`         plot magnitude of s-parameters vs frequency
-    :func:`plot_s_db`          plot magnitude (in dB) of s-parameters vs frequency
-    :func:`plot_s_deg`         plot phase of s-parameters (in degrees) vs frequency
-    :func:`plot_s_deg_unwrap`  plot phase of s-parameters (in unwrapped degrees) vs frequency
+    :func:`plot_s_smith`       Plot complex s-parameters on smith chart.
+    :func:`plot_s_re`          Plot real part of s-parameters vs frequency.
+    :func:`plot_s_im`          Plot imaginary part of s-parameters vs frequency.
+    :func:`plot_s_mag`         Plot magnitude of s-parameters vs frequency.
+    :func:`plot_s_db`          Plot magnitude (in dB) of s-parameters vs frequency.
+    :func:`plot_s_deg`         Plot phase of s-parameters (in degrees) vs frequency.
+    :func:`plot_s_deg_unwrap`  Plot phase of s-parameters (in unwrapped degrees) vs frequency.
 
     =========================  =============================================
 
-    :class:`Network`  objects can be  created from a touchstone or pickle
+    :class:`Network`  objects can be created from a touchstone or pickle
     file  (see :func:`__init__`), by a
     :class:`~skrf.media.media.Media` object, or manually by assigning the
     network properties directly. :class:`Network`  objects
@@ -334,7 +334,7 @@ class Network:
         'time_step': 'Magnitude',
     }
     """
-    y-axis labels to the plotting functions
+    Y-axis labels to the plotting functions.
     """
 
     noise_interp_kind = 'linear'
@@ -1614,10 +1614,10 @@ class Network:
         power received at all ports, normalized to the power at a single
         excitement port.
 
-        mathematically, this is a test for unitary-ness of the
+        Mathematically, this is a test for unitary-ness of the
         s-parameter matrix [#]_.
 
-        for two port this is
+        For two port this is
 
         .. math::
 
@@ -1650,7 +1650,7 @@ class Network:
         This returns the difference between the s-parameter matrix
         and its transpose.
 
-        for two port this is
+        For two port this is
 
         .. math::
 
@@ -2631,7 +2631,7 @@ class Network:
 
     def to_dataframe(self, *args, **kwargs) -> 'pd.DataFrame':
         """
-        Convert attributes of a Network to a pandas DataFrame
+        Convert attributes of a Network to a pandas DataFrame.
 
         Use the same parameters than :func:`skrf.io.general.network_2_dataframe`
 
@@ -4255,7 +4255,7 @@ for func_name, (_func, prop_name, conversion) in Network._generated_functions().
 
     func_name = f"{prop_name}_{conversion}"
     doc = f"""
-        The {conversion} component of the {prop_name}-matrix
+        The {conversion} component of the {prop_name}-matrix.
 
         See Also
         --------

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5,7 +5,7 @@ network (:mod:`skrf.network`)
 ========================================
 
 
-Provides a n-port network class and associated functions.
+Provides an n-port network class and associated functions.
 
 Much of the functionality in this module is provided as methods and
 properties of the :class:`Network` Class.
@@ -187,10 +187,10 @@ if TYPE_CHECKING:
 
 class Network:
     r"""
-    A n-port electrical network.
+    An n-port electrical network.
 
     For instructions on how to create Network see  :func:`__init__`.
-    A n-port network [#TwoPortWiki]_ may be defined by three quantities
+    An n-port network [#TwoPortWiki]_ may be defined by three quantities
     * network parameter matrix (s, z, or y-matrix)
     * port characteristic impedance matrix
     * frequency information
@@ -496,7 +496,7 @@ class Network:
     @classmethod
     def from_z(cls, z: npy.ndarray, *args, **kw) -> 'Network':
         r"""
-        Create a Network from its Z-parameters
+        Create a Network from its Z-parameters.
 
         Parameters
         ----------
@@ -527,7 +527,7 @@ class Network:
     # OPERATORS
     def __pow__(self, other: 'Network') -> 'Network':
         """
-        Cascade this network with another network
+        Cascade this network with another network.
 
         Returns
         -------
@@ -598,7 +598,7 @@ class Network:
 
     def __floordiv__(self, other: Union['Network', Tuple['Network', ...]] ) -> 'Network':
         """
-        de-embedding 1 or 2 network[s], from this network
+        De-embedding 1 or 2 network[s], from this network.
 
         :param other: skrf.Network, list, tuple: Network(s) to de-embed
         :return: skrf.Network: De-embedded network
@@ -650,7 +650,7 @@ class Network:
 
     def __mul__(self, other:'Network') -> 'Network':
         """
-        Element-wise complex multiplication of s-matrix
+        Element-wise complex multiplication of s-matrix.
 
         Returns
         -------
@@ -671,7 +671,7 @@ class Network:
 
     def __rmul__(self, other: 'Network') -> 'Network':
         """
-        Element-wise complex multiplication of s-matrix
+        Element-wise complex multiplication of s-matrix.
 
         Returns
         -------
@@ -691,7 +691,7 @@ class Network:
 
     def __add__(self, other:'Network') -> 'Network':
         """
-        Element-wise complex addition of s-matrix
+        Element-wise complex addition of s-matrix.
 
         Returns
         -------
@@ -710,7 +710,7 @@ class Network:
 
     def __radd__(self, other:'Network') -> 'Network':
         """
-        Element-wise complex addition of s-matrix
+        Element-wise complex addition of s-matrix.
 
         Returns
         -------
@@ -729,7 +729,7 @@ class Network:
 
     def __sub__(self, other:'Network') -> 'Network':
         """
-        Element-wise complex subtraction of s-matrix
+        Element-wise complex subtraction of s-matrix.
         """
         result = self.copy()
 
@@ -744,7 +744,7 @@ class Network:
 
     def __rsub__(self, other:'Network') -> 'Network':
         """
-        Element-wise complex subtraction of s-matrix
+        Element-wise complex subtraction of s-matrix.
 
         Returns
         -------
@@ -766,7 +766,7 @@ class Network:
 
     def __div__(self, other: 'Network') -> 'Network':
         """
-        Element-wise complex division of s-matrix
+        Element-wise complex division of s-matrix.
 
         Returns
         -------
@@ -796,7 +796,7 @@ class Network:
 
     def __getitem__(self, key:Union[str, int, slice, Sized]) -> 'Network':
         """
-        Slices a Network object based on an index, or human readable string
+        Slices a Network object based on an index, or human readable string.
 
         Parameters
         ----------
@@ -1185,7 +1185,7 @@ class Network:
     @property
     def t(self) -> npy.ndarray:
         """
-        Scattering transfer parameters
+        Scattering transfer parameter matrix.
 
         The t-matrix [#]_ is a 3-dimensional :class:`numpy.ndarray`
         which has shape `fx2x2`, where `f` is frequency axis.
@@ -1254,7 +1254,7 @@ class Network:
     @property
     def a(self) -> npy.ndarray:
         """
-        abcd parameter matrix. Used to cascade two-ports
+        abcd parameter matrix. Used to cascade two-ports.
 
         The abcd-matrix  [#]_ is a 3-dimensional :class:`numpy.ndarray` which has shape
         `fxnxn`, where `f` is frequency axis and `n` is number of ports.
@@ -1342,7 +1342,7 @@ class Network:
     @property
     def frequency(self) -> Frequency:
         """
-        frequency information for the network.
+        Frequency information for the network.
 
         This property is a :class:`~skrf.frequency.Frequency` object.
         It holds the frequency vector, as well frequency unit, and
@@ -1385,7 +1385,7 @@ class Network:
     @property
     def inv(self) -> 'Network':
         """
-        a :class:`Network` object with 'inverse' s-parameters.
+        A :class:`Network` object with 'inverse' s-parameters.
 
         This is used for de-embedding.
         It is defined such that the inverse of the s-matrix cascaded with itself
@@ -1410,7 +1410,7 @@ class Network:
     @property
     def f(self) -> npy.ndarray:
         """
-        the frequency vector for the network, in Hz.
+        The frequency vector for the network, in Hz.
 
         Returns
         -------
@@ -1438,14 +1438,14 @@ class Network:
     @property
     def noisy(self) -> bool:
       """
-      whether this network has noise
+      Whether this network has noise.
       """
       return self.noise is not None and self.noise_freq is not None
 
     @property
     def n(self) -> npy.ndarray:
         """
-        the ABCD form of the noise correlation matrix for the network
+        The ABCD form of the noise correlation matrix for the network.
         """
         if not self.noisy:
             raise ValueError('network does not have noise')
@@ -1465,7 +1465,7 @@ class Network:
     @property
     def f_noise(self) -> Frequency:
       """
-      the frequency vector for the noise of the network, in Hz.
+      The frequency vector for the noise of the network, in Hz.
       """
       if not self.noisy:
         raise ValueError('network does not have noise')
@@ -1474,7 +1474,7 @@ class Network:
     @property
     def y_opt(self) -> npy.ndarray:
       """
-      the optimum source admittance to minimize noise
+      The optimum source admittance to minimize noise.
       """
       noise = self.n
       return (npy.sqrt(noise[:,1,1]/noise[:,0,0] - npy.square(npy.imag(noise[:,0,1]/noise[:,0,0])))
@@ -1483,21 +1483,21 @@ class Network:
     @property
     def z_opt(self) -> npy.ndarray:
       """
-      the optimum source impedance to minimize noise
+      The optimum source impedance to minimize noise.
       """
       return 1./self.y_opt
 
     @property
     def g_opt(self) -> npy.ndarray:
       """
-      the optimum source reflection coefficient to minimize noise
+      The optimum source reflection coefficient to minimize noise.
       """
       return z2s(self.z_opt.reshape((self.f.shape[0], 1, 1)), self.z0[:,0])[:,0,0]
 
     @property
     def nfmin(self) -> npy.ndarray:
       """
-      the minimum noise figure for the network
+      The minimum noise figure for the network.
       """
       noise = self.n
       return npy.real(1. + (noise[:,0,1] + noise[:,0,0] * npy.conj(self.y_opt))/(2*K_BOLTZMANN*T0))
@@ -1505,13 +1505,13 @@ class Network:
     @property
     def nfmin_db(self) -> npy.ndarray:
       """
-      the minimum noise figure for the network in dB
+      The minimum noise figure for the network in dB.
       """
       return mf.complex_2_db10(self.nfmin)
 
     def nf(self, z: NumberLike) -> npy.ndarray:
       """
-      the noise figure for the network if the source impedance is z
+      The noise figure for the network if the source impedance is z.
       """
       z0 = self.z0
       y_opt = self.y_opt
@@ -1524,7 +1524,7 @@ class Network:
 
     def nfdb_gs(self, gs: NumberLike) -> npy.ndarray:
       """
-      return dB(NF) foreach gamma_source x noise_frequency
+      Return dB(NF) foreach gamma_source x noise_frequency.
       """
       g = self.copy().s11
       nfreq = self.noise_freq.npoints
@@ -1545,7 +1545,7 @@ class Network:
     @property
     def rn(self) -> npy.ndarray:
       """
-      the equivalent noise resistance for the network
+      The equivalent noise resistance for the network.
       """
       return npy.real(self.n[:,0,0]/(4.*K_BOLTZMANN*T0))
 
@@ -1553,7 +1553,7 @@ class Network:
     @property
     def number_of_ports(self) -> int:
         """
-        the number of ports the network has.
+        The number of ports the network has.
 
         Returns
         -------
@@ -1569,7 +1569,7 @@ class Network:
     @property
     def nports(self) -> int:
         """
-        the number of ports the network has.
+        The number of ports the network has.
 
         Returns
         -------
@@ -1582,10 +1582,10 @@ class Network:
     @property
     def port_tuples(self) -> List[Tuple[int, int]]:
         """
-        Returns a list of tuples, for each port index pair
+        Returns a list of tuples, for each port index pair.
 
         A convenience function for the common task for iterating over
-        all s-parameters index pairs
+        all s-parameters index pairs.
 
         This just calls::
 
@@ -1608,7 +1608,7 @@ class Network:
     @property
     def passivity(self) -> ndarray:
         r"""
-        passivity metric for a multi-port network.
+        Passivity metric for a multi-port network.
 
         This returns a matrix who's diagonals are equal to the total
         power received at all ports, normalized to the power at a single
@@ -1645,7 +1645,7 @@ class Network:
     @property
     def reciprocity(self) -> npy.ndarray:
         """
-        reciprocity metric for a multi-port network.
+        Reciprocity metric for a multi-port network.
 
         This returns the difference between the s-parameter matrix
         and its transpose.
@@ -1687,7 +1687,7 @@ class Network:
     @property
     def stability(self) -> npy.ndarray:
         """
-        Stability factor
+        Stability factor.
 
         .. math::
 
@@ -1716,7 +1716,7 @@ class Network:
     @property
     def max_stable_gain(self) -> npy.ndarray:
         r"""
-        Maximum stable power gain (in linear)
+        Maximum stable power gain (in linear).
 
         .. math::
 
@@ -1747,7 +1747,7 @@ class Network:
     @property
     def max_gain(self) -> npy.ndarray:
         r"""
-        Maximum available power gain for K > 1 and maximum stable power gain for K <= 1 (in linear)
+        Maximum available power gain for K > 1 and maximum stable power gain for K <= 1 (in linear).
 
         .. math::
 
@@ -1763,7 +1763,7 @@ class Network:
         ----
         The maximum available power gain is defined for a unconditionally stable network (K > 1).
         For K <= 1, this property returns the maximum stable gain instead.
-        This behavior is similarly to the max_gain() function in Keysight's Advanced Desigh System (but differs in decibel or linear) [3]_.
+        This behavior is similar to the max_gain() function in Keysight's Advanced Design System (but differs in decibel or linear) [3]_.
 
         References
         ----------
@@ -1790,7 +1790,7 @@ class Network:
     @property
     def unilateral_gain(self) -> npy.ndarray:
         r"""
-        Mason's unilateral power gain (in linear)
+        Mason's unilateral power gain (in linear).
 
         .. math::
 
@@ -1823,7 +1823,7 @@ class Network:
     @property
     def group_delay(self) -> npy.ndarray:
         """
-        The group delay
+        Group delay.
 
         Usually used as a measure of dispersion (or distortion).
 
@@ -1854,7 +1854,7 @@ class Network:
     ## NETWORK CLASSIFIERs
     def is_reciprocal(self, tol: float = mf.ALMOST_ZERO) -> bool:
         """
-        Test for reciprocity
+        Test for reciprocity.
 
         Parameters
         ----------
@@ -1874,7 +1874,7 @@ class Network:
 
     def is_symmetric(self, n: int = 1, port_order: Dict[int, int] = {}, tol: float = mf.ALMOST_ZERO) -> bool:
         """
-        Returns whether the 2N-port network has n-th order reflection symmetry by checking
+        Returns whether the 2N-port network has n-th order reflection symmetry by checking.
         :math:`S_{i,i} == S_{j,j}` for appropriate pair(s) of :math:`i` and :math:`j`.
 
         Parameters
@@ -1935,7 +1935,7 @@ class Network:
 
     def is_passive(self, tol: float = mf.ALMOST_ZERO) -> bool:
         """
-        Test for passivity
+        Test for passivity.
 
         Parameters
         ----------
@@ -1962,7 +1962,7 @@ class Network:
 
     def is_lossless(self, tol: float = mf.ALMOST_ZERO) -> bool:
         """
-        Test for losslessness
+        Test for losslessness.
 
         [S] is lossless if [S] is unitary, i.e. if :math:`([S][S]^* = [1])`
 
@@ -1993,7 +1993,7 @@ class Network:
     ## CLASS METHODS
     def copy(self) -> 'Network':
         """
-        Returns a copy of this Network
+        Returns a copy of this Network.
 
         Needed to allow pass-by-value for a Network instead of
         pass-by-reference
@@ -2027,7 +2027,7 @@ class Network:
 
     def copy_from(self, other: 'Network') -> None:
         """
-        Copies the contents of another Network into self
+        Copies the contents of another Network into self.
 
         Uses copy, so that the data is passed-by-value, not reference
 
@@ -2047,7 +2047,7 @@ class Network:
 
     def copy_subset(self, key: npy.ndarray) -> 'Network':
         """
-        Returns a copy of a frequency subset of this Network
+        Returns a copy of a frequency subset of this Network.
 
         Needed to allow pass-by-value for a subset Network instead of
         pass-by-reference
@@ -2084,7 +2084,8 @@ class Network:
         return ntwk
 
     def drop_non_monotonic_increasing(self) -> None:
-        """Drop invalid values based on duplicate and non increasing frequency values
+        """
+        Drop invalid values based on duplicate and non increasing frequency values.
 
         Example
         -------
@@ -2120,7 +2121,7 @@ class Network:
     def set_noise_a(self, noise_freq: Frequency = None, nfmin_db: float = 0,
         gamma_opt: float = 0, rn: NumberLike = 1 ) -> None:
           """
-          sets the "A" (ie cascade) representation of the correlation matrix, based on the
+          Sets the "A" (ie cascade) representation of the correlation matrix, based on the
           noise frequency and input parameters.
           """
           sh_fr = noise_freq.f.shape
@@ -2146,7 +2147,7 @@ class Network:
     def read_touchstone(self, filename: Union[str, TextIO],
                         encoding: Union[str, None] = None) -> None:
         """
-        loads values from a touchstone file.
+        Loads values from a touchstone file.
 
         The work of this function is done through the
         :class:`~skrf.io.touchstone` class.
@@ -2161,7 +2162,7 @@ class Network:
 
         Note
         ----
-        Only the scattering parameters format is supported at the moment
+        Only the scattering parameters format is supported at the moment.
 
 
         """
@@ -2231,7 +2232,7 @@ class Network:
     @classmethod
     def zipped_touchstone(cls, filename: str, archive: zipfile.ZipFile) -> 'Network':
         """
-        read a Network from a Touchstone file in a ziparchive
+        Read a Network from a Touchstone file in a ziparchive.
 
         Parameters
         ----------
@@ -2373,11 +2374,11 @@ class Network:
 
         # add formatting to funcA and funcB so we don't have to write it out many many times.
         def c2str_A(c: NumberLike) -> str:
-            """Take a complex number for the A part of param and return an appropriately formatted string"""
+            """Take a complex number for the A part of param and return an appropriately formatted string."""
             return format_spec_A.format(funcA(c))
 
         def c2str_B(c: NumberLike) -> str:
-            """Take a complex number for B part of param and return an appropriately formatted string"""
+            """Take a complex number for B part of param and return an appropriately formatted string."""
             return format_spec_B.format(funcB(c))
 
         def get_buffer() -> io.StringIO:
@@ -2587,7 +2588,7 @@ class Network:
 
     def read(self, *args, **kwargs) -> None:
         r"""
-        Read a Network from a 'ntwk' file
+        Read a Network from a 'ntwk' file.
 
         A ntwk file is written with :func:`write`. It is just a pickled
         file.
@@ -2680,7 +2681,7 @@ class Network:
                     coords: str = 'cart', f_kwargs: dict = {}, return_array: bool = False,
                     **kwargs) -> Union['Network', npy.ndarray]:
         r"""
-        Interpolate a Network along frequency axis
+        Interpolate a Network along frequency axis.
 
         The input 'freq_or_n` can be either a new
         :class:`~skrf.frequency.Frequency` or an `int`, or a new
@@ -3268,7 +3269,7 @@ class Network:
 
         >>> bar.renumber( [0,1,2], [1,2,0] )
 
-        To swap the first and last ports of a N-port (N>=2) Network 'duck':
+        To swap the first and last ports of an N-port (N>=2) Network 'duck':
 
         >>> duck.renumber( [0,-1], [-1,0] )
 
@@ -3373,7 +3374,7 @@ class Network:
         When using time domain through :attr:`s_time_db`,
         or similar properties, the spectrum is usually windowed,
         before the IFFT is taken. This is done to
-        compensate for the band-pass nature of a spectrum [#]_ .
+        compensate for the band-pass nature of a spectrum [#]_.
 
         This function calls :func:`scipy.signal.get_window` which gives
         more details about the windowing.
@@ -3431,7 +3432,7 @@ class Network:
 
     def time_gate(self, *args, **kw) -> 'Network':
         """
-        Time gate this Network
+        Time gate this Network.
 
         Returns
         -------
@@ -3446,7 +3447,7 @@ class Network:
     # noise
     def add_noise_polar(self, mag_dev: float, phase_dev: float, **kwargs) -> None:
         """
-        adds a complex zero-mean gaussian white-noise.
+        Adds a complex zero-mean gaussian white-noise.
 
         adds a complex zero-mean gaussian white-noise of a given
         standard deviation for magnitude and phase
@@ -3469,8 +3470,8 @@ class Network:
 
     def add_noise_polar_flatband(self, mag_dev: float, phase_dev: float, **kwargs) -> None:
         """
-        adds a flatband complex zero-mean gaussian white-noise signal of
-        given standard deviations for magnitude and phase
+        Adds a flatband complex zero-mean gaussian white-noise signal of
+        given standard deviations for magnitude and phase.
 
         Parameters
         ----------
@@ -3489,9 +3490,9 @@ class Network:
 
     def multiply_noise(self, mag_dev: float, phase_dev: float, **kwargs) -> None:
         """
-        multiplies a complex bivariate gaussian white-noise signal
+        Multiplies a complex bivariate gaussian white-noise signal
         of given standard deviations for magnitude and phase.
-        magnitude mean is 1, phase mean is 0
+        magnitude mean is 1, phase mean is 0.
 
         Parameters
         ----------
@@ -3537,7 +3538,7 @@ class Network:
     # other
     def func_on_parameter(self, func: Callable, attr: str = 's', *args, **kwargs) -> 'Network':
         r"""
-        Applies a function parameter matrix, one frequency slice at a time
+        Applies a function parameter matrix, one frequency slice at a time.
 
         This is useful for functions that can only operate on 2d arrays,
         like numpy.linalg.inv. This loops over f and calls
@@ -3575,7 +3576,7 @@ class Network:
         r"""
         Normalized non-reciprocity metric.
 
-        This is a port-by-port measure of how non-reciprocal a n-port
+        This is a port-by-port measure of how non-reciprocal an n-port
         network is. It is defined by,
 
         .. math::
@@ -3609,7 +3610,7 @@ class Network:
     # generalized mixed mode transformations
     def se2gmm(self, p: int, z0_mm: npy.ndarray = None, s_def : str = None) -> None:
         """
-        Transform network from single ended parameters to generalized mixed mode parameters [#]_
+        Transform network from single ended parameters to generalized mixed mode parameters [#]_.
 
         Parameters
         ----------
@@ -3762,7 +3763,7 @@ class Network:
 
     def gmm2se(self, p: int, z0_se: NumberLike = None, s_def : str = None) -> None:
         """
-        Transform network from generalized mixed mode parameters [#]_ to single ended parameters
+        Transform network from generalized mixed mode parameters [#]_ to single ended parameters.
 
         Parameters
         ----------
@@ -4488,7 +4489,7 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
 
 def connect_fast(ntwkA: Network, k: int, ntwkB: Network, l: int) -> Network:
     """
-    Alias for connect
+    Alias for connect.
 
     Parameters
     ----------
@@ -4513,7 +4514,7 @@ def connect_fast(ntwkA: Network, k: int, ntwkB: Network, l: int) -> Network:
 
 def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
     """
-    connect ports of a single n-port network.
+    Connect ports of a single n-port network.
 
     this results in a (n-2)-port network. remember port indices start
     from 0.
@@ -4642,7 +4643,7 @@ def cascade(ntwkA: Network, ntwkB: Network) -> Network:
 
     N = int(ntwkA.nports/2 )
     if ntwkB.nports == 1:
-        # we are terminating a N-port with a 1-port.
+        # we are terminating an N-port with a 1-port.
         # which port on self to use is ambiguous. choose N
         return connect(ntwkA, N, ntwkB, 0)
 
@@ -4651,7 +4652,7 @@ def cascade(ntwkA: Network, ntwkB: Network) -> Network:
         return connect(ntwkA, N, ntwkB, 0, num=N)
 
     elif ntwkA.nports % 2 == 0 and ntwkA.nports == 2 * ntwkB.nports:
-        # we have a 2N-port balanced network terminated by a N-port network
+        # we have a 2N-port balanced network terminated by an N-port network
         return connect(ntwkA, N, ntwkB, 0, num=N)
 
     else:
@@ -4661,7 +4662,7 @@ def cascade(ntwkA: Network, ntwkB: Network) -> Network:
 
 def cascade_list(l: Sequence[Network]) -> Network:
     """
-    cascade a list of 2N-port networks
+    Cascade a list of 2N-port networks.
 
     all networks must have same frequency
 
@@ -4817,7 +4818,7 @@ def overlap_multi(ntwk_list: Sequence[Network]):
 def concat_ports(ntwk_list: Sequence[Network], port_order: str = 'second',
         *args, **kw) -> Network:
     """
-    Concatenate networks along the port axis
+    Concatenate networks along the port axis.
 
 
     Note
@@ -5058,9 +5059,9 @@ def chopinhalf(ntwk: Network, *args, **kwargs) -> Network:
 def evenodd2delta(n: Network, z0: NumberLike = 50, renormalize: bool = True,
         doublehalf: bool = True) -> Network:
     """
-    Convert ntwk's s-matrix from even/odd mode into a delta (normal) s-matrix
+    Convert ntwk's s-matrix from even/odd mode into a delta (normal) s-matrix.
 
-    This assumes even/odd ports are ordered [1e,1o,2e,2o]
+    This assumes even/odd ports are ordered [1e,1o,2e,2o].
 
     This is useful for handling coupler sims. Only 4-ports supported for now.
 
@@ -5173,7 +5174,7 @@ def subnetwork(ntwk: Network, ports: int, offby:int = 1) -> Network:
 ## Building composit networks from sub-networks
 def n_oneports_2_nport(ntwk_list: Sequence[Network], *args, **kwargs) -> Network:
     r"""
-    Builds a N-port Network from list of N one-ports
+    Builds an N-port Network from list of N one-ports.
 
     Parameters
     ----------
@@ -5203,9 +5204,9 @@ def n_oneports_2_nport(ntwk_list: Sequence[Network], *args, **kwargs) -> Network
 def n_twoports_2_nport(ntwk_list: Sequence[Network], nports: int,
         offby:int = 1, **kwargs) -> Network:
     r"""
-    Builds a N-port Network from list of two-ports
+    Builds an N-port Network from list of two-ports.
 
-    This  method was made to reconstruct a n-port network from 2-port
+    This  method was made to reconstruct an n-port network from 2-port
     subnetworks as measured by a 2-port VNA. So, for example, given a
     3-port DUT, you  might measure the set p12.s2p, p23.s2p, p13.s2p.
     From these measurements, you can construct p.s3p.
@@ -5259,7 +5260,7 @@ def n_twoports_2_nport(ntwk_list: Sequence[Network], nports: int,
 
 def four_oneports_2_twoport(s11: Network, s12: Network, s21: Network, s22: Network, *args, **kwargs) -> Network:
     r"""
-    Builds a 2-port Network from list of four 1-ports
+    Builds a 2-port Network from list of four 1-ports.
 
     Parameters
     ----------
@@ -5290,7 +5291,7 @@ def four_oneports_2_twoport(s11: Network, s12: Network, s21: Network, s22: Netwo
 def three_twoports_2_threeport(ntwk_triplet: Sequence[Network], auto_order:bool = True, *args,
                                **kwargs) -> Network:
     r"""
-    Creates 3-port from  three 2-port Networks
+    Creates 3-port from  three 2-port Networks.
 
     This function provides a convenient way to build a 3-port Network
     from a set of 2-port measurements. Which may occur when measuring
@@ -5445,7 +5446,7 @@ def connect_s(A: npy.ndarray, k: int, B: npy.ndarray, l: int) -> npy.ndarray:
 
 def innerconnect_s(A: npy.ndarray, k: int, l: int) -> npy.ndarray:
     """
-    connect two ports of a single n-port network's s-matrix.
+    Connect two ports of a single n-port network's s-matrix.
 
     Specifically, connect port `k`  to port `l` on `A`. This results in
     a (n-2)-port network.  This     function operates on, and returns
@@ -5516,7 +5517,7 @@ def innerconnect_s(A: npy.ndarray, k: int, l: int) -> npy.ndarray:
 ## network parameter conversion
 def s2z(s: npy.ndarray, z0: NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.ndarray:
     r"""
-    Convert scattering parameters [#]_ to impedance parameters [#]_
+    Convert scattering parameters [#]_ to impedance parameters [#]_.
 
 
     For power-waves, Eq.(19) from [#Kurokawa]_:
@@ -5608,7 +5609,7 @@ def s2z(s: npy.ndarray, z0: NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.
 
 def s2y(s: npy.ndarray, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.ndarray:
     """
-    convert scattering parameters [#]_ to admittance parameters [#]_
+    Convert scattering parameters [#]_ to admittance parameters [#]_.
 
     Equations are the inverse of :func:`s2z`.
 
@@ -5705,7 +5706,7 @@ def s2y(s: npy.ndarray, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.n
 
 def s2t(s: npy.ndarray) -> npy.ndarray:
     """
-    Converts scattering parameters [#]_ to scattering transfer parameters [#]_ .
+    Converts scattering parameters [#]_ to scattering transfer parameters [#]_.
 
     transfer parameters are also referred to as
     'wave cascading matrix' [#]_, this function only operates on 2N-ports
@@ -5882,7 +5883,7 @@ def s2s(s: NumberLike, z0: NumberLike, s_def_new: str, s_def_old: str):
 
 def z2s(z: NumberLike, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.ndarray:
     r"""
-    convert impedance parameters [#]_ to scattering parameters [#]_
+    Convert impedance parameters [#]_ to scattering parameters [#]_.
 
     For power-waves, Eq.(18) from [#Kurokawa]_:
 
@@ -5971,7 +5972,7 @@ def z2s(z: NumberLike, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> npy.nd
 
 def z2y(z: npy.ndarray) -> npy.ndarray:
     """
-    convert impedance parameters [#]_ to admittance parameters [#]_
+    Convert impedance parameters [#]_ to admittance parameters [#]_.
 
 
     .. math::
@@ -6015,9 +6016,9 @@ def z2y(z: npy.ndarray) -> npy.ndarray:
 
 def z2t(z: npy.ndarray) -> NoReturn:
     """
-    Not Implemented yet
+    Not Implemented yet.
 
-    convert impedance parameters [#]_ to scattering transfer parameters [#]_
+    Convert impedance parameters [#]_ to scattering transfer parameters [#]_.
 
 
     Parameters
@@ -6060,7 +6061,7 @@ def z2t(z: npy.ndarray) -> NoReturn:
 
 def a2s(a: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
     """
-    convert abcd parameters to s parameters
+    Convert abcd parameters to s parameters.
 
     Parameters
     ----------
@@ -6107,7 +6108,7 @@ def a2s(a: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def a2z(a: npy.ndarray) -> npy.ndarray:
     """
-    Converts abcd parameters to z parameters [#]_ .
+    Converts abcd parameters to z parameters [#]_.
 
 
     Parameters
@@ -6151,7 +6152,7 @@ def a2z(a: npy.ndarray) -> npy.ndarray:
 
 def z2a(z: npy.ndarray) -> npy.ndarray:
     """
-    Converts impedance parameters to abcd  parameters [#]_ .
+    Converts impedance parameters to abcd  parameters [#]_.
 
 
     Parameters
@@ -6200,7 +6201,7 @@ def z2a(z: npy.ndarray) -> npy.ndarray:
 
 def s2a(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
     """
-    Converts scattering parameters to abcd parameters [#]_ .
+    Converts scattering parameters to abcd parameters [#]_.
 
     Parameters
     ----------
@@ -6244,7 +6245,7 @@ def s2a(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def y2s(y: npy.ndarray, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> Network:
     r"""
-    convert admittance parameters [#]_ to scattering parameters [#]_
+    Convert admittance parameters [#]_ to scattering parameters [#]_.
 
     For power-waves, from [#Kurokawa]_:
 
@@ -6358,7 +6359,7 @@ def y2s(y: npy.ndarray, z0:NumberLike = 50, s_def: str = S_DEF_DEFAULT) -> Netwo
 
 def y2z(y: npy.ndarray) -> npy.ndarray:
     """
-    convert admittance parameters [#]_ to impedance parameters [#]_
+    Convert admittance parameters [#]_ to impedance parameters [#]_.
 
     .. math::
 
@@ -6403,9 +6404,9 @@ def y2z(y: npy.ndarray) -> npy.ndarray:
 
 def y2t(y: npy.ndarray) -> NoReturn:
     """
-    Not Implemented Yet
+    Not Implemented Yet.
 
-    convert admittance parameters [#]_ to scattering-transfer parameters [#]_
+    Convert admittance parameters [#]_ to scattering-transfer parameters [#]_.
 
 
     Parameters
@@ -6447,7 +6448,7 @@ def y2t(y: npy.ndarray) -> NoReturn:
 
 def t2s(t: npy.ndarray) -> npy.ndarray:
     """
-    converts scattering transfer parameters [#]_ to scattering parameters [#]_
+    Converts scattering transfer parameters [#]_ to scattering parameters [#]_.
 
     transfer parameters are also referred to as
     'wave cascading matrix', this function only operates on 2N-ports
@@ -6516,9 +6517,9 @@ def t2s(t: npy.ndarray) -> npy.ndarray:
 
 def t2z(t: npy.ndarray) -> NoReturn:
     """
-    Not Implemented Yet
+    Not Implemented Yet.
 
-    Convert scattering transfer parameters [#]_ to impedance parameters [#]_
+    Convert scattering transfer parameters [#]_ to impedance parameters [#]_.
 
 
     Parameters
@@ -6560,9 +6561,9 @@ def t2z(t: npy.ndarray) -> NoReturn:
 
 def t2y(t: npy.ndarray) -> NoReturn:
     """
-    Not Implemented Yet
+    Not Implemented Yet.
 
-    Convert scattering transfer parameters to admittance parameters [#]_
+    Convert scattering transfer parameters to admittance parameters [#]_.
 
 
     Parameters
@@ -6604,7 +6605,7 @@ def t2y(t: npy.ndarray) -> NoReturn:
 
 def h2z(h: npy.ndarray) -> npy.ndarray:
     """
-    Converts hybrid parameters to z parameters [#]_ .
+    Converts hybrid parameters to z parameters [#]_.
 
 
     Parameters
@@ -6648,7 +6649,7 @@ def h2z(h: npy.ndarray) -> npy.ndarray:
 
 def h2s(h: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
     """
-    convert hybrid parameters to s parameters
+    Convert hybrid parameters to s parameters.
 
     Parameters
     ----------
@@ -6669,7 +6670,7 @@ def h2s(h: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def s2h(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
     """
-    Convert scattering parameters [#]_ to hybrid parameters [#]_
+    Convert scattering parameters [#]_ to hybrid parameters [#]_.
 
 
     Parameters
@@ -6697,7 +6698,7 @@ def s2h(s: npy.ndarray, z0: NumberLike = 50) -> npy.ndarray:
 
 def z2h(z: npy.ndarray) -> npy.ndarray:
     """
-    Converts impedance parameters to hybrid parameters [#]_ .
+    Converts impedance parameters to hybrid parameters [#]_.
 
 
     Parameters
@@ -6925,7 +6926,7 @@ def renormalize_s(
 
 def fix_param_shape(p: NumberLike):
     """
-    This attempts to broadcast p to satisfy
+    Attempts to broadcast p to satisfy.
         npy.shape(p) == (nfreqs, nports, nports)
 
     Parameters
@@ -6963,7 +6964,7 @@ def fix_param_shape(p: NumberLike):
 
 def fix_z0_shape(z0: NumberLike, nfreqs: int, nports: int) -> npy.ndarray:
     """
-    Make a port impedance of correct shape for a given network's matrix
+    Make a port impedance of correct shape for a given network's matrix.
 
     This attempts to broadcast z0 to satisfy
         npy.shape(z0) == (nfreqs,nports)
@@ -7023,7 +7024,7 @@ def fix_z0_shape(z0: NumberLike, nfreqs: int, nports: int) -> npy.ndarray:
 ## cascading assistance functions
 def inv(s: npy.ndarray) -> npy.ndarray:
     """
-    Calculates 'inverse' s-parameter matrix, used for de-embedding
+    Calculates 'inverse' s-parameter matrix, used for de-embedding.
 
     This is not literally the inverse of the s-parameter matrix.
     Instead, it is defined such that the inverse of the s-matrix cascaded
@@ -7069,7 +7070,7 @@ def flip(a: npy.ndarray) -> npy.ndarray:
     """
     Invert the ports of a networks s-matrix, 'flipping' it over left and right.
 
-    in case the network is 2n-port and n > 1, 'second' numbering scheme is
+    In case the network is 2n-port and n > 1, 'second' numbering scheme is
     assumed to be consistent with the ** cascade operator::
 
          +--------+                 +--------+
@@ -7116,7 +7117,7 @@ def flip(a: npy.ndarray) -> npy.ndarray:
 ## COMMON CHECKS (raise exceptions)
 def check_frequency_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    checks if two Networks have same frequency
+    Checks if two Networks have same frequency.
     """
     if assert_frequency_equal(ntwkA, ntwkB) is False:
         raise IndexError('Networks don\'t have matching frequency. See `Network.interpolate`')
@@ -7132,7 +7133,7 @@ def check_frequency_exist(ntwk) -> None:
 
 def check_z0_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    checks if two Networks have same port impedances
+    Checks if two Networks have same port impedances.
     """
     # note you should check frequency equal before you call this
     if assert_z0_equal(ntwkA, ntwkB) is False:
@@ -7141,7 +7142,7 @@ def check_z0_equal(ntwkA: Network, ntwkB: Network) -> None:
 
 def check_nports_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
-    checks if two Networks have same number of ports
+    Checks if two Networks have same number of ports.
     """
     if assert_nports_equal(ntwkA, ntwkB) is False:
         raise ValueError('Networks don\'t have matching number of ports.')
@@ -7189,7 +7190,7 @@ def assert_nports_equal(ntwkA: Network, ntwkB: Network) -> bool:
 # this is needed for port impedance mismatches
 def impedance_mismatch(z1: NumberLike, z2: NumberLike, s_def: str = 'traveling') -> npy.ndarray:
     """
-    creates a two-port s-matrix for a impedance mis-match
+    Creates a two-port s-matrix for a impedance mis-match.
 
     Parameters
     ----------

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -915,7 +915,7 @@ class Network:
     # INTERNAL CODE GENERATION METHODS
     def __compatable_for_scalar_operation_test(self, other:'Network') -> None:
         """
-        test to make sure other network's s-matrix is of same shape
+        Test to make sure other network's s-matrix is of same shape.
         """
         if other.frequency != self.frequency:
             raise IndexError('Networks must have same frequency. See `Network.interpolate`')
@@ -1372,7 +1372,7 @@ class Network:
     @frequency.setter
     def frequency(self, new_frequency: Union[Frequency, int, Sequence[float], npy.ndarray]) -> None:
         """
-        take a Frequency object, see frequency.py
+        Take a Frequency object, see frequency.py.
         """
         if isinstance(new_frequency, Frequency):
             self._frequency = new_frequency.copy()
@@ -3470,7 +3470,7 @@ class Network:
 
     def add_noise_polar_flatband(self, mag_dev: float, phase_dev: float, **kwargs) -> None:
         """
-        Adds a flatband complex zero-mean gaussian white-noise signal of
+        Add a flatband complex zero-mean gaussian white-noise signal of
         given standard deviations for magnitude and phase.
 
         Parameters

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -560,7 +560,7 @@ def plot_smith(s: NumberLike, smith_r: float = 1, chart_type: str = 'z',
                force_chart: bool = False, draw_vswr: Union[List, bool, None] = None, draw_labels: bool = False,
                *args, **kwargs):
     r"""
-    plot complex data on smith chart.
+    Plot complex data on smith chart.
 
     Parameters
     ------------
@@ -786,7 +786,7 @@ def legend_off(ax: Union[plt.Axes, None] = None):
     """
     Turn off the legend for a given axes.
 
-    if no axes is given then it will use current axes.
+    If no axes is given then it will use current axes.
 
     Parameters
     ----------
@@ -838,7 +838,7 @@ def func_on_all_figs(func: Callable, *args, **kwargs):
     r"""
     Run a function after making all open figures current.
 
-    useful if you need to change the properties of many open figures
+    Useful if you need to change the properties of many open figures
     at once, like turn off the grid.
 
     Parameters
@@ -992,7 +992,7 @@ def __generate_plot_functions(self):
             #     plt.show()
 
         plot_prop_polar.__doc__ = r"""
-plot the Network attribute :attr:`{}` vs frequency.
+Plot the Network attribute :attr:`{}` vs frequency.
 
 Parameters
 ----------
@@ -1082,7 +1082,7 @@ Examples
             #    plt.show()
 
         plot_prop_rect.__doc__ = r"""
-plot the Network attribute :attr:`{}` vs frequency.
+Plot the Network attribute :attr:`{}` vs frequency.
 
 Parameters
 ----------
@@ -1237,7 +1237,7 @@ Examples
                 #    #plt.show()
 
             plot_func.__doc__ = r"""
-    plot the Network attribute :attr:`%s` vs frequency.
+    Plot the Network attribute :attr:`%s` vs frequency.
 
     Parameters
     ----------
@@ -1396,7 +1396,7 @@ def plot_reciprocity2(self, db=False, *args, **kwargs):
     """
     Plot reciprocity metric #2.
 
-    this is distance of the determinant of the wave-cascading matrix
+    This is distance of the determinant of the wave-cascading matrix
     from unity.
 
     .. math::
@@ -1432,9 +1432,9 @@ def plot_s_db_time(self, *args, window: Union[str, float, Tuple[str, float]]=('k
 def plot_s_smith(self, m=None, n=None,r=1, ax=None, show_legend=True,\
         chart_type='z', draw_labels=False, label_axes=False, draw_vswr=None, *args,**kwargs):
     r"""
-    plots the scattering parameter on a smith chart
+    Plots the scattering parameter on a smith chart.
 
-    plots indices `m`, `n`, where `m` and `n` can be integers or
+    Plots indices `m`, `n`, where `m` and `n` can be integers or
     lists of integers.
 
 
@@ -1760,7 +1760,7 @@ def plot_uncertainty_bounds_component(
 
         mean(|s|) \pm std(|s|)
 
-    the order of mean and abs is important.
+    The order of mean and abs is important.
 
 
     Parameters
@@ -1796,7 +1796,7 @@ def plot_uncertainty_bounds_component(
 
     Note
     ----
-    for phase uncertainty you probably want s_deg_unwrap, or
+    For phase uncertainty you probably want s_deg_unwrap, or
     similar. uncertainty for wrapped phase blows up at +-pi.
 
     """
@@ -1871,16 +1871,16 @@ def plot_minmax_bounds_component(self, attribute: str, m: int = 0, n: int = 0,
                                  ppf: bool = None, kwargs_error: dict = {},
                                  *args, **kwargs):
     r"""
-    plots mean value of the NetworkSet with +/- uncertainty bounds in an Network's attribute.
+    Plots mean value of the NetworkSet with +/- uncertainty bounds in an Network's attribute.
 
-    This is designed to represent uncertainty in a scalar component of the s-parameter. for example
+    This is designed to represent uncertainty in a scalar component of the s-parameter. For example
     plotting the uncertainty in the magnitude would be expressed by
 
     .. math::
 
         mean(|s|) \pm std(|s|)
 
-    the order of mean and abs is important.
+    The order of mean and abs is important.
 
     Parameters
     ----------
@@ -1915,8 +1915,8 @@ def plot_minmax_bounds_component(self, attribute: str, m: int = 0, n: int = 0,
 
     Note
     ----
-    for phase uncertainty you probably want s_deg_unwrap, or
-    similar.  uncertainty for wrapped phase blows up at +-pi.
+    For phase uncertainty you probably want s_deg_unwrap, or
+    similar.  Uncertainty for wrapped phase blows up at +-pi.
 
     """
 
@@ -1972,7 +1972,7 @@ def plot_uncertainty_bounds_s_db(self, *args, **kwargs):
     """
     Call ``plot_uncertainty_bounds(attribute='s_mag','ppf':mf.magnitude_2_db*args,**kwargs)``.
 
-    see plot_uncertainty_bounds for help
+    See plot_uncertainty_bounds for help.
 
     """
     kwargs.update({'attribute':'s_mag','ppf':mf.magnitude_2_db})
@@ -1982,7 +1982,7 @@ def plot_minmax_bounds_s_db(self, *args, **kwargs):
     """
     Call ``plot_uncertainty_bounds(attribute= 's_mag','ppf':mf.magnitude_2_db*args,**kwargs)``.
 
-    see plot_uncertainty_bounds for help
+    See plot_uncertainty_bounds for help.
 
     """
     kwargs.update({'attribute':'s_mag','ppf':mf.magnitude_2_db})
@@ -2002,7 +2002,7 @@ def plot_uncertainty_bounds_s_time_db(self, *args, **kwargs):
     """
     Call ``plot_uncertainty_bounds(attribute= 's_mag','ppf':mf.magnitude_2_db*args,**kwargs)``.
 
-    see plot_uncertainty_bounds for help
+    See plot_uncertainty_bounds for help.
 
     """
     kwargs.update({'attribute':'s_time_mag','ppf':mf.magnitude_2_db})
@@ -2012,7 +2012,7 @@ def plot_minmax_bounds_s_time_db(self, *args, **kwargs):
     """
     Call ``plot_uncertainty_bounds(attribute= 's_mag','ppf':mf.magnitude_2_db*args,**kwargs)``.
 
-    see plot_uncertainty_bounds for help
+    See plot_uncertainty_bounds for help.
 
     """
     kwargs.update({'attribute':'s_time_mag','ppf':mf.magnitude_2_db})


### PR DESCRIPTION
I have corrected the formatting of the Network and Plotting API documentation.
The format mimics the Numpy API documentation as follows
- Capitalize the beginning of a sentence
- Add a period at the end of a sentence
- When starting a verb, do not add an s in the third person singular.