### PR TITLE
Remove `html_theme_path` setting from docs config to fix search & other JavaScript functions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@ author = 'scikit-rf team'
 
 import sys
 import os
-import sphinx_rtd_theme
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -40,6 +39,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'sphinx_rtd_theme',
     'nbsphinx',
     #'inheritance_diagram',
     'IPython.sphinxext.ipython_directive',
@@ -96,11 +96,10 @@ pygments_style = 'sphinx'
 # further.  For a list of options available for each theme, see the
 # documentation.
 
-# Add any paths that contain custom themes here, relative to this directory.
-
 html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# Add any paths that contain custom themes here, relative to this directory.
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
I've noticed that search and other JavaScript functions (like opening the version information box in the bottom left) fail on the readthedocs page, which I think is due to an exception thrown over missing jQuery.

I found some advice in the sphinx_rtd_theme issues ([1](https://github.com/readthedocs/sphinx_rtd_theme/issues/1434#issuecomment-1472671651), [2](https://github.com/readthedocs/sphinx_rtd_theme/issues/1452#issuecomment-1575476244)) suggesting this can be caused by setting `html_theme_path`, which was previously recommended but is now out of date.

This updates the config in-line with current advice from sphinx_rtd_theme adding it to `extensions` and removing the `html_theme_path` setting.

~~I wasn't able to reproduce the problem offline to test, but I'm hoping this PR kicks off an RTD build to test it out~~
Edit: the build worked, and it seems to be fixed! https://scikit-rf--970.org.readthedocs.build/en/970/