### PR TITLE
Force PNA to use expected format for SNP data

### DIFF
--- a/skrf/vi/vna/keysight/pna.py
+++ b/skrf/vi/vna/keysight/pna.py
@@ -342,6 +342,8 @@ class PNA(VNA):
             orig_query_fmt = self.parent.query_format
             self.parent.query_format = ValuesFormat.BINARY_64
             self.parent.active_channel = self
+            orig_snp_fmt = self.query("MMEM:STOR:TRAC:FORM:SNP?")
+            self.write("MMEM:STOR:TRACE:FORM:SNP RI") # Expect Real/Imaginary data
 
             msmnt_params = [f"S{a}{b}" for a, b in itertools.product(ports, repeat=2)]
 
@@ -391,6 +393,7 @@ class PNA(VNA):
                     ntwk.s[:, n, m] = real_rows[i] + 1j * imag_rows[i]
 
             self.parent.query_format = orig_query_fmt
+            self.write("MMEM:STOR:TRACE:FORM:SNP %s" % orig_snp_fmt)
 
             return ntwk
 


### PR DESCRIPTION
`get_snp_network()` in the PNA virtual instrument expects the data to be returned in Real/Imaginary format, but the instrument isn't necessarily configured to do so. This pull request alters the behavior to save the initial SNP format, change it to Real/Imaginary, then restore the original after pulling the SNP data.

You can verify that this matters by manually setting the SNP data type to one of the other values ("MA" or "DB") before calling `get_snp_network()` on the master branch. e.g., `instr.write("MMEM:STOR:TRACE:FORM:SNP MA")`.

This was tested on a Keysight P9374A, but I use similar code on PNAs (where I can't test this change directly).