### PR TITLE
Vector Fitting: Support for large number of parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ test = [
     "coverage >=6.0",
     "flake8 >=5.0",
     "pytest-cov >=4.0",
-    "nbval >=0.9"
+    "nbval >=0.9",
+    "pyarrow >= 10.0"
 ]
 
 plot = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ test = [
     "coverage >=6.0",
     "flake8 >=5.0",
     "pytest-cov >=4.0",
-    "nbval >=0.9",
-    "pyarrow >= 10.0"
+    "nbval >=0.9"
 ]
 
 plot = [

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -355,9 +355,14 @@ class VectorFitting:
                 R[i] = np.linalg.qr(A_ri[i], mode='r')
 
             # only R22 is required to solve for c_res and d_res
-            # R12 and R22 both have shape (L, K/2, n_cols_used)
-            n_rows_r22 = int(dim_k / 2)
-            R22 = R[:, n_rows_r22:, n_cols_unused:]
+            # R12 and R22 can have a different number of rows, depending on K
+            if dim_k == 2 * n_freqs:
+                n_rows_r12 = n_freqs
+                n_rows_r22 = n_freqs
+            else:
+                n_rows_r12 = n_cols_unused
+                n_rows_r22 = n_cols_used
+            R22 = R[:, n_rows_r12:, n_cols_unused:]
 
             # weighting
             R22 = weights_responses[:, None, None] * R22

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -389,13 +389,12 @@ class VectorFitting:
             logging.info(f'Condition number of coefficient matrix is {int(cond_A)}')
             self.history_cond_A.append(cond_A)
 
-            rank_A = np.linalg.matrix_rank(A_fast)
-            self.history_rank_A.append(rank_A)
-            self.full_rank = np.min(A_fast.shape)
-            logging.info(f'The rank of the coefficient matrix is {rank_A}. Deficiency is {self.full_rank - rank_A}')
-
             # solve least squares for real parts
             x, residuals, rank, singular_vals = np.linalg.lstsq(A_fast, b, rcond=None)
+
+            self.history_rank_A.append(rank)
+            self.full_rank = np.min(A_fast.shape)
+            logging.info(f'The rank of the coefficient matrix is {rank}. Rank deficiency is {self.full_rank - rank}.')
 
             # assemble individual result vectors from single LS result x
             c_res = x[:-1]

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -350,7 +350,7 @@ class VectorFitting:
 
             # direct QR of stacked matrices for linalg.qr() only works with numpy>=1.22.0
             # workaround for old numpy:
-            R = np.empty((n_responses, dim_k, A_ri.shape[2]))
+            R = np.empty((n_responses, dim_k, n_cols_unused + n_cols_used))
             for i in range(n_responses):
                 R[i] = np.linalg.qr(A_ri[i], mode='r')
 
@@ -384,18 +384,10 @@ class VectorFitting:
             logging.info(f'Condition number of coefficient matrix is {int(cond_A)}')
             self.history_cond_A.append(cond_A)
 
-            # if cond_A > 1e6:
-            #     warnings.warn(f'The condition number of the coefficient matrix is huge ({cond_A}).',
-            #                   RuntimeWarning, stacklevel=2)
-
             rank_A = np.linalg.matrix_rank(A_fast)
             self.history_rank_A.append(rank_A)
             self.full_rank = np.min(A_fast.shape)
             logging.info(f'The rank of the coefficient matrix is {rank_A}. Deficiency is {self.full_rank - rank_A}')
-
-            # if rank_A < np.min(A_fast.shape):
-            #     warnings.warn(f'The coefficient matrix is rank-deficient (rank = {rank_A}).',
-            #                   RuntimeWarning, stacklevel=2)
 
             # solve least squares for real parts
             x, residuals, rank, singular_vals = np.linalg.lstsq(A_fast, b, rcond=None)

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -97,6 +97,7 @@ class VectorFitting:
         self.history_max_sigma = []
         self.history_cond_A = []
         self.history_rank_A = []
+        self.full_rank = 0
 
     def vector_fit(self, n_poles_real: int = 2, n_poles_cmplx: int = 2, init_pole_spacing: str = 'lin',
                    parameter_type: str = 's', fit_constant: bool = True, fit_proportional: bool = False) -> None:
@@ -389,7 +390,8 @@ class VectorFitting:
 
             rank_A = np.linalg.matrix_rank(A_fast)
             self.history_rank_A.append(rank_A)
-            logging.info(f'The rank of the coefficient matrix is {rank_A}')
+            self.full_rank = np.min(A_fast.shape)
+            logging.info(f'The rank of the coefficient matrix is {rank_A}. Deficiency is {self.full_rank - rank_A}')
 
             # if rank_A < np.min(A_fast.shape):
             #     warnings.warn(f'The coefficient matrix is rank-deficient (rank = {rank_A}).',
@@ -473,8 +475,9 @@ class VectorFitting:
                     hint_illcond = f'\nHint: the linear system was ill-conditioned (max. condition number was {max_cond}).'
                 else:
                     hint_illcond = ''
-                if min_rank < np.min(A_fast.shape):
-                    hint_rank = f'\nHint: the coefficient matrix was rank-deficient (min. rank was {min_rank}).'
+                if min_rank < self.full_rank:
+                    hint_rank = (f'\nHint: the coefficient matrix was rank-deficient (min. rank was {min_rank}, full '
+                                 f'rank is {self.full_rank}).')
                 else:
                     hint_rank = ''
                 if converged and stop is False:

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -333,24 +333,23 @@ class VectorFitting:
             # part 4: constant (variable d_res)
             A[:, :, -1] = -1 * freq_responses
 
-            A_ri = np.hstack((A.real, A.imag))
-
             # calculation of matrix sizes after QR decomposition:
-            # A_ri has shape (L, M, N)
+            # stacked coefficient matrix (A.real, A.imag) has shape (L, M, N)
             # with
             # L = n_responses = n_ports ** 2
-            # M = 2 * n_freqs
+            # M = 2 * n_freqs (because of hstack with 2x n_freqs)
             # N = n_cols_unused + n_cols_used
             # then
             # R has shape (L, K, N) with K = min(M, N)
             dim_k = min(2 * n_freqs, n_cols_unused + n_cols_used)
 
             # QR decomposition
-            # R = np.linalg.qr(A_ri, 'r')
+            # R = np.linalg.qr(np.hstack((A.real, A.imag)), 'r')
 
             # direct QR of stacked matrices for linalg.qr() only works with numpy>=1.22.0
             # workaround for old numpy:
             R = np.empty((n_responses, dim_k, n_cols_unused + n_cols_used))
+            A_ri = np.hstack((A.real, A.imag))
             for i in range(n_responses):
                 R[i] = np.linalg.qr(A_ri[i], mode='r')
 


### PR DESCRIPTION
Bugfix for #1001.

As it turned out, the matrix slicing operations for fast pole relocation with QR decomposition were assuming `R` to be quadratic, which is not always the case.

I also took the opportunity to add some more conditioning checks and to rephrase the hints (discussion #1002).

Background (also see https://numpy.org/doc/stable/reference/generated/numpy.linalg.qr.html):
- The matrix to be decomposed has the shape `(..., M, N)`, with `M` depending on the number of frequencies and `N` depending on the number of poles. 
- The reduced R will then have the shape `(..., K, N)` with `K = min(M, N)`.
- In all of my test fits, I had `M > N` (many frequencies and only a few poles), so R always had the shape `(..., N, N)`. This is not the case if one uses many poles with a few frequencies, because then R has the (complete) shape `(..., M, N)`. The former case is very common, but the later apparently still exists. The code can now deal with both.