### PR TITLE
Fix network_2_dataframe for more than 10 ports

### DIFF
--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -246,7 +246,8 @@ def write(file, obj, overwrite = True):
         pickle.dump(obj, fid, protocol=2)
         fid.close()
 
-def read_all(dir: str ='.', sort = True, contains = None, f_unit = None, obj_type=None, files: list=None, recursive=False) -> dict:
+def read_all(dir: str ='.', sort = True, contains = None, f_unit = None, 
+        obj_type=None, files: list=None, recursive=False) -> dict:
     """
     Read all skrf objects in a directory.
 

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -62,7 +62,7 @@ JSON
 
 
 """
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import glob
 import inspect
@@ -712,7 +712,8 @@ def network_2_spreadsheet(ntwk: Network, file_name: str = None,
     df.__getattribute__('to_%s'%file_type)(file_name,
         index_label='Freq(%s)'%ntwk.frequency.unit, *args, **kwargs)
 
-def network_2_dataframe(ntwk: Network, attrs: List[str] =['s_db'], ports: List[Tuple[int, int]] = None):
+def network_2_dataframe(ntwk: Network, attrs: List[str] =['s_db'], 
+        ports: List[Tuple[int, int]] = None, port_sep: Optional[str] = None):
     """
     Convert one or more attributes of a network to a pandas DataFrame.
 
@@ -725,6 +726,11 @@ def network_2_dataframe(ntwk: Network, attrs: List[str] =['s_db'], ports: List[T
     ports : list of tuples
         list of port pairs to write. defaults to ntwk.port_tuples
         (like [(0,0)])
+    port_sep : string
+        defaults to None, which means a empty string "" is used for 
+        networks with lower than 10 ports. (s_db 11, s_db 21)
+        For more than ten ports a "_" is used to avoid ambiguity.
+        (s_db 1_1, s_db 2_1)    
 
     Returns
     -------
@@ -733,11 +739,14 @@ def network_2_dataframe(ntwk: Network, attrs: List[str] =['s_db'], ports: List[T
     if ports is None:
         ports = ntwk.port_tuples
 
+    if port_sep is None:
+        port_sep = "_" if ntwk.nports >= 10 else ""
+
     d = {}
     for attr in attrs:
         attr_array = getattr(ntwk, attr)
         for m, n in ports:
-            d[f'{attr} {m+1}{n+1}'] = attr_array[:, m, n]
+            d[f'{attr} {m+1}{port_sep}{n+1}'] = attr_array[:, m, n]
     return DataFrame(d, index=ntwk.frequency.f)
 
 def networkset_2_spreadsheet(ntwkset: 'NetworkSet', file_name: str = None, file_type: str = 'excel',

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -740,7 +740,7 @@ def network_2_dataframe(ntwk: Network, attrs: List[str] =['s_db'],
         ports = ntwk.port_tuples
 
     if port_sep is None:
-        port_sep = "_" if ntwk.nports >= 10 else ""
+        port_sep = "_" if ntwk.nports > 10 else ""
 
     d = {}
     for attr in attrs:

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -192,13 +192,13 @@ class IOTestCase(unittest.TestCase):
 
     def test_network_2_dataframe_port_sep_auto(self):
         f = [1]
-        for ports in [1, 2, 4, 8, 16]:
+        for ports in [1, 2, 4, 8, 10, 11, 16]:
             s = npy.random.standard_normal((1, ports, ports))
             netw = rf.Network(s=s, f=f)
 
             df = netw.to_dataframe()
             
-            if ports < 10:
+            if ports <= 10:
                 assert f"s_db 11" in df.columns
             else:
                 assert f"s_db 1_1" in df.columns

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -6,6 +6,7 @@ import skrf as rf
 from skrf.io import Touchstone
 from skrf.io import network_2_dataframe
 
+import pytest
 
 class IOTestCase(unittest.TestCase):
     """
@@ -177,5 +178,27 @@ class IOTestCase(unittest.TestCase):
         f = [1]
         netw = rf.Network(s=s, f=f)
 
-        s2 = netw.to_dataframe().values
-        assert s.size == s2.size
+        df = netw.to_dataframe()
+        assert s.size == df.values.size
+        assert "s_db 1_11" in df.columns
+        assert "s_db 11_1" in df.columns
+
+    def test_network_2_dataframe_port_sep(self):
+        for port_sep in ["", "_", ","]:
+            df = self.ntwk1.to_dataframe(port_sep=port_sep)
+
+            assert len(df.columns == self.ntwk1.nports ** 2)
+            assert f"s_db 2{port_sep}1" in df.columns
+
+    def test_network_2_dataframe_port_sep_auto(self):
+        f = [1]
+        for ports in [1, 2, 4, 8, 16]:
+            s = npy.random.standard_normal((1, ports, ports))
+            netw = rf.Network(s=s, f=f)
+
+            df = netw.to_dataframe()
+            
+            if ports < 10:
+                assert f"s_db 11" in df.columns
+            else:
+                assert f"s_db 1_1" in df.columns

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -4,6 +4,7 @@ import numpy as npy
 
 import skrf as rf
 from skrf.io import Touchstone
+from skrf.io import network_2_dataframe
 
 
 class IOTestCase(unittest.TestCase):
@@ -164,3 +165,17 @@ class IOTestCase(unittest.TestCase):
         given = {'p1': ('.03', ''), 'p2': ('0.03', ''), 'p3': ('100', ''), 'p4': ('2.5', 'um')}
         actual = Touchstone(self.ntwk_comments_file).get_comment_variables()
         self.assertEqual(given, actual)
+
+    def test_network_2_dataframe_equal(self):
+        df_method = self.ntwk1.to_dataframe()
+        df_function = network_2_dataframe(self.ntwk1)
+
+        assert df_method.equals(df_function)
+
+    def test_network_2_dataframe_columns(self):
+        s = npy.random.standard_normal((1, 11, 11))
+        f = [1]
+        netw = rf.Network(s=s, f=f)
+
+        s2 = netw.to_dataframe().values
+        assert s.size == s2.size

--- a/skrf/io/tests/test_io.py
+++ b/skrf/io/tests/test_io.py
@@ -6,8 +6,6 @@ import skrf as rf
 from skrf.io import Touchstone
 from skrf.io import network_2_dataframe
 
-import pytest
-
 class IOTestCase(unittest.TestCase):
     """
     """
@@ -199,6 +197,6 @@ class IOTestCase(unittest.TestCase):
             df = netw.to_dataframe()
             
             if ports <= 10:
-                assert f"s_db 11" in df.columns
+                assert "s_db 11" in df.columns
             else:
-                assert f"s_db 1_1" in df.columns
+                assert "s_db 1_1" in df.columns

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2652,7 +2652,8 @@ class Network:
         from .io.general import network_2_spreadsheet
         network_2_spreadsheet(self, *args, **kwargs)
 
-    def to_dataframe(self, *args, **kwargs) -> 'pd.DataFrame':
+    def to_dataframe(self, attrs: List[str] =['s_db'], 
+            ports: List[Tuple[int, int]] = None, port_sep: Optional[str] = None):
         """
         Convert attributes of a Network to a pandas DataFrame.
 
@@ -2665,6 +2666,13 @@ class Network:
         ports : list of tuples
             list of port pairs to write. defaults to ntwk.port_tuples
             (like [[0,0]])
+        port_sep : string
+            defaults to None, which means a empty string "" is used for 
+            networks with lower than 10 ports. (s_db 11, s_db 21)
+            For more than ten ports a "_" is used to avoid ambiguity.
+            (s_db 1_1, s_db 2_1)
+            For consistent behaviour it's recommended to specify "_" or
+            "," explicitly.
 
         Returns
         -------
@@ -2676,7 +2684,7 @@ class Network:
         skrf.io.general.network_2_dataframe
         """
         from .io.general import network_2_dataframe
-        return network_2_dataframe(self, *args, **kwargs)
+        return network_2_dataframe(self, attrs=attrs, ports=ports, port_sep=port_sep)
 
     def write_to_json_string(self) -> str:
         """


### PR DESCRIPTION
Currently the columns in the exported dataframe look like `s_db 11`, `s_db 21` ...
There's a name clash in case of more than 11 ports as s_db 1_11 and s_db 11_1 look the same if the separator is removed.

Now a port separator can be specified manually.
If not specified, `` is used for networks with a maximum of 10 ports, a `_` otherwise. This allows to keep backward compability.