### PR TITLE
Make SOLT class inherit run method from TwelveTermModel to allow arbitrary thrus

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1832,51 +1832,6 @@ class SOLT(TwelveTerm):
         TwelveTerm.__init__(self,*args, **kwargs)
 
 
-
-    def run(self):
-        """
-        """
-        n_thrus = self.n_thrus
-        p1_m = [k.s11 for k in self.measured[:-n_thrus]]
-        p2_m = [k.s22 for k in self.measured[:-n_thrus]]
-        p1_i = [k.s11 for k in self.ideals[:-n_thrus]]
-        p2_i = [k.s22 for k in self.ideals[:-n_thrus]]
-        thru = NetworkSet(self.measured[-n_thrus:]).mean_s
-
-        # create one port calibration for reflective standards
-        port1_cal = OnePort(measured = p1_m, ideals = p1_i)
-        port2_cal = OnePort(measured = p2_m, ideals = p2_i)
-
-        # cal coefficient dictionaries
-        p1_coefs = port1_cal.coefs
-        p2_coefs = port2_cal.coefs
-
-        if self.kwargs.get('isolation',None) is not None:
-            p1_coefs['isolation'] = self.kwargs['isolation'].s21.s.flatten()
-            p2_coefs['isolation'] = self.kwargs['isolation'].s12.s.flatten()
-        else:
-            p1_coefs['isolation'] = npy.zeros(len(thru), dtype=complex)
-            p2_coefs['isolation'] = npy.zeros(len(thru), dtype=complex)
-
-        p1_coefs['load match'] = port1_cal.apply_cal(thru.s11).s.flatten()
-        p2_coefs['load match'] = port2_cal.apply_cal(thru.s22).s.flatten()
-
-        p1_coefs['transmission tracking'] = \
-            (thru.s21.s.flatten() - p1_coefs.get('isolation',0))*\
-            (1. - p1_coefs['source match']*p1_coefs['load match'])
-        p2_coefs['transmission tracking'] = \
-            (thru.s12.s.flatten() - p2_coefs.get('isolation',0))*\
-            (1. - p2_coefs['source match']*p2_coefs['load match'])
-        coefs = {}
-
-        coefs.update({'forward %s'%k: p1_coefs[k] for k in p1_coefs})
-        coefs.update({'reverse %s'%k: p2_coefs[k] for k in p2_coefs})
-        eight_term_coefs = convert_12term_2_8term(coefs)
-
-        coefs.update({l: eight_term_coefs[l] for l in \
-            ['forward switch term','reverse switch term','k'] })
-        self._coefs = coefs
-
 class TwoPortOnePath(TwelveTerm):
     """
     Two Port One Path Calibration (aka poor man's TwelveTerm).

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1744,10 +1744,7 @@ class SOLT(TwelveTerm):
     more than 3 reflect standards are provided a least-squares solution
     is implemented for the one-port stage of the calibration.
 
-    If your `thru` is not flush you need to use `TwelveTerm` instead of
-    SOLT.
-
-    Redundant flush thru measurements can also be used, through the `n_thrus`
+    Redundant thru measurements can also be used, through the `n_thrus`
     parameter. See :func:`__init__`
 
     References
@@ -1771,12 +1768,11 @@ class SOLT(TwelveTerm):
         standards must align.
 
         If `n_thrus!=None`, then the thru standard[s] must be last in
-        the list. The `n_thrus` argument can be used to allow  multiple
-        measurements of the flush thru standard.
+        the list. The `n_thrus` argument can be used to allow multiple
+        measurements of the thru standard.
 
         If the ideal element for the thru is set to None, a flush thru
-        is assumed. If your `thru` is not flush you need
-        to use `TwelveTerm` instead of SOLT. Use
+        is assumed.
 
         Notes
         -----

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1229,16 +1229,10 @@ class SOLTTest(TwelveTermTest):
             wg.short(nports=2, name='short'),
             wg.open(nports=2, name='open'),
             wg.match(nports=2, name='load'),
-            None,
-            ]
-        actuals = [
-            wg.short(nports=2, name='short'),
-            wg.open(nports=2, name='open'),
-            wg.match(nports=2, name='load'),
-            wg.thru(),
+            wg.random(n_ports=2),
             ]
 
-        measured = [ self.measure(k) for k in actuals]
+        measured = [ self.measure(k) for k in ideals]
 
         self.cal = SOLT(
             ideals = ideals,

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1229,10 +1229,16 @@ class SOLTTest(TwelveTermTest):
             wg.short(nports=2, name='short'),
             wg.open(nports=2, name='open'),
             wg.match(nports=2, name='load'),
-            wg.random(n_ports=2),
+            None,
+            ]
+        actuals = [
+            wg.short(nports=2, name='short'),
+            wg.open(nports=2, name='open'),
+            wg.match(nports=2, name='load'),
+            wg.thru(),
             ]
 
-        measured = [ self.measure(k) for k in ideals]
+        measured = [ self.measure(k) for k in actuals]
 
         self.cal = SOLT(
             ideals = ideals,
@@ -2132,7 +2138,8 @@ class MultiportSOLTTest(MultiportCalTest):
             s = wg.short(nports=nports, name='short')
             m = wg.match(nports=nports, name='load')
 
-            thru = wg.thru(name='thru')
+            # thru = wg.thru(name='thru')
+            thru = wg.impedance_mismatch(50, 45) ** wg.line(20, 'deg') ** wg.impedance_mismatch(45, 50)
 
             ideals = []
             # nports-1 thrus from port 0 to all other ports.

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -4,6 +4,7 @@ import skrf
 import numpy as np
 import tempfile
 import os
+from pathlib import Path
 import sys
 
 
@@ -44,14 +45,16 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_190ghz_measured(self):
         # perform the fit without proportional term
-        nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
+        nw = skrf.network.Network(s2p_file)
         vf = skrf.vectorFitting.VectorFitting(nw)
         vf.vector_fit(n_poles_real=4, n_poles_cmplx=4, fit_proportional=False, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
     def test_no_convergence(self):
+        s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
         # perform a bad fit that does not converge and check if a RuntimeWarning is given
-        nw = skrf.network.Network('./doc/source/examples/vectorfitting/190ghz_tx_measured.S2P')
+        nw = skrf.network.Network(s2p_file)
         vf = skrf.vectorFitting.VectorFitting(nw)
 
         with pytest.warns(RuntimeWarning) as record:
@@ -61,7 +64,8 @@ class VectorFittingTestCase(unittest.TestCase):
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
-        nw = skrf.Network('./skrf/tests/cst_example_4ports.s4p')
+        s4p_file = Path(__file__).parent / 'cst_example_4ports.s4p'
+        nw = skrf.Network(s4p_file)
         vf = skrf.VectorFitting(nw)
         vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
         # quality of the fit is not important in this test; it only needs to finish


### PR DESCRIPTION
This is a follow-up PR from this PR #983 

To date, SOLT class does only accept flush thrus. This a modification to make SOLT class inherit run method from TwelveTermModel to allow arbitrary thrus, as discussed in #983 .

Docstrings were also adjusted.
