### PR TITLE
Define circuit name at initialization

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -131,7 +131,7 @@ class Circuit:
         except ImportError as err:
             raise ImportError('networkx package as not been installed and is required.') from err
 
-    def __init__(self, connections: List[List[Tuple]]) -> None:
+    def __init__(self, connections: List[List[Tuple]], name: str = None,) -> None:
         """
         Circuit constructor. Creates a circuit made of a set of N-ports networks.
 
@@ -142,6 +142,9 @@ class Circuit:
             Each connection is a described by a list of tuple.
             Each tuple contains (network, network_port_nb).
             Port number indexing starts from zero.
+            
+        name : string
+            Name assigned to the circuit (network).
 
 
         Examples
@@ -188,6 +191,7 @@ class Circuit:
 
         """
         self.connections = connections
+        self.name = name
 
         # check if all networks have a name
         for cnx in self.connections:
@@ -894,6 +898,7 @@ class Circuit:
         ntw.frequency = self.frequency
         ntw.z0 = self.port_z0
         ntw.s = self.s_external
+        ntw.name = self.name
         return ntw
 
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -142,9 +142,8 @@ class Circuit:
             Each connection is a described by a list of tuple.
             Each tuple contains (network, network_port_nb).
             Port number indexing starts from zero.
-            
-        name : string
-            Name assigned to the circuit (network).
+        name : string, optional
+            Name assigned to the circuit (Network). Default is None.
 
 
         Examples


### PR DESCRIPTION
I suggest to have the possibility to define the `name` of a circuit network during the circuit initialization, as argument of the constructor, e.g., `cir = rf.Circuit(cnx, name = 'circuit')`.

To use a `network` inside a `circuit` connection list requires the `network` to have a `name`. Indeed in the `__init__` of  `circuit.py`:

```
# check if all networks have a name  
        for cnx in self.connections:  
            for (ntw, _) in cnx:  
                if not self._is_named(ntw):  
                    raise AttributeError('All Networks must have a name. Faulty network:', ntw)
``` 

Currently, one is forced to use a variable to store the circuit `network`, and then specify a `name`, e.g.: 
```
cir = rf.Circuit(cnx)
ntw = cir.network
ntw.name = "circuit"
```

I find the suggested option more convenient, and readable, especially when nesting several circuits inside other circuits.