### PR TITLE
NanoVNA fixes

### DIFF
--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -112,7 +112,7 @@ class NanoVNA(vna.VNA):
     @freq_start.setter
     def freq_start(self, f: int) -> None:
         self.write(OP.WRITE8, REG_ADDR.SWEEP_START, 8, f)
-        self._freq.start = f
+        self._freq = skrf.Frequency(start=f, stop=self._freq.stop, npoints=self._freq.npoints)
 
     @property
     def freq_stop(self) -> float:
@@ -120,7 +120,7 @@ class NanoVNA(vna.VNA):
 
     @freq_stop.setter
     def freq_stop(self, f: int) -> None:
-        self._freq.stop = f
+        self._freq = skrf.Frequency(start=self._freq.start, stop=f, npoints=self._freq.npoints)
         self.write(OP.WRITE8, REG_ADDR.SWEEP_STEP, 8, self._freq.step)
 
     @property
@@ -141,7 +141,7 @@ class NanoVNA(vna.VNA):
     @npoints.setter
     def npoints(self, n: int) -> None:
         self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, n)
-        self._freq.npoints = n
+        self._freq = skrf.Frequency(start=self._freq.start, stop=self._freq.stop, npoints=n)
 
     @property
     def frequency(self) -> skrf.Frequency:

--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -203,6 +203,6 @@ class NanoVNA(vna.VNA):
         s11.frequency = self._freq.copy()
         s21.frequency = self._freq.copy()
 
-        s11.s, s21.s = self._convert_bytes_to_sparams(n, raw)
+        s11.s, s21.s = NanoVNA._convert_bytes_to_sparams(n, raw)
 
         return s11, s21

--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -111,7 +111,7 @@ class NanoVNA(vna.VNA):
 
     @freq_start.setter
     def freq_start(self, f: int) -> None:
-        self.write(f"WRITE8;SWEEP_START;8;{f}")
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_START, 8, f)
         self._freq.start = f
 
     @property
@@ -120,7 +120,7 @@ class NanoVNA(vna.VNA):
 
     @freq_stop.setter
     def freq_stop(self, f: int) -> None:
-        self.write(f"WRITE8;SWEEP_STOP;8;{f}")
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_STOP, 8, f)
         self._freq.stop = f
 
     @property
@@ -132,7 +132,7 @@ class NanoVNA(vna.VNA):
         self._freq = skrf.Frequency.from_f(
             range(self._freq.start, self._freq.stop + f, f)
         )
-        self.write(f"WRITE2;SWEEP_POINTS;2;{self._freq.npoints}")
+        self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, self._freq.npoints)
 
     @property
     def npoints(self) -> int:
@@ -140,7 +140,7 @@ class NanoVNA(vna.VNA):
 
     @npoints.setter
     def npoints(self, n: int) -> None:
-        self.write(f"WRITE2;SWEEP_POINTS;2;{n}")
+        self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, n)
         self._freq.npoints = n
 
     @property
@@ -149,13 +149,13 @@ class NanoVNA(vna.VNA):
 
     @frequency.setter
     def frequency(self, f: skrf.Frequency):
-        self.write(f"WRITE8;SWEEP_START;8;{f.start}")
-        self.write(f"WRITE8;SWEEP_STOP;8;{f.stop}")
-        self.write(f"WRITE2;SWEEP_POINTS;2;{f.npoints}")
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_START, 8, f.start)
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_STOP, 8, f.stop)
+        self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, f.npoints)
         self._freq = f
 
     def clear_fifo(self) -> None:
-        self.write("WRITE;VALS_FIFO;1;0")
+        self.write(OP.WRITE, REG_ADDR.VALS_FIFO, 1, 0)
 
     def _convert_bytes_to_sparams(n: int, raw: bytearray) -> tuple[np.ndarray, np.ndarray]:
         s11 = np.zeros(n, dtype=complex)
@@ -196,7 +196,7 @@ class NanoVNA(vna.VNA):
         while n_remaining > 0:
             len_segment = 255 if n_remaining > 255 else n_remaining
             n_remaining = n_remaining - len_segment
-            self.write(f"READFIFO;VALS_FIFO;{len_segment}")
+            self.write(OP.READFIFO, REG_ADDR.VALS_FIFO, 1, len_segment)
             raw.extend(self.read_bytes(32 * len_segment))
 
         s11, s21 = skrf.Network(), skrf.Network()

--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -120,8 +120,8 @@ class NanoVNA(vna.VNA):
 
     @freq_stop.setter
     def freq_stop(self, f: int) -> None:
-        self.write(OP.WRITE8, REG_ADDR.SWEEP_STOP, 8, f)
         self._freq.stop = f
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_STEP, 8, self._freq.step)
 
     @property
     def freq_step(self) -> float:
@@ -150,7 +150,7 @@ class NanoVNA(vna.VNA):
     @frequency.setter
     def frequency(self, f: skrf.Frequency):
         self.write(OP.WRITE8, REG_ADDR.SWEEP_START, 8, f.start)
-        self.write(OP.WRITE8, REG_ADDR.SWEEP_STOP, 8, f.stop)
+        self.write(OP.WRITE8, REG_ADDR.SWEEP_STEP, 8, f.step)
         self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, f.npoints)
         self._freq = f
 

--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -57,8 +57,9 @@ class NanoVNA(vna.VNA):
         self.read_bytes = self._resource.read_bytes
         self.write_raw = self._resource.write_raw
 
-        self._freq = skrf.Frequency(start=1e6, stop=10e6, npoints=201)
         self._reset_protocol()
+
+        self.frequency = skrf.Frequency(start=1e6, stop=10e6, npoints=201)
 
     def _reset_protocol(self):
         self.write_raw(b"\x00\x00\x00\x00\x00\x00\x00\x00")

--- a/skrf/vi/vna/nanovna/nanovna.py
+++ b/skrf/vi/vna/nanovna/nanovna.py
@@ -130,10 +130,10 @@ class NanoVNA(vna.VNA):
 
     @freq_step.setter
     def freq_step(self, f: int) -> None:
-        self._freq = skrf.Frequency.from_f(
-            range(self._freq.start, self._freq.stop + f, f)
-        )
-        self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, self._freq.npoints)
+        npoints = (self._freq.stop - self._freq.start + f) / f
+        npoints = int(npoints.round())
+        self._freq = skrf.Frequency(start=self._freq.start, stop=self._freq.stop, npoints=npoints)
+        self.write(OP.WRITE2, REG_ADDR.SWEEP_POINTS, 2, npoints)
 
     @property
     def npoints(self) -> int:


### PR DESCRIPTION
I've been trying to use the NanoVNA support included in the recent VNA overhaul, but I ran into lots of basic runtime errors. Looking back over #744, I'm not sure if anyone with a NanoVNA was able to test it before merging, so that probably explains it.

I've gone through and fixed everything I could find to get it functioning, doing my best to keep to the API that was there. I've been testing with a LiteVNA (which implements the NanoVNAv2 protocol) using the following script:

```python
import matplotlib.pyplot as plt
import skrf
from skrf.vi.vna.nanovna import NanoVNA

nv = NanoVNA('ASRL/dev/ttyACM0::INSTR')
print(nv.device_info)

nv.freq_start = 1e6
nv.freq_stop = 6e9
nv.npoints = 201

s11, s21 = nv.get_s11_s21()
n = skrf.network.four_oneports_2_twoport(s11, s21, s21, s11)
n.plot_it_all(n=0)
plt.show()
```
and it seems to be working well with this set of changes:
![skrf_litevna](https://github.com/scikit-rf/scikit-rf/assets/578095/99468323-1981-4e22-bb69-5f2f10f70f15)
(uncorrected output of course)
