### PR TITLE
Check python 3.12 compability

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
     3.9: py39, minimal-dependencies
     3.10: py310
     3.11: py311
+    3.12: py312
 
 # This is the default testsetup with all (optional) dependencies installed
 [testenv]


### PR DESCRIPTION
Let's see if we are compatible with python3.12 yet. 
I don't expect any bigger issues, hopefully all needed packages are already deployed for python3.12.