### PR TITLE
Reduce the circuit to obtain a Network-consistent "equivalent circuit"

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -719,7 +719,12 @@ class Circuit:
         S : :class:`numpy.ndarray`
             global scattering parameters of the circuit.
         """
-        return self.X @ np.linalg.inv(np.identity(self.dim) - self.C @ self.X)
+        X = self.X
+        C = self.C
+        T = - C @ X
+        idx = np.arange(self.dim)
+        T.real[:, idx, idx] += 1.0
+        return X @ np.linalg.inv(T)
 
     @property
     def port_indexes(self) -> list:

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -91,7 +91,7 @@ import numpy as np
 
 from .constants import INF, S_DEF_DEFAULT, NumberLike
 from .media import media
-from .network import Network, s2s
+from .network import Network, s2s, connect
 from .util import subplots
 
 if TYPE_CHECKING:
@@ -1320,3 +1320,66 @@ class Circuit:
         # remove x and y axis and labels
         ax.axis('off')
         fig.tight_layout()
+
+    @classmethod
+    def reduce_circuit(cls, circuit: Circuit) -> Circuit:
+        """
+        Return a Returns an reduced equivalent circuit with fewer components.
+
+        The reduced equivalent circuit allows faster calculation of the circuit network.
+
+        Parameters
+        ----------
+        circuit: The circuit need to reduce.
+
+        Returns
+        -------
+        reduced_circuit: The reduced circuit.
+        """
+        # Use list comprehension to find the connection need to be reduced
+        gen = (
+            (idx, cnx)
+            for idx, cnx in enumerate(circuit.connections)
+            if not (
+                any(getattr(ntwk, "_is_circuit_port", False) for ntwk, _ in cnx)
+                or len(cnx) != 2
+            )
+        )
+
+        # Get the first connection need to be reduced
+        skip_idx, cnx_to_reduce = next(gen, (-1, [(Network(), -1)] * 2))
+
+        # If there is no connection need to reduce, return the original circuit
+        if skip_idx == -1:
+            return circuit
+
+        # Connect the connecions need to be reduced
+        (ntwk1, k), (ntwk2, l) = cnx_to_reduce
+        ntwks_name = (ntwk1.name, ntwk2.name)
+
+        # Generate the connected network and the original port index
+        ntwk_tmp = connect(ntwkA=ntwk1, k=k, ntwkB=ntwk2, l=l)
+        orig_p = tuple(
+            tuple(i for i in range(ntwk.nports) if i != p) for ntwk, p in cnx_to_reduce
+        )
+
+        # Perform the reduction to get the reduced circuit connections
+        # Skip the connection that connected and replace the network and port index
+        reduced_cnxs = [
+            [
+                (
+                    (
+                        ntwk_tmp,
+                        orig_p[ntwks_name.index(ntwk.name)].index(port)
+                        + len(orig_p[: ntwks_name.index(ntwk.name)]),
+                    )
+                    if ntwk.name in ntwks_name
+                    else (ntwk, port)
+                )
+                for ntwk, port in cnx
+            ]
+            for idx, cnx in enumerate(circuit.connections)
+            if idx != skip_idx
+        ]
+
+        return cls.reduce_circuit(Circuit(reduced_cnxs))


### PR DESCRIPTION
This pull request provides a method that optimizes a given circuit represented by a **`Circuit`** object from the skrf library.

It iterates through the connections in the circuit, pre-connects networks that can be directly connected, and replaces the original two networks with the resulting connected network.

This process ensures that the final circuit maintains network equivalence while reducing the number of components. The optimized circuit allows for faster calculation of the overall network properties in large size circuit, for example.
```
import skrf as rf
import numpy as np
from time import time


def test_reduce_circuit():
    """
    Test reducing circuit function and speed comparison with direct method.
    """
    freq_n = 1001
    snp_n = 80

    freq = rf.Frequency(start=1, stop=2, npoints=freq_n, unit="GHz")
    line = rf.media.DefinedGammaZ0(frequency=freq, z0=50)

    Snp = [
        rf.Network(name=f"Snp{i}", s=np.random.rand(freq_n, 2, 2)) for i in range(snp_n)
    ]
    for i in range(snp_n):
        Snp[i].frequency = freq

    Gnd = [rf.Circuit.Ground(frequency=freq, name=f"Gnd{i}") for i in range(10)]

    Input1 = rf.Circuit.Port(frequency=freq, name="Input1")
    Input2 = rf.Circuit.Port(frequency=freq, name="Input2")
    Ind = [line.inductor(name=f"Ind{i}", L=1e-9) for i in range(5)]
    Output1 = rf.Circuit.Port(frequency=freq, name="Output1")

    connections = [
        [(Snp[24], 0), (Gnd[0], 0)],
        [(Snp[24], 1), (Snp[25], 0)],
        [(Snp[5], 0), (Gnd[1], 0)],
        [(Snp[5], 1), (Snp[6], 0)],
        [(Input1, 0), (Snp[1], 0)],
        [(Snp[12], 0), (Snp[11], 1)],
        [(Snp[12], 1), (Snp[13], 0)],
        [(Snp[30], 0), (Gnd[2], 0)],
        [(Snp[30], 1), (Snp[31], 0)],
        [(Snp[20], 0), (Snp[19], 1)],
        [(Snp[33], 0), (Snp[32], 1)],
        [(Snp[33], 1), (Snp[36], 1), (Snp[38], 0)],
        [(Input2, 0), (Snp[27], 0)],
        [(Snp[7], 0), (Snp[6], 1)],
        [(Snp[7], 1), (Snp[10], 1), (Snp[11], 0)],
        [(Snp[25], 1), (Snp[26], 0)],
        [(Snp[23], 0), (Snp[22], 1)],
        [(Snp[23], 1), (Output1, 0), (Snp[71], 1), (Ind[0], 0)],
        [(Snp[22], 0), (Snp[21], 1)],
        [(Snp[45], 0), (Gnd[3], 0)],
        [(Snp[45], 1), (Snp[47], 0)],
        [(Snp[13], 1), (Snp[14], 0)],
        [(Ind[0], 1), (Gnd[4], 0)],
        [(Snp[15], 0), (Gnd[5], 0)],
        [(Snp[15], 1), (Snp[16], 0)],
        [(Snp[27], 1), (Snp[28], 0)],
        [(Snp[32], 0), (Snp[47], 1), (Snp[46], 1)],
        [(Snp[35], 0), (Gnd[6], 0)],
        [(Snp[35], 1), (Snp[36], 0)],
        [(Snp[28], 1), (Snp[46], 0), (Snp[31], 1)],
        [(Snp[16], 1), (Snp[17], 0)],
        [(Snp[14], 1), (Snp[17], 1), (Snp[18], 0)],
        [(Snp[71], 0), (Snp[70], 1)],
        [(Snp[21], 0), (Snp[20], 1), (Snp[26], 1)],
        [(Snp[70], 0), (Snp[38], 1)],
        [(Snp[1], 1), (Snp[8], 0)],
        [(Snp[8], 1), (Snp[9], 0)],
        [(Snp[10], 0), (Snp[9], 1)],
        [(Snp[19], 0), (Snp[18], 1)],
    ]

    # Circuit connecting
    direct_start = time()
    direct_rst = rf.Circuit(connections).network.s
    direct_end = time()

    # Reduce the circuit
    reduce_start = time()
    reduce_rst = rf.reduce_circuit(rf.Circuit(connections)).network.s
    reduce_end = time()

    return (
        direct_end - direct_start,
        reduce_end - reduce_start,
        np.allclose(direct_rst, reduce_rst),
    )


if __name__ == "__main__":
    rst = np.array([test_reduce_circuit() for _ in range(50)])

    print(f"Direct method time: {np.mean(rst[:,0])*1000:.4f} ms")
    print(f"Reduce method time: {np.mean(rst[:,1])*1000:.4f} ms")
    print(f"Direct and reduce results are equal: {np.all(rst[:,2])}")
```

The test results on my PC are as follows. It can be seen that the reduce method has been improved by nearly 5 times (under OpenBLAS backend, MKL backend can be improved by 3 times also)
```
Direct method time: 1074.1992 ms
Reduce method time: 186.2764 ms
Direct and reduce results are equal: True
```
In a smaller Circuit, the test results may be opposite, but due to the small size of the X and C matrices in the Circuit, the absolute value of the time deviation between the two methods will be small.