### PR TITLE
Adapt PR Labeler config to new version

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-Continuous integration:
+Continuous-Integration:
 - changed-files:
   - any-glob-to-any-file: .github/**/*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-Continuous-Integration:
+ContinuousIntegration:
 - changed-files:
   - any-glob-to-any-file: .github/**/*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,50 @@
-Continuous integration: .github/**/*
+Continuous integration:
+- changed-files:
+  - any-glob-to-any-file: .github/**/*
 
-Network: skrf/network.py
+Network:
+- changed-files:
+  - any-glob-to-any-file: skrf/network.py
 
-VectorFitting: skrf/vectorFitting.py
+VectorFitting:
+- changed-files:
+  - any-glob-to-any-file: skrf/vectorFitting.py
 
-Circuit: skrf/circuit.py
+Circuit:
+- changed-files:
+  - any-glob-to-any-file: skrf/circuit.py
 
-Plotting: skrf/plotting.py
+Plotting:
+- changed-files:
+  - any-glob-to-any-file: skrf/plotting.py
 
-Time: skrf/time.py
+Time:
+- changed-files:
+  - any-glob-to-any-file: skrf/time.py
 
-TransmissionLines: skrf/tlineFunctions.py
+TransmissionLines:
+- changed-files:
+  - any-glob-to-any-file: skrf/tlineFunctions.py
 
-qtapps: qtapps/**/*
+qtapps:
+- changed-files:
+  - any-glob-to-any-file: qtapps/**/*
 
-Calibration: skrf/calibration/**/*
+Calibration:
+- changed-files:
+  - any-glob-to-any-file: skrf/calibration/**/*
 
-IO: skrf/io/**/*
+IO:
+- changed-files:
+  - any-glob-to-any-file: skrf/io/**/*
 
-Media: skrf/media/**/*
+Media:
+- changed-files:
+  - any-glob-to-any-file: skrf/media/**/*
 
-Documentation: doc/**/*
+Documentation:
+- changed-files:
+  - any-glob-to-any-file: doc/**/*
+
+Release:
+- base-branch: main

--- a/.github/workflows/PR_labeler.yml
+++ b/.github/workflows/PR_labeler.yml
@@ -6,7 +6,11 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@5
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          .github
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/PR_labeler.yml
+++ b/.github/workflows/PR_labeler.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
The new release of PR labeler (https://github.com/actions/labeler/releases/tag/v5.0.0) requires a new config format, this PR updates the appropriate file.