### PR TITLE
Fixed SOLT calibration

### DIFF
--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1225,20 +1225,17 @@ class SOLTTest(TwelveTermTest):
         self.If = wg.random(n_ports =1, name='If')
         self.Ir = wg.random(n_ports =1, name='Ir')
 
+        thru = wg.line(20,'deg',name='line')**wg.impedance_mismatch(45,50)  # use any non-flush thru
+        thru.name = 'thru'
+
         ideals = [
             wg.short(nports=2, name='short'),
             wg.open(nports=2, name='open'),
             wg.match(nports=2, name='load'),
-            None,
-            ]
-        actuals = [
-            wg.short(nports=2, name='short'),
-            wg.open(nports=2, name='open'),
-            wg.match(nports=2, name='load'),
-            wg.thru(),
+            thru,
             ]
 
-        measured = [ self.measure(k) for k in actuals]
+        measured = [ self.measure(k) for k in ideals]
 
         self.cal = SOLT(
             ideals = ideals,
@@ -2138,7 +2135,8 @@ class MultiportSOLTTest(MultiportCalTest):
             s = wg.short(nports=nports, name='short')
             m = wg.match(nports=nports, name='load')
 
-            thru = wg.thru(name='thru')
+            thru = wg.line(20, 'deg', name='line') ** wg.impedance_mismatch(45, 50)  # use any non-flush thru
+            thru.name = 'thru'
 
             ideals = []
             # nports-1 thrus from port 0 to all other ports.

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -4,6 +4,7 @@ import skrf
 import numpy as np
 import tempfile
 import os
+from pathlib import Path
 import sys
 
 
@@ -44,14 +45,16 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_190ghz_measured(self):
         # perform the fit without proportional term
-        nw = skrf.network.Network('./../../doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
+        nw = skrf.network.Network(s2p_file)
         vf = skrf.vectorFitting.VectorFitting(nw)
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=4, fit_proportional=False, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
     def test_no_convergence(self):
+        s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
         # perform a bad fit that does not converge and check if a RuntimeWarning is given
-        nw = skrf.network.Network('./../../doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        nw = skrf.network.Network(s2p_file)
         vf = skrf.vectorFitting.VectorFitting(nw)
 
         with pytest.warns(RuntimeWarning) as record:

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -44,14 +44,14 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_190ghz_measured(self):
         # perform the fit without proportional term
-        nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        nw = skrf.network.Network('./../../doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
         vf = skrf.vectorFitting.VectorFitting(nw)
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=4, fit_proportional=False, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
     def test_no_convergence(self):
         # perform a bad fit that does not converge and check if a RuntimeWarning is given
-        nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        nw = skrf.network.Network('./../../doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
         vf = skrf.vectorFitting.VectorFitting(nw)
 
         with pytest.warns(RuntimeWarning) as record:
@@ -61,7 +61,7 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
-        nw = skrf.Network('./skrf/tests/cst_example_4ports.s4p')
+        nw = skrf.Network('./cst_example_4ports.s4p')
         vf = skrf.VectorFitting(nw)
         vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
         # quality of the fit is not important in this test; it only needs to finish

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -64,7 +64,8 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
-        nw = skrf.Network('./cst_example_4ports.s4p')
+        s4p_file = Path(__file__).parent / 'cst_example_4ports.s4p'
+        nw = skrf.Network(s4p_file)
         vf = skrf.VectorFitting(nw)
         vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
         # quality of the fit is not important in this test; it only needs to finish


### PR DESCRIPTION
Hi there,

I have noticed that the SOLT calibration does not work as desired.
I have not prepared a minimal working example, but this is my use case:
I have
- Three one-port reflectance standards, both measured and idealised
- known

After running the SOLT calibration and measuring the known through, I would expect the through to be measured as known. However, the S21, for example, is centred around 0 dB.

The reason for this is that the wrong equation is used within the run() calibration method to calculate the transmission tracking (e10*e32). I assume that the eq from [1], p. 18 was simply used. However, this eq assumes that the connection between port 1 and port 2 is a zero thru (i.e. direct connection of both ports: S21=S12=1, S11=S22=0).
As this is not the case here, because we have given the SOLT the known thru, we have to consider the actual s-params for the thru when calculating the transmission tracking (e10*e32).

**The solution is quite simple: just take the S21M eq from [1] p.16 and solve for e10*e32.**.
The known thru will then be properly taken into account in the transmission retracking and the measurement will output the actual s-params after calibration.

Sorry for the lack of plots. I think the reason is quite obvious.

Thank you very much for your work and for considering this request!

Best regards,
Florian

PS: In addition, I generalised the paths of two of the (vectorfitting) tests that failed because I called the test from the PyCharm GUI, which caused the paths to fail - they are expected to be called from the repo's base path.

[1] Rytting, D. (1996) Network Analyzer Error Models and Calibration Methods. RF 8: Microwave Measurements for Wireless Applications (ARFTG/NIST Short Course Notes)