### PR TITLE
fix n-port mismatch junction issue in Circuit

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -613,93 +613,11 @@ class Circuit:
         return edge_labels
 
 
-    def _Y_k(self, cnx: list[tuple]) -> np.ndarray:
-        """
-        Return the sum of the system admittances of each intersection.
-
-        Parameters
-        ----------
-        cnx : list of tuples
-            each tuple contains (network, port)
-
-        Returns
-        -------
-        y_k : :class:`numpy.ndarray`
-        """
-        y_ns = []
-        for (ntw, ntw_port) in cnx:
-            # formula (2)
-            y_ns.append(1/ntw.z0[:,ntw_port] )
-
-        y_k = np.array(y_ns).sum(axis=0)  # shape: (nb_freq,)
-        return y_k
-
-    def _Xnn_k(self, cnx_k: list[tuple]) -> np.ndarray:
-        """
-        Return the reflection coefficients x_nn of the connection matrix [X]_k.
-
-        Parameters
-        ----------
-        cnx_k : list of tuples
-            each tuple contains (network, port)
-
-        Returns
-        -------
-        X_nn : :class:`numpy.ndarray`
-            shape `f x n`
-        """
-        X_nn = []
-        y_k = self._Y_k(cnx_k)
-
-        for (ntw, ntw_port) in cnx_k:
-            # formula (1)
-            X_nn.append( 2/(ntw.z0[:,ntw_port]*y_k) - 1)
-
-        return np.array(X_nn).T  # shape: (nb_freq, nb_n)
-
-    def _Xmn_k(self, cnx_k: list[tuple]) -> np.ndarray:
-        """
-        Return the transmission coefficient X_mn of the mth column of
-        intersection scattering matrix matrix [X]_k.
-
-        Parameters
-        ----------
-        cnx_k : list of tuples
-            each tuple contains (network, port)
-
-        Returns
-        -------
-        X_mn : :class:`numpy.ndarray`
-            shape `f x n`
-        """
-        # get the char.impedance of the n
-        X_mn = []
-        y_k = self._Y_k(cnx_k)
-
-        # There is a problem in the case of two-ports connexion:
-        # the formula (3) in P. Hallbjörner (2003) seems incorrect.
-        # Instead of Z_n one should have sqrt(Z_1 x Z_2).
-        # The formula works with respect to the example given in the paper
-        # (3 port connection), but not with 2-port connections made with skrf
-        if len(cnx_k) == 2:
-            z0s = []
-            for (ntw, ntw_port) in cnx_k:
-                z0s.append(ntw.z0[:,ntw_port])
-
-            z0eq = np.array(z0s).prod(axis=0)
-
-            for _i in range(len(cnx_k)):
-                X_mn.append( 2/(np.sqrt(z0eq) *y_k) )
-        else:
-            # formula (3)
-            for (ntw, ntw_port) in cnx_k:
-                X_mn.append( 2/(ntw.z0[:,ntw_port]*y_k) )
-
-        return np.array(X_mn).T  # shape: (nb_freq, nb_n)
-
     def _Xk(self, cnx_k: list[tuple]) -> np.ndarray:
         """
         Return the scattering matrices [X]_k of the individual intersections k.
+        The results in [#]_ do not agree due to an error in the formula (3)
+        for mismatched intersections.
 
         Parameters
         ----------
@@ -710,46 +628,20 @@ class Circuit:
         -------
         Xs : :class:`numpy.ndarray`
             shape `f x n x n`
+        
+        References
+        ----------
+        .. [#] P. Hallbjörner, Microw. Opt. Technol. Lett. 38, 99 (2003).
         """
-        # Xnn = self._Xnn_k(cnx_k)  # shape: (nb_freq, nb_n)
-        # Xmn = self._Xmn_k(cnx_k)  # shape: (nb_freq, nb_n)
-        # # for loop version
-        # Xs = []
-        # for (_Xnn, _Xmn) in zip(Xnn, Xmn):  # for all frequencies
-        #       # repeat Xmn along the lines
-        #     _X = np.tile(_Xmn, (len(_Xmn), 1))
-        #     _X[np.diag_indices(len(_Xmn))] = _Xnn
-        #     Xs.append(_X)
+        
+        y0s = np.array([1/ntw.z0[:,ntw_port] for (ntw, ntw_port) in cnx_k]).T
+        y_k = y0s.sum(axis=1)
 
-        # return np.array(Xs) # shape : nb_freq, nb_n, nb_n
-
-        # vectorized version
-        # nb_n = Xnn.shape[1]
-        # Xs = np.tile(Xmn, (nb_n, 1, 1)).swapaxes(1, 0)
-        # Xs[:, np.arange(nb_n), np.arange(nb_n)] = Xnn
-
-        # return Xs # shape : nb_freq, nb_n, nb_n
-
-        # TEST : Could we use media.splitter() instead ? -> does not work
-        # _media = media.DefinedGammaZ0(frequency=self.frequency)
-        # Xs = _media.splitter(len(cnx_k), z0=self._cnx_z0(cnx_k))
-        # return Xs.s
-        n_port = len(cnx_k)
-        s = np.zeros((self.frequency.npoints, n_port, n_port), dtype = complex)
-        y_k = self._Y_k(cnx_k)
-        # sii
-        for i in range(n_port):
-            (ntw_i, port_i) = cnx_k[i]
-            s[:,i,i] = 2. / (ntw_i.z0[:,port_i] * y_k) - 1
-            #sji
-            for j in range(n_port):
-                if j != i:
-                    (ntw_j, port_j) = cnx_k[j]
-                    y_eq = np.sqrt((1./ntw_i.z0[:,port_i]) \
-                                   * (1./ntw_j.z0[:,port_j]))
-                    s[:,j,i] = 2. *y_eq / y_k
-                    s[:,i,j] = s[:,j,i]
-        return s
+        Xs = np.zeros((len(self.frequency), len(cnx_k), len(cnx_k)), dtype='complex')
+        
+        Xs = 2 *np.sqrt(np.einsum('ij,ik->ijk', y0s, y0s)) / y_k[:, None, None]       
+        np.einsum('kii->ki', Xs)[:] -= 1  # Sii
+        return Xs
 
     @property
     def X(self) -> np.ndarray:

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1832,7 +1832,7 @@ def parse_z0(s: str) -> NumberLike:
 
 def splitter_s(frequency: Frequency, n: int,
                z0: NumberLike | None = None) -> npy.ndarray:
-    """
+    r"""
     Compute the scattering parametters of an n-port lossless splitter.
     The port impedances can be mismatched and the power is split accordingly.
     

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -794,6 +794,25 @@ class Media(ABC):
     def splitter(self, nports: int, **kwargs) -> Network:
         r"""
         Ideal, lossless n-way splitter.
+        
+        The port impedances can be mismatched and the power is split
+        accordingly.
+        
+        For n > 2, the splitter is not matched because the power wave entering
+        one port meet the equivalent impedance of the other ports in parallel.
+        
+        .. math::
+            S_{ii} = \frac{Y_i - \sum_{j\neq i} Y_j}{Y_i + \sum_{j\neq i} Y_j}
+            = \frac{2Y_i}{\sum_{j=1...n} Y_j} - 1
+        
+        The remaining power is split between the other ports depending their
+        impedances.
+        
+        .. math::
+            \sum_{j=1...n} S_{ij}^2 = 1 - S_{ii}^2
+        
+        .. math::
+            S_{ij} = \frac{2\sqrt{Y_i \cdot Y_j}}{\sum_{k=1...n} Y_{k}}
 
         Parameters
         ----------
@@ -813,8 +832,14 @@ class Media(ABC):
         match : called to create a 'blank' network
         """
         result = self.match(nports, **kwargs)
-
-        result.s =  splitter_s(self.frequency, nports, z0=result.z0)
+        
+        y0s = npy.array(1./result.z0)
+        y_k = y0s.sum(axis=1)
+        s = npy.zeros((self.frequency.npoints, nports, nports),
+                      dtype='complex')
+        s = 2 *npy.sqrt(npy.einsum('ki,kj->kij', y0s, y0s)) / y_k[:, None, None]
+        npy.einsum('kii->ki', s)[:] -= 1  # Sii
+        result.s =  s
         return result
 
 
@@ -1829,49 +1854,3 @@ def parse_z0(s: str) -> NumberLike:
     else:
         raise ValueError('couldnt parse z0 string')
     return out
-
-def splitter_s(frequency: Frequency, n: int,
-               z0: NumberLike | None = None) -> npy.ndarray:
-    r"""
-    Compute the scattering parametters of an n-port lossless splitter.
-    The port impedances can be mismatched and the power is split accordingly.
-    
-    For n > 2, the splitter is not matched because the power wave entering
-    one port meet the quivalent impedance of the other ports in parallel.
-    
-    .. math::
-        S_{ii} = \frac{Y_i - \sum_{j\neq i} Y_j}{Y_i + \sum_{j\neq i} Y_j}
-        = \frac{2Y_i}{\sum_{j=1...n} Y_j} - 1
-    
-    The remaining power is split between the other ports
-    
-    .. math::
-        \sum_{j=1...n} S_{ij}^2 = 1 - S_{ii}^2
-    
-    .. math::
-        S_{ij} = \frac{2\sqrt{Y_i \cdot Y_j}}{\sum_{k=1...n} Y_{k}}
-
-    Parameters
-    ----------
-    frequency : :class:`~skrf.frequency.Frequency` object or None
-        frequency band of this transmission line medium.
-        Used only to get the npoints dimension.
-    n  : int
-        number of ports
-    z0 : number, or array-like or None
-        port impedance. Default is None, in which case the splitter has the
-        same impedance on all ports.
-
-    Returns
-    -------
-    s : :class:`numpy.ndarray`
-        shape `f x n x n`
-    """
-    if z0 is None:
-        z0 = ones(frequency.npoints, n)
-    y0s = npy.array(1./z0)
-    y_k = y0s.sum(axis=1)
-    s = npy.zeros((frequency.npoints, n, n), dtype='complex')
-    s = 2 *npy.sqrt(npy.einsum('ki,kj->kij', y0s, y0s)) / y_k[:, None, None]
-    npy.einsum('kii->ki', s)[:] -= 1  # Sii
-    return s

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1830,8 +1830,8 @@ def parse_z0(s: str) -> NumberLike:
         raise ValueError('couldnt parse z0 string')
     return out
 
-def splitter_s(frequency: Frequency, n: int, z0: NumberLike | None = None) \
-    -> npy.ndarray:
+def splitter_s(frequency: Frequency, n: int, z0: NumberLike | None = None
+               )-> npy.ndarray:
     """
     Compute the scattering parametters of an n-port lossless splitter.
     The port impedances can be mismatched and the power is split accordingly.

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1830,8 +1830,8 @@ def parse_z0(s: str) -> NumberLike:
         raise ValueError('couldnt parse z0 string')
     return out
 
-def splitter_s(frequency: Frequency, n: int, z0: NumberLike | None = None
-               )-> npy.ndarray:
+def splitter_s(frequency: Frequency, n: int,
+               z0: NumberLike | None = None) -> npy.ndarray:
     """
     Compute the scattering parametters of an n-port lossless splitter.
     The port impedances can be mismatched and the power is split accordingly.

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -2,10 +2,11 @@ import os
 import unittest
 
 import numpy as npy
+from numpy.testing import assert_array_almost_equal
 
 from skrf.frequency import Frequency
 from skrf.media import DefinedGammaZ0
-from skrf.network import Network
+from skrf.network import concat_ports, connect, Network
 
 
 class DefinedGammaZ0TestCase(unittest.TestCase):
@@ -51,11 +52,33 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         """
         Test the naming of the network. When circuit is used to connect a
         topology of networks, they should have unique names.
+        Test mismatched splitter.
         """
         name = 'splitter'
         self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
         skrf_ntwk = self.dummy_media.splitter(3, name = name)
         self.assertEqual(name, skrf_ntwk.name)
+        
+    def test_mismatch_splitter(self):
+        """
+        Test mismatched splitter against 50-ohm splitter connected to
+        equivalent mismatched thrus.
+        """
+        freq = Frequency(1, 1, 1, unit='GHz')
+        med = DefinedGammaZ0(frequency=freq, z0=50)
+
+        for n in range(2, 5):
+            z_port = npy.arange(1, n + 1) * 20
+            split =med.splitter(n, z0=z_port)
+            thrus = []
+            for k in range(n):
+                thrus.append(med.thru(z0 = z_port[k]))
+            
+            # connect
+            thru = concat_ports(thrus, port_order='second')
+            ref = med.splitter(n)
+            ref = connect(ref, 0, thru, 0, n)
+            assert_array_almost_equal(split.s, ref.s)
 
     def test_thru(self):
         """
@@ -157,7 +180,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, -1+1j],
                                        [0, 1]])
         ABCD[:,0,1] = Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_shunt_resistor(self):
         """
@@ -172,7 +195,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         Z = 10 - 4j
         ntwk = self.dummy_media.shunt_resistor(Z)
         ABCD = npy.asarray([[[1, 0], [1/Z, 1]]])
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_capacitor(self):
         """
@@ -193,7 +216,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, -1+1j],
                                        [0, 1]])
         ABCD[:,0,1] = Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_shunt_capacitor(self):
         """
@@ -211,7 +234,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, 0],
                                        [-1+1j, 1]])
         ABCD[:,1,0] = 1/Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_capacitor_q(self):
         """
@@ -239,7 +262,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, -1+1j],
                                        [0, 1]])
         ABCD[:,0,1] = Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_inductor(self):
         """
@@ -260,7 +283,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, -1+1j],
                                        [0, 1]])
         ABCD[:,0,1] = Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_shunt_inductor(self):
         """
@@ -278,7 +301,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, 0],
                                        [1-1j, 1]])
         ABCD[:,1,0] = 1/Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_inductor_q(self):
         """
@@ -312,7 +335,7 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         ABCD = npy.full(ntwk.s.shape, [[1, -1+1j],
                                        [0, 1]])
         ABCD[:,0,1] = Z
-        npy.testing.assert_array_almost_equal(ABCD, ntwk.a)
+        assert_array_almost_equal(ABCD, ntwk.a)
 
     def test_attenuator(self):
         """
@@ -414,10 +437,10 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         Z0 = self.dummy_media.z0
         S11 = (R/Z0) / (R/Z0 + 2)
         S21 = 2 / (R/Z0 + 2)
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+        assert_array_almost_equal(ntw.s[:,0,0], S11)
+        assert_array_almost_equal(ntw.s[:,0,1], S21)
+        assert_array_almost_equal(ntw.s[:,1,0], S21)
+        assert_array_almost_equal(ntw.s[:,1,1], S11)
 
     def test_s_shunt_element(self):
         """
@@ -438,10 +461,10 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
         Z0 = self.dummy_media.z0
         S11 = -(1/R*Z0) / (1/R*Z0 + 2)
         S21 = 2 / (1/R*Z0 + 2)
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+        assert_array_almost_equal(ntw.s[:,0,0], S11)
+        assert_array_almost_equal(ntw.s[:,0,1], S21)
+        assert_array_almost_equal(ntw.s[:,1,0], S21)
+        assert_array_almost_equal(ntw.s[:,1,1], S11)
 
     def test_s_lossless_line(self):
         """
@@ -467,10 +490,10 @@ class STwoPortsNetworkTestCase(unittest.TestCase):
             (2*_z1*npy.cos(beta*l) + 1j*(_z1**2 + 1)*npy.sin(beta*l))
         S21 = 2*_z1 / \
             (2*_z1*npy.cos(beta*l) + 1j*(_z1**2 + 1)*npy.sin(beta*l))
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,0], S11)
-        npy.testing.assert_array_almost_equal(ntw.s[:,0,1], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,0], S21)
-        npy.testing.assert_array_almost_equal(ntw.s[:,1,1], S11)
+        assert_array_almost_equal(ntw.s[:,0,0], S11)
+        assert_array_almost_equal(ntw.s[:,0,1], S21)
+        assert_array_almost_equal(ntw.s[:,1,0], S21)
+        assert_array_almost_equal(ntw.s[:,1,1], S11)
 
     def test_s_lossy_line(self):
         """
@@ -514,10 +537,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         """
         R = 1.0  # Ohm
         ntw = self.dummy_media.resistor(R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,0], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,1], R)
+        assert_array_almost_equal(ntw.a[:,1,0], 0.0)
+        assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_shunt_element(self):
         """
@@ -535,10 +558,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         """
         R = 1.0  # Ohm
         ntw = self.dummy_media.shunt(self.dummy_media.resistor(R)**self.dummy_media.short())
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/R)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,0], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,1], 0.0)
+        assert_array_almost_equal(ntw.a[:,1,0], 1.0/R)
+        assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_series_shunt_elements(self):
         """
@@ -560,10 +583,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
 
         ntw = serie_resistor ** shunt_resistor
 
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0+Rs/Rp)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], Rs)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/Rp)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,0], 1.0+Rs/Rp)
+        assert_array_almost_equal(ntw.a[:,0,1], Rs)
+        assert_array_almost_equal(ntw.a[:,1,0], 1.0/Rp)
+        assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_thru(self):
         """
@@ -572,10 +595,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         [ 0  1 ]
         """
         ntw = self.dummy_media.thru()
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], 1.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 0.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 0.0)
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,0], 1.0)
+        assert_array_almost_equal(ntw.a[:,0,1], 0.0)
+        assert_array_almost_equal(ntw.a[:,1,0], 0.0)
+        assert_array_almost_equal(ntw.a[:,1,1], 1.0)
 
     def test_abcd_lossless_line(self):
         """
@@ -595,10 +618,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
         z0 = 80
         ntw = self.dummy_media.line(d=l, unit='m', z0=z0)
         beta = self.dummy_media.beta
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], npy.cos(beta*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], 1j*z0*npy.sin(beta*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1j/z0*npy.sin(beta*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], npy.cos(beta*l))
+        assert_array_almost_equal(ntw.a[:,0,0], npy.cos(beta*l))
+        assert_array_almost_equal(ntw.a[:,0,1], 1j*z0*npy.sin(beta*l))
+        assert_array_almost_equal(ntw.a[:,1,0], 1j/z0*npy.sin(beta*l))
+        assert_array_almost_equal(ntw.a[:,1,1], npy.cos(beta*l))
 
     def test_abcd_lossy_line(self):
         """
@@ -625,10 +648,10 @@ class ABCDTwoPortsNetworkTestCase(unittest.TestCase):
             )
         ntw = lossy_media.line(d=l, unit='m', z0=z0)
         gamma = lossy_media.gamma
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,0], npy.cosh(gamma*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,0,1], z0*npy.sinh(gamma*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,0], 1.0/z0*npy.sinh(gamma*l))
-        npy.testing.assert_array_almost_equal(ntw.a[:,1,1], npy.cosh(gamma*l))
+        assert_array_almost_equal(ntw.a[:,0,0], npy.cosh(gamma*l))
+        assert_array_almost_equal(ntw.a[:,0,1], z0*npy.sinh(gamma*l))
+        assert_array_almost_equal(ntw.a[:,1,0], 1.0/z0*npy.sinh(gamma*l))
+        assert_array_almost_equal(ntw.a[:,1,1], npy.cosh(gamma*l))
 
 class DefinedGammaZ0_s_def(unittest.TestCase):
     """Test various media constructs with complex ports and different s_def"""
@@ -679,3 +702,6 @@ class DefinedGammaZ0_s_def(unittest.TestCase):
         npy.testing.assert_allclose(thru_traveling.s, mismatch_traveling.s, rtol=1e-3)
         npy.testing.assert_allclose(thru_pseudo.s, mismatch_pseudo.s, rtol=1e-3)
         npy.testing.assert_allclose(thru_power.s, mismatch_power.s, rtol=1e-3)
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -149,7 +149,9 @@ class CircuitClassMethods(unittest.TestCase):
 class CircuitTestWilkinson(unittest.TestCase):
     """
     Create a Wilkinson power divider Circuit [#]_ and test the results
-    against theoretical ones (obtained in [#]_)
+    against network.connect.
+    The results in [#]_ do not agree due to an error in the formula (3)
+    for mismatched intersections.
 
     References
     ----------
@@ -223,33 +225,31 @@ class CircuitTestWilkinson(unittest.TestCase):
         assert_array_almost_equal(self.C._Y_k(self.connections[1]), Y2)
         assert_array_almost_equal(self.C._Y_k(self.connections[2]), Y2)
 
-    def test_reflection_coefficients(self):
-        """
-        Check if Xnn are correct wrt to ref P.Hallbjörner (2003)
-        """
-        assert_array_almost_equal(self.C._Xnn_k(self.connections[0])[0], self.X1_nn)
-        assert_array_almost_equal(self.C._Xnn_k(self.connections[1])[0], self.X2_nn)
-        assert_array_almost_equal(self.C._Xnn_k(self.connections[2])[0], self.X2_nn)
-
-    def test_transmission_coefficients(self):
-        """
-        Check if Xmn are correct wrt to ref P.Hallbjörner (2003)
-        """
-        assert_array_almost_equal(self.C._Xmn_k(self.connections[0])[0], np.r_[self.X1_m1, self.X1_m2, self.X1_m2])
-        assert_array_almost_equal(self.C._Xmn_k(self.connections[1])[0], np.r_[self.X2_m1, self.X2_m2, self.X2_m3])
-        assert_array_almost_equal(self.C._Xmn_k(self.connections[2])[0], np.r_[self.X2_m1, self.X2_m2, self.X2_m3])
-
+    @unittest.expectedFailure
     def test_sparam_individual_intersection_matrices(self):
         """
         Testing the individual intersection scattering matrices X_k
+        The results in [#]_ do not agree due to an error in the formula (3)
+        for mismatched intersections.
+
+        References
+        ----------
+        .. [#] P. Hallbjörner, Microw. Opt. Technol. Lett. 38, 99 (2003).
         """
         np.testing.assert_array_almost_equal(self.C._Xk(self.connections[0])[0], self.X1)
         np.testing.assert_array_almost_equal(self.C._Xk(self.connections[1])[0], self.X2)
         np.testing.assert_array_almost_equal(self.C._Xk(self.connections[2])[0], self.X2)
 
+    @unittest.expectedFailure
     def test_sparam_global_intersection_matrix(self):
         """
         Testing the global intersection scattering matrix
+        The results in [#]_ do not agree due to an error in the formula (3)
+        for mismatched intersections.
+
+        References
+        ----------
+        .. [#] P. Hallbjörner, Microw. Opt. Technol. Lett. 38, 99 (2003).
         """
         from scipy.linalg import block_diag
         assert_array_almost_equal(self.C.X[0], block_diag(self.X1, self.X2, self.X2) )


### PR DESCRIPTION
Fix issue #1022
It appears that formula (3) in P. Hallbjörner, Microw. Opt. Technol. Lett. 38, 99 (2003). does not work for mismatched intersections.
This was temporarily fixed for 2-connection intersections and is now generalized to n-connection intersections with mismatched port impedances.
- [x] Fix circuit
- [x] Optimize
- [x] Update test_circuit 
- [x] Add mismatched splitter to media and a test case