### PR TITLE
fix switch term termination function

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -6058,11 +6058,9 @@ def terminate(ntwk, gamma_f, gamma_r):
     """
 
     m = ntwk.copy()
-    ntwk_flip = ntwk.copy()
-    ntwk_flip.flip()
 
-    m.s[:,0,0] = (ntwk**gamma_f).s[:,0,0]
-    m.s[:,1,1] = (ntwk_flip**gamma_r).s[:,0,0]
+    m.s[:,0,0] = ntwk.s[:,0,0] + ntwk.s[:,1,0]*ntwk.s[:,0,1]*gamma_f.s[:,0,0]/(1-ntwk.s[:,1,1]*gamma_f.s[:,0,0])
+    m.s[:,1,1] = ntwk.s[:,1,1] + ntwk.s[:,1,0]*ntwk.s[:,0,1]*gamma_r.s[:,0,0]/(1-ntwk.s[:,0,0]*gamma_r.s[:,0,0])
     m.s[:,1,0] = ntwk.s[:,1,0]/(1-ntwk.s[:,1,1]*gamma_f.s[:,0,0])
     m.s[:,0,1] = ntwk.s[:,0,1]/(1-ntwk.s[:,0,0]*gamma_r.s[:,0,0])
     return m


### PR DESCRIPTION
I have noticed that when terminating switch terms with zero values to a network and they have different port impedances, I get a wrong answer. Ideally, when switch terms are zero, I should get the same values of the network back. However, S11 and S22 are impacted depending on the port impedances of the network and the switch terms.

The problem comes from the fact that the function is written in such way that it performs network cascading when computing S11 and S22, which obviously results in implicit impedance transformation when the network and switch terms have different impedances.

The fix is basically to explicitly write the equations for S11 and S22 without using network cascading.

Here is a test code:
```python
import skrf as rf
import matplotlib.pyplot as plt
from skrf.media import Coaxial

freq = rf.F(1, 10, 299, 'GHz')

coax1mm = Coaxial(freq, z0_port=50, Dint=0.434e-3, Dout=1.0e-3, sigma=1e8)

# Network
X = coax1mm.line(0.1, 'm', name='X')
X.name = 'Network unterminated'
X.z0 = [60, 60]   # overwrite port impedance

# switch terms
gamma_f = coax1mm.delay_load(0.2, 21e-3, 'm')
gamma_f.z0 = 50  # overwrite port impedance

gamma_r = coax1mm.delay_load(0.25, 16e-3, 'm')
gamma_r.z0 = 50  # overwrite port impedance

gamma_f.s = gamma_f.s*0  # zero switch terms
gamma_r.s = gamma_r.s*0  # zero switch terms

X_terminated = rf.terminate(X, gamma_f, gamma_r)
X_terminated.name = 'Network terminated'

fig, axs = plt.subplots(2,1)
fig.tight_layout(pad=2)
ax= axs[0]
X.s11.plot_s_db(ax=ax)
X_terminated.s11.plot_s_db(ax=ax, linestyle='--')
ax= axs[1]
X.s11.plot_s_deg(ax=ax)
X_terminated.s11.plot_s_deg(ax=ax, linestyle='--')

fig, axs = plt.subplots(2,1)
fig.tight_layout(pad=2)
ax= axs[0]
X.s22.plot_s_db(ax=ax)
X_terminated.s22.plot_s_db(ax=ax, linestyle='--')
ax= axs[1]
X.s22.plot_s_deg(ax=ax)
X_terminated.s22.plot_s_deg(ax=ax, linestyle='--')

plt.show()
```

Which results in below plots:
![image](https://github.com/scikit-rf/scikit-rf/assets/46247580/1259606a-b197-45a8-8f11-478063f0b32f)
![image](https://github.com/scikit-rf/scikit-rf/assets/46247580/7c1a55f9-917b-426d-9fcf-431005568790)

After the fix:
![image](https://github.com/scikit-rf/scikit-rf/assets/46247580/1d343c7f-5555-480a-8627-96b8c8753241)
![image](https://github.com/scikit-rf/scikit-rf/assets/46247580/3f07e09a-0e86-4340-acd0-405ee124f83d)


