### PR TITLE
Fixed the bug that touchstone files containing noise could not be cropped.

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2075,7 +2075,7 @@ class Network:
 
         if self.noise is not None and self.noise_freq is not None:
             ntwk.noise = npy.copy(self.noise[key,:])
-            ntwk.noise_freq = npy.copy(self.noise_freq[key])
+            ntwk.noise_freq = copy(self.noise_freq[key])
 
         try:
             ntwk.port_names = copy(self.port_names)


### PR DESCRIPTION
Because self.noise_freq is an object of type skr.frequency.Frequency , but the npy.copy function should handle objects of type np.ndarray. 
So self.noise_freq needs to use deepcopy for deep copy instead of npy.copy.