### PR TITLE
Fix de-embedding when 2 networks are provided

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -618,10 +618,7 @@ class Network:
 
         if isinstance(other, (list, tuple)):
             if len(other) >= 3:
-                warnings.warn(
-                    "Number of networks greater than 2. Truncating!",
-                    RuntimeWarning
-                )
+                raise ValueError('Incorrect number of networks.')
             other_tpl = other[:2]
         else:
             other_tpl = (other, )

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -622,7 +622,7 @@ class Network:
                     "Number of networks greater than 2. Truncating!",
                     RuntimeWarning
                 )
-                other_tpl = other[:2]
+            other_tpl = other[:2]
         else:
             other_tpl = (other, )
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1826,8 +1826,16 @@ class NetworkTestCase(unittest.TestCase):
         ntwk_result_2 = self.ntwk1 // (self.ntwk2)
         np.testing.assert_array_equal(ntwk_result_1.s, ntwk_result_2.s)
 
-        with pytest.warns(None):
-            ntwk_result_3 = self.ntwk1 // (self.ntwk2, self.ntwk3)
+        # By definition A // B      => B.inv * A
+        # By definition A // [B, C] => B.inv * A * C.inv
+        # So, A // [B, C] should be equal to (A // B) * C.inv
+        ntwk_result_3 = self.ntwk1 // (self.ntwk2, self.ntwk3)
+        ntwk_result_4 = (self.ntwk1 // self.ntwk2) ** self.ntwk3.inv
+        np.testing.assert_array_almost_equal(ntwk_result_3.s, ntwk_result_4.s)
+
+        # Check weather an error is raised when more than two networks are specified
+        with pytest.raises(ValueError):
+            ntwk_result_3 = self.ntwk1 // (self.ntwk1, self.ntwk2, self.ntwk3)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(NetworkTestCase)
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1821,5 +1821,13 @@ class NetworkTestCase(unittest.TestCase):
         with pytest.raises(ValueError):
             net.stability_circle(target_port='foobar')
 
+    def test_de_embed_by_floordiv(self):
+        ntwk_result_1 = self.ntwk1 // self.ntwk2
+        ntwk_result_2 = self.ntwk1 // (self.ntwk2)
+        np.testing.assert_array_equal(ntwk_result_1.s, ntwk_result_2.s)
+
+        with pytest.warns(None):
+            ntwk_result_3 = self.ntwk1 // (self.ntwk2, self.ntwk3)
+
 suite = unittest.TestLoader().loadTestsFromTestCase(NetworkTestCase)
 unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
The network operator "//" used for de-embed 1 or 2 networks is not working for exactly 2 networks.  

ntwk1 // ntwk2 works
ntwk1 // (ntwk2) works
ntwk1 // (ntwk2, ntwk3) does not work

it fixes that
