### PR TITLE
Fix true-false-comparison errors.

### DIFF
--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -622,9 +622,9 @@ def statistical_2_touchstone(file_name, new_file_name=None,\
             touchstone header written to first beginning of file
 
     """
-    if new_file_name is None:
+    remove_tmp_file = new_file_name is None
+    if remove_tmp_file:
         new_file_name = 'tmp-'+file_name
-        remove_tmp_file = True
 
     # This breaks compatibility with python 2.6 and older
     with open(file_name) as old_file, open(new_file_name, 'w') as new_file:
@@ -632,7 +632,7 @@ def statistical_2_touchstone(file_name, new_file_name=None,\
         for line in old_file:
             new_file.write(line)
 
-    if remove_tmp_file is True:
+    if remove_tmp_file:
         os.rename(new_file_name,file_name)
 
 def network_2_spreadsheet(ntwk, file_name =None, file_type= 'excel', form='db',

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -7136,7 +7136,7 @@ def check_frequency_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
     Check if two Networks have same frequency.
     """
-    if assert_frequency_equal(ntwkA, ntwkB) is False:
+    if not assert_frequency_equal(ntwkA, ntwkB):
         raise IndexError('Networks don\'t have matching frequency. See `Network.interpolate`')
 
 
@@ -7144,7 +7144,7 @@ def check_frequency_exist(ntwk) -> None:
     """
     Check if a Network has a non-zero Frequency.
     """
-    if assert_frequency_exist(ntwk) is False:
+    if not assert_frequency_exist(ntwk):
         raise ValueError('Network has no Frequency. Frequency points must be defined.')
 
 
@@ -7153,7 +7153,7 @@ def check_z0_equal(ntwkA: Network, ntwkB: Network) -> None:
     Check if two Networks have same port impedances.
     """
     # note you should check frequency equal before you call this
-    if assert_z0_equal(ntwkA, ntwkB) is False:
+    if not assert_z0_equal(ntwkA, ntwkB):
         raise ValueError('Networks don\'t have matching z0.')
 
 
@@ -7161,7 +7161,7 @@ def check_nports_equal(ntwkA: Network, ntwkB: Network) -> None:
     """
     Check if two Networks have same number of ports.
     """
-    if assert_nports_equal(ntwkA, ntwkB) is False:
+    if not assert_nports_equal(ntwkA, ntwkB):
         raise ValueError('Networks don\'t have matching number of ports.')
 
 

--- a/skrf/util.py
+++ b/skrf/util.py
@@ -711,7 +711,7 @@ def unique_name(name: str, names: list, exclude: int = -1) -> str:
 
         for num in range(suffix, 100, 1):
             name = f"{name_base:s}_{num:02d}"
-            if has_duplicate_value(name, names, exclude) is False:
+            if not has_duplicate_value(name, names, exclude):
                 break
     return name
 


### PR DESCRIPTION
Commit 1228661, 'Rule E712: true-false-comparison', replaced boolean comparison `==` with boolean comparison by id `is` in some conditional statements which results in exceptions not raised and unexpected behavior.

The commit attached replaces comparison by id `fn() is False` with truthy true/false `not fn()` for conditional logic that compares the result of a callable to a boolean. It restores the original behavior (<=v0.26.0)  of the modified functions.

Cascading two networks with different frequency data is shown below to demonstrate the issue. 

#### (<=v0.26.0, attached):
The original code / attached  changes return a network with the intersecting subset of frequency data.
`skrf.connect` raises an `IndexError`  by way of `skrf.check_frequency_equal` if the frequency data is not equal and no common values are found with `np.intersect1d`. If some common values are found, a warning alerts about dropped data.
 
```python
>>> import skrf as rf, numpy as np
>>> a = rf.Network(f=[1,2,3], s=np.zeros((3,2,2),dtype='c16'))
>>> b = rf.Network(f=[4,5,6], s=np.ones((3,2,2),dtype='c16'))
>>> c = rf.Network(f=[1,3,5], s=np.ones((3,2,2),dtype='c16'))
>>> (a ** b).f
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/bec/scikit-rf/skrf/network.py", line 551, in __pow__
    return cascade(self, other)
  File "/home/bec/scikit-rf/skrf/network.py", line 4669, in cascade
    return connect(ntwkA, N, ntwkB, 0, num=N)
  File "/home/bec/scikit-rf/skrf/network.py", line 4355, in connect
    raise e
  File "/home/bec/scikit-rf/skrf/network.py", line 4351, in connect
    check_frequency_equal(ntwkA, ntwkB)
  File "/home/bec/scikit-rf/skrf/network.py", line 7140, in check_frequency_equal
    raise IndexError('Networks don\'t have matching frequency. See `Network.interpolate`')
IndexError: Networks don't have matching frequency. See `Network.interpolate`
>>> (a**c).f
/home/bec/scikit-rf/skrf/network.py:4359: UserWarning: Using a frequency subset:
1.0-3.0 GHz, 2 pts
  warnings.warn("Using a frequency subset:\n" + str(ntwkA.frequency))
array([1.e+09, 3.e+09])
```
#### (v0.27.1, v0.28.0):
In the current release `skrf.connect` always returns frequency data from the first input as a result of the conditional
`skrf.assert_frequency_equal is False` never being satisfied in the function `skrf.check_frequency_equal` and not raising the `IndexError` which is caught in `skrf.connect` to determine the shared subset of values.

```python
Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import skrf as rf, numpy as np
>>> a = rf.Network(f=[1,2,3], s=np.ones((3,2,2), dtype='c16'))
>>> b = rf.Network(f=[4,5,6], s=np.zeros((3,2,2), dtype='c16')) 
>>> c = rf.Network(f=[1,3,5], s=np.zeros((3,2,2), dtype='c16')) 
>>> (a**b).f
array([1.e+09, 2.e+09, 3.e+09])
>>> (a**c).f
array([1.e+09, 2.e+09, 3.e+09])
```





