### PR TITLE
Speed up Circuit.s_external property(method) by using block matrix ca…

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -785,11 +785,15 @@ class Circuit:
             Scattering parameters of the circuit for the external ports.
             Shape `f x nb_ports x nb_ports`
         """
-        # Global matrix version by indexing into s matrix
+        # The external S-matrix is the submatrix corresponding to external ports:
         # port_indexes = self.port_indexes
         # a, b = np.meshgrid(port_indexes, port_indexes, indexing='ij')
         # S_ext = self.s[:, a, b]
 
+        # Instead of calculating all S-parameters and taking a submatrix,
+        # the following faster approach only calculates external the S-parameters
+        # from block-matrix operations.
+        
         # generate index lists of internal and external ports
         port_indexes = self.port_indexes
         in_idxs = [(i,) for i in range(self.dim) if i not in port_indexes]

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -797,7 +797,7 @@ class Circuit:
         ext_l, in_l = len(ext_idxs), len(in_idxs)
 
         # generate index slices for each sub-matrices
-        idx_a, idx_b, idx_c, idx_d = [
+        idx_a, idx_b, idx_c, idx_d = (
             np.repeat(i, l, axis=1)
             for i, l in (
                 (ext_idxs, ext_l),
@@ -805,7 +805,7 @@ class Circuit:
                 (in_idxs, ext_l),
                 (in_idxs, in_l),
             )
-        ]
+        )
 
         # sub-matrices index, Matrix = [[A, B], [C, D]]]
         A_idx = (slice(None), idx_a, idx_a.T)

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -793,7 +793,6 @@ class Circuit:
         # Instead of calculating all S-parameters and taking a submatrix,
         # the following faster approach only calculates external the S-parameters
         # from block-matrix operations.
-        
         # generate index lists of internal and external ports
         port_indexes = self.port_indexes
         in_idxs = [(i,) for i in range(self.dim) if i not in port_indexes]


### PR DESCRIPTION
This pull request aims to enhance the performance of the `Circuit.s_external` property/method by implementing block matrix calculation instead of full calculation followed by indexing. Related to https://github.com/scikit-rf/scikit-rf/issues/574 https://github.com/scikit-rf/scikit-rf/pull/1069

My Benchmark code is as follows:
(The Circuit.s_external_block method in Benchmark is the modified code in this PR. Copy the s_external method in the PR to the local and rename it to s_external_block, so that this Bechmark code can run normally)

```python
import skrf as rf
import numpy as np
from time import time


def complex_cnxs(f_n: int):
    freq = rf.Frequency(start=1, stop=2, npoints=f_n, unit="GHz")
    line = rf.media.DefinedGammaZ0(frequency=freq, z0=50)

    snp_n = 80
    Snp = [
        rf.Network(name=f"Snp{i}", s=np.random.rand(f_n, 2, 2)) for i in range(snp_n)
    ]
    for i in range(snp_n):
        Snp[i].frequency = freq

    Gnd = [rf.Circuit.Ground(frequency=freq, name=f"Gnd{i}") for i in range(10)]

    Input1 = rf.Circuit.Port(frequency=freq, name="Input1")
    Input2 = rf.Circuit.Port(frequency=freq, name="Input2")
    Ind = [line.inductor(name=f"Ind{i}", L=1e-9) for i in range(5)]
    Output1 = rf.Circuit.Port(frequency=freq, name="Output1")

    connections = [
        [(Snp[24], 0), (Gnd[0], 0)],
        [(Snp[24], 1), (Snp[25], 0)],
        [(Snp[5], 0), (Gnd[1], 0)],
        [(Snp[5], 1), (Snp[6], 0)],
        [(Input1, 0), (Snp[1], 0)],
        [(Snp[12], 0), (Snp[11], 1)],
        [(Snp[12], 1), (Snp[13], 0)],
        [(Snp[30], 0), (Gnd[2], 0)],
        [(Snp[30], 1), (Snp[31], 0)],
        [(Snp[20], 0), (Snp[19], 1)],
        [(Snp[33], 0), (Snp[32], 1)],
        [(Snp[33], 1), (Snp[36], 1), (Snp[38], 0)],
        [(Input2, 0), (Snp[27], 0)],
        [(Snp[7], 0), (Snp[6], 1)],
        [(Snp[7], 1), (Snp[10], 1), (Snp[11], 0)],
        [(Snp[25], 1), (Snp[26], 0)],
        [(Snp[23], 0), (Snp[22], 1)],
        [(Snp[23], 1), (Output1, 0), (Snp[71], 1), (Ind[0], 0)],
        [(Snp[22], 0), (Snp[21], 1)],
        [(Snp[45], 0), (Gnd[3], 0)],
        [(Snp[45], 1), (Snp[47], 0)],
        [(Snp[13], 1), (Snp[14], 0)],
        [(Ind[0], 1), (Gnd[4], 0)],
        [(Snp[15], 0), (Gnd[5], 0)],
        [(Snp[15], 1), (Snp[16], 0)],
        [(Snp[27], 1), (Snp[28], 0)],
        [(Snp[32], 0), (Snp[47], 1), (Snp[46], 1)],
        [(Snp[35], 0), (Gnd[6], 0)],
        [(Snp[35], 1), (Snp[36], 0)],
        [(Snp[28], 1), (Snp[46], 0), (Snp[31], 1)],
        [(Snp[16], 1), (Snp[17], 0)],
        [(Snp[14], 1), (Snp[17], 1), (Snp[18], 0)],
        [(Snp[71], 0), (Snp[70], 1)],
        [(Snp[21], 0), (Snp[20], 1), (Snp[26], 1)],
        [(Snp[70], 0), (Snp[38], 1)],
        [(Snp[1], 1), (Snp[8], 0)],
        [(Snp[8], 1), (Snp[9], 0)],
        [(Snp[10], 0), (Snp[9], 1)],
        [(Snp[19], 0), (Snp[18], 1)],
    ]

    return connections


def simple_cnxs(f_n: int):
    freq = rf.Frequency(start=1, stop=2, npoints=f_n, unit="GHz")
    line = rf.media.DefinedGammaZ0(frequency=freq, z0=50)

    # network A
    ntwkA = rf.Network(name="a")
    ntwkA.frequency = freq
    ntwkA_z0 = (60, 70, 80, 90, 100)
    ntwkA.z0 = [ntwkA_z0] * f_n
    ntwkA.s = (
        np.random.default_rng()
        .random(f_n * len(ntwkA_z0) ** 2)
        .reshape(f_n, len(ntwkA_z0), len(ntwkA_z0))
    )

    # network B
    ntwkB = rf.Network(name="b")
    ntwkB.frequency = freq
    ntwkB_z0 = (10, 20, 30)
    ntwkB.z0 = [ntwkB_z0] * f_n
    ntwkB.s = (
        np.random.default_rng()
        .random(f_n * len(ntwkB_z0) ** 2)
        .reshape(f_n, len(ntwkB_z0), len(ntwkB_z0))
    )

    # Construct the connection
    port1 = rf.Circuit.Port(frequency=freq, name="port1", z0=50)
    port2 = rf.Circuit.Port(frequency=freq, name="port2", z0=50)
    ground1 = rf.Circuit.Ground(frequency=freq, name="ground1", z0=50)
    ground2 = rf.Circuit.Ground(frequency=freq, name="ground2", z0=50)
    open_port = rf.Circuit.Open(frequency=freq, name="open_port", z0=50)
    ind_shunt = line.inductor(50e-12, name="ind_shunt")
    cap_series = line.capacitor(30e-9, name="cap_series")
    port3 = rf.Circuit.Port(frequency=freq, name="port3", z0=50)
    port4 = rf.Circuit.Port(frequency=freq, name="port4", z0=50)

    connections = [
        [(ntwkA, 0), (cap_series, 0)],
        [(port1, 0), (ind_shunt, 0), (cap_series, 1)],
        [(ground1, 0), (ind_shunt, 1)],
        [(ntwkA, 1), (port2, 0)],
        [(ntwkA, 2), (ground2, 0)],
        [(ntwkA, 3), (open_port, 0)],
        [(ntwkA, 4), (ntwkB, 0)],
        [(ntwkB, 1), (port3, 0)],
        [(ntwkB, 2), (port4, 0)],
    ]

    return connections


def easy_cnxs(f_n: int):
    freq = rf.Frequency(start=1, stop=2, npoints=f_n, unit="GHz")
    line = rf.media.DefinedGammaZ0(frequency=freq, z0=50)

    # network A
    ntwkA = rf.Network(name="a")
    ntwkA.frequency = freq
    ntwkA_z0 = (60, 70, 80, 90, 100)
    ntwkA.z0 = [ntwkA_z0] * f_n
    ntwkA.s = (
        np.random.default_rng()
        .random(f_n * len(ntwkA_z0) ** 2)
        .reshape(f_n, len(ntwkA_z0), len(ntwkA_z0))
    )

    # Construct the connection
    port1 = rf.Circuit.Port(frequency=freq, name="port1", z0=50)
    port2 = rf.Circuit.Port(frequency=freq, name="port2", z0=50)
    port3 = rf.Circuit.Port(frequency=freq, name="port3", z0=50)
    port4 = rf.Circuit.Port(frequency=freq, name="port4", z0=50)
    port5 = rf.Circuit.Port(frequency=freq, name="port5", z0=50)

    connections = [
        [(ntwkA, 0), (port1, 0)],
        [(ntwkA, 1), (port2, 0)],
        [(ntwkA, 2), (port3, 0)],
        [(ntwkA, 3), (port4, 0)],
        [(ntwkA, 4), (port5, 0)],
    ]

    return connections


def test_reduce_circuit(connections):
    """
    Test block method and speed comparison with Index method.
    """
    # Index method, that is calculate the whole external S matrix, and index the ports
    index_start = time()
    index_rst = rf.Circuit(connections).s_external
    index_end = time()

    # Bloack method the circuit
    block_start = time()
    block_rst = rf.Circuit(connections).s_external_block
    block_end = time()

    return (
        (index_end - index_start) * 1000.0,
        (block_end - block_start) * 1000.0,
        np.allclose(index_rst, block_rst),
    )


if __name__ == "__main__":
    freq_n = 1001
    fcalls = 100

    for key, func in (
        ("Easy", easy_cnxs),
        ("Simple", simple_cnxs),
        ("Complex", complex_cnxs),
    ):
        connections = func(freq_n)

        rst = np.array([test_reduce_circuit(connections) for _ in range(fcalls)])

        print(f"Index method time in {key} example: {np.mean(rst[:,0]):.4f} ms, min: {np.min(rst[:,0]):.4f} ms, std: {np.std(rst[:,0]):.4f} ms")
        print(f"Block method time in {key} example: {np.mean(rst[:,1]):.4f} ms, min: {np.min(rst[:,1]):.4f} ms, std: {np.std(rst[:,1]):.4f} ms")

        print(f"Index and Block results are equal: {np.all(rst[:,2])}\n")

```

And the output is as follows, the provided benchmark results demonstrate notable speedups ranging from 10% to 30% across different scales of circuit calculations.

```
# MKL Backend
Index method time in Easy example: 4.9773 ms, min: 4.5533 ms, std: 0.2608 ms
Block method time in Easy example: 4.5311 ms, min: 4.0984 ms, std: 0.2449 ms
Index and Block results are equal: True

Index method time in Simple example: 17.1692 ms, min: 16.1066 ms, std: 0.7990 ms
Block method time in Simple example: 14.6554 ms, min: 13.6664 ms, std: 0.6485 ms
Index and Block results are equal: True

Index method time in Complex example: 402.4863 ms, min: 389.1032 ms, std: 5.5019 ms
Block method time in Complex example: 348.9205 ms, min: 339.8814 ms, std: 5.2407 ms
Index and Block results are equal: True

# OpenBLAS Backend
Index method time in Easy example: 17.9426 ms, min: 13.0880 ms, std: 1.4881 ms
Block method time in Easy example: 13.3860 ms, min: 9.4385 ms, std: 1.2090 ms
Index and Block results are equal: True

Index method time in Simple example: 64.1135 ms, min: 41.7631 ms, std: 16.3134 ms
Block method time in Simple example: 52.4727 ms, min: 39.8459 ms, std: 15.9302 ms
Index and Block results are equal: True

Index method time in Complex example: 1326.5239 ms, min: 970.4659 ms, std: 308.5768 ms
Block method time in Complex example: 1185.8280 ms, min: 874.0511 ms, std: 251.7308 ms
Index and Block results are equal: True
```

Your feedback and suggestions on this optimization are welcome!