### PR TITLE
8510 Fixes

### DIFF
--- a/skrf/vi/validators.py
+++ b/skrf/vi/validators.py
@@ -158,6 +158,8 @@ class SetValidator(Validator):
         self.dtype = dtype
 
     def validate_input(self, arg) -> Any:
+        if isinstance(arg, str):
+            arg = arg.strip()
         arg = self.dtype(arg)
         if arg in self.valid:
             return arg

--- a/skrf/vi/vna/hp/hp8510c.py
+++ b/skrf/vi/vna/hp/hp8510c.py
@@ -63,7 +63,7 @@ class HP8510C(VNA):
         get_cmd='POIN;OUTPACTI;',
         set_cmd="STEP; POIN <arg>;",
         doc="""Number of frequency points""",
-        validator=SetValidator(_supported_npoints)
+        validator=SetValidator(_supported_npoints, lambda x: int(float(x.strip())))
     )
 
     is_continuous = VNA.command(
@@ -158,6 +158,7 @@ class HP8510C(VNA):
         ntwk.s = self.get_complex_data("OUTPDATA")
         f = self.frequency
         ntwk.frequency = f
+        ntwk.z0 = 50
 
         return ntwk
 
@@ -175,6 +176,7 @@ class HP8510C(VNA):
             [s12, s22]
         ]).transpose().reshape((-1, 2, 2))
         ntwk.frequency = freq
+        ntwk.z0 = 50
 
         return ntwk
 

--- a/skrf/vi/vna/hp/hp8510c.py
+++ b/skrf/vi/vna/hp/hp8510c.py
@@ -142,6 +142,9 @@ class HP8510C(VNA):
         vals_complex = (vals[:,0] + 1j * vals[:,1]).flatten()
         return vals_complex
 
+    def sweep(self):
+        self.write('SING;')
+
     def _get_oneport(self, parameter: tuple[int, int], sweep: bool=True):
         if any(p not in {1,2} for p in parameter):
             raise ValueError("The elements of parameter must be 1, or 2.")
@@ -153,7 +156,8 @@ class HP8510C(VNA):
 
         ntwk = skrf.Network(name=f"S{parameter[0]}{parameter[1]}")
         ntwk.s = self.get_complex_data("OUTPDATA")
-        ntwk.frequency = self.frequency
+        f = self.frequency
+        ntwk.frequency = f
 
         return ntwk
 
@@ -180,7 +184,7 @@ class HP8510C(VNA):
             raise ValueError("This instrument only has two ports. Must pass 1, 2, or (1,2)")
 
         if len(ports) == 1:
-            p = ports[0]
+            p = list(ports)[0]
             return self._get_oneport((p, p))
         else:
             return self._get_twoport()


### PR DESCRIPTION
Hi!

A few years back, I contributed an 8510 class for doing compound sweeps, but it happened at a bad time right before a refactor of the VNA classes. Life got in the way and I disappeared before I finished updating the code. Apologies for disappearing on you like that, but now I've got a new project with the 8510 and with it renewed time/motivation to work on this.

I am currently trying to figure out what VNA interface I should adapt my code to in order to maximize longevity. In a few months I will no longer have access to the 8510, so I would like to future-proof as much as practical. I started with the hp8510c.py I currently see in the project, but it has a number of basic problems that suggest it was written without the benefit of an 8510 to test against, so perhaps it is incomplete in other ways and not the best reference. I'd appreciate guidance on what to use as a "compatibility checklist/reference" for updating my code.

These patches suffice to  fix HP8510C get_snp_network([1]) and get_snp_network([1,2]), but they do spread some 8510-isms into places that might not want the complexity. For example, number of points is a string like '  2.01000000000E+02     \n', and this patchset contains updates to VNA.command to deal with that but I tend to suspect one-offing it in the 8510 class might be better from the view of isolating complexity. Is VNA.command important for metaprogramming somewhere or could I just define my own properties where convenient?