### PR TITLE
Add valid case to convert_8term_2_12term function where switch_terms …

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -6472,24 +6472,35 @@ def convert_8term_2_12term(coefs_8term):
     k_first = coefs_8term.get('k first', k)
     k_second = coefs_8term.get('k second', k)
 
-    # taken from eq (36)-(39) in the Roger Marks paper given in the
-    # docstring
-    Elf  = Esr + (Err*gamma_f)/(1. - Edr * gamma_f)
-    Elr = Esf  + (Erf *gamma_r)/(1. - Edf  * gamma_r)
-    Etf  = ((Elf  - Esr)/gamma_f) * k_first
-    Etr = ((Elr - Esf )/gamma_r) * 1./k_second
-
     coefs_12term = {}
-    for l in ['forward directivity','forward source match',
-        'forward reflection tracking','reverse directivity',
-        'reverse reflection tracking','reverse source match',
-        'forward isolation', 'reverse isolation']:
-        coefs_12term[l] = coefs_8term[l].copy()
+
+    if True or (not (np.allclose(gamma_f, np.zeros_like(gamma_f))\
+            and np.allclose(gamma_r, np.zeros_like(gamma_r)))):
+        # taken from eq (36)-(39) in the Roger Marks paper given in the
+        # docstring
+        Elf  = Esr + (Err*gamma_f)/(1. - Edr * gamma_f)
+        Elr = Esf  + (Erf *gamma_r)/(1. - Edf  * gamma_r)
+        Etf  = ((Elf  - Esr)/gamma_f) * k_first
+        Etr = ((Elr - Esf )/gamma_r) * 1./k_second
+    else:
+        # taken from eq (40)-(44) in the Roger Marks paper given in the
+        # docstring
+        Elf = Esr
+        Elr = Esf
+        Etf = Err * k_first
+        Etr = Erf * 1. / k_second
 
     coefs_12term['forward load match'] = Elf
     coefs_12term['reverse load match'] = Elr
-    coefs_12term['forward transmission tracking'] =  Etf
-    coefs_12term['reverse transmission tracking'] =  Etr
+    coefs_12term['forward transmission tracking'] = Etf
+    coefs_12term['reverse transmission tracking'] = Etr
+
+    for l in ['forward directivity', 'forward source match',
+              'forward reflection tracking', 'reverse directivity',
+              'reverse reflection tracking', 'reverse source match',
+              'forward isolation', 'reverse isolation']:
+        coefs_12term[l] = coefs_8term[l].copy()
+
     return coefs_12term
 
 

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -6474,21 +6474,21 @@ def convert_8term_2_12term(coefs_8term):
 
     coefs_12term = {}
 
-    if (not (np.allclose(gamma_f, np.zeros_like(gamma_f))\
-            and np.allclose(gamma_r, np.zeros_like(gamma_r)))):
-        # taken from eq (36)-(39) in the Roger Marks paper given in the
-        # docstring
-        Elf  = Esr + (Err*gamma_f)/(1. - Edr * gamma_f)
-        Elr = Esf  + (Erf *gamma_r)/(1. - Edf  * gamma_r)
-        Etf  = ((Elf  - Esr)/gamma_f) * k_first
-        Etr = ((Elr - Esf )/gamma_r) * 1./k_second
-    else:
+    if np.allclose(gamma_f, np.zeros_like(gamma_f))\
+            or np.allclose(gamma_r, np.zeros_like(gamma_r)):
         # taken from eq (40)-(44) in the Roger Marks paper given in the
         # docstring
         Elf = Esr
         Elr = Esf
         Etf = Err * k_first
         Etr = Erf * 1. / k_second
+    else:
+        # taken from eq (36)-(39) in the Roger Marks paper given in the
+        # docstring
+        Elf  = Esr + (Err*gamma_f)/(1. - Edr * gamma_f)
+        Elr = Esf  + (Erf *gamma_r)/(1. - Edf  * gamma_r)
+        Etf  = ((Elf  - Esr)/gamma_f) * k_first
+        Etr = ((Elr - Esf )/gamma_r) * 1./k_second
 
     coefs_12term['forward load match'] = Elf
     coefs_12term['reverse load match'] = Elr

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -6474,7 +6474,7 @@ def convert_8term_2_12term(coefs_8term):
 
     coefs_12term = {}
 
-    if True or (not (np.allclose(gamma_f, np.zeros_like(gamma_f))\
+    if (not (np.allclose(gamma_f, np.zeros_like(gamma_f))\
             and np.allclose(gamma_r, np.zeros_like(gamma_r)))):
         # taken from eq (36)-(39) in the Roger Marks paper given in the
         # docstring

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -6474,20 +6474,22 @@ def convert_8term_2_12term(coefs_8term):
 
     coefs_12term = {}
 
-    if np.allclose(gamma_f, np.zeros_like(gamma_f))\
-            or np.allclose(gamma_r, np.zeros_like(gamma_r)):
-        # taken from eq (40)-(44) in the Roger Marks paper given in the
-        # docstring
+    if np.allclose(gamma_f, np.zeros_like(gamma_f)):
+        # taken from eq (40),(41) in the Roger Marks paper
         Elf = Esr
-        Elr = Esf
         Etf = Err * k_first
+    else:
+        # taken from eq (36),(38) in the Roger Marks paper
+        Elf = Esr + (Err * gamma_f) / (1. - Edr * gamma_f)
+        Etf = ((Elf - Esr) / gamma_f) * k_first
+
+    if np.allclose(gamma_r, np.zeros_like(gamma_r)):
+        # taken from eq (43),(44) in the Roger Marks paper
+        Elr = Esf
         Etr = Erf * 1. / k_second
     else:
-        # taken from eq (36)-(39) in the Roger Marks paper given in the
-        # docstring
-        Elf  = Esr + (Err*gamma_f)/(1. - Edr * gamma_f)
+        # taken from eq (37),(39) in the Roger Marks paper
         Elr = Esf  + (Erf *gamma_r)/(1. - Edf  * gamma_r)
-        Etf  = ((Elf  - Esr)/gamma_f) * k_first
         Etr = ((Elr - Esf )/gamma_r) * 1./k_second
 
     coefs_12term['forward load match'] = Elf

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -592,6 +592,21 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
         self.cal.apply_cal(self.X)
         self.assertEqual(dut_before, self.X)
 
+    def test_convert_8term_2_12term(self):
+        coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
+        coefs_8term = rf.convert_12term_2_8term(coefs_12term)
+        for k,v in self.cal.coefs.items():
+            np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
+
+    def test_convert_8term_2_12term_no_switch_terms(self):
+        self.cal.coefs['forward switch term'] = np.zeros(self.cal.frequency.npoints, dtype=complex)
+        self.cal.coefs['reverse switch term'] = np.zeros(self.cal.frequency.npoints, dtype=complex)
+        coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
+        coefs_8term = rf.convert_12term_2_8term(coefs_12term)
+        for k,v in self.cal.coefs.items():
+            np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
+
+
 class TRLTest(EightTermTest):
     def setUp(self):
         self.n_ports = 2

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -595,7 +595,7 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
     def test_convert_8term_2_12term(self):
         coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
         coefs_8term = rf.convert_12term_2_8term(coefs_12term)
-        for k,v in self.cal.coefs.items():
+        for k in self.cal.coefs.keys():
             np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
 
     def test_convert_8term_2_12term_no_switch_terms(self):
@@ -603,7 +603,7 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
         self.cal.coefs['reverse switch term'] = np.zeros(self.cal.frequency.npoints, dtype=complex)
         coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
         coefs_8term = rf.convert_12term_2_8term(coefs_12term)
-        for k,v in self.cal.coefs.items():
+        for k in self.cal.coefs.keys():
             np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
 
 

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 import warnings
 
@@ -592,20 +593,24 @@ class EightTermTest(unittest.TestCase, CalibrationTest):
         self.cal.apply_cal(self.X)
         self.assertEqual(dut_before, self.X)
 
-    def test_convert_8term_2_12term(self):
-        coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
-        coefs_8term = rf.convert_12term_2_8term(coefs_12term)
-        for k in self.cal.coefs.keys():
-            np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
+    def test_convert_8term_2_12term_subtests(self):
 
-    def test_convert_8term_2_12term_no_switch_terms(self):
-        self.cal.coefs['forward switch term'] = np.zeros(self.cal.frequency.npoints, dtype=complex)
-        self.cal.coefs['reverse switch term'] = np.zeros(self.cal.frequency.npoints, dtype=complex)
-        coefs_12term = rf.convert_8term_2_12term(self.cal.coefs)
-        coefs_8term = rf.convert_12term_2_8term(coefs_12term)
-        for k in self.cal.coefs.keys():
-            np.testing.assert_almost_equal(coefs_8term[k], self.cal.coefs[k])
+        for st in [
+            (self.cal.coefs['forward switch term'], self.cal.coefs['reverse switch term']),
+            (np.zeros(self.cal.frequency.npoints, dtype=complex), np.zeros(self.cal.frequency.npoints, dtype=complex)),
+            (self.cal.coefs['forward switch term'], np.zeros(self.cal.frequency.npoints, dtype=complex)),
+            (np.zeros(self.cal.frequency.npoints, dtype=complex), self.cal.coefs['reverse switch term']),
+        ]:
+            with self.subTest(st=st):
+                coefs = copy.deepcopy(self.cal.coefs)
 
+                coefs['forward switch term'] = st[0]
+                coefs['reverse switch term'] = st[1]
+
+                coefs_12term = rf.convert_8term_2_12term(coefs)
+                coefs_8term = rf.convert_12term_2_8term(coefs_12term)
+                for k in self.cal.coefs.keys():
+                    np.testing.assert_almost_equal(coefs_8term[k], coefs[k])
 
 class TRLTest(EightTermTest):
     def setUp(self):


### PR DESCRIPTION
…are not available

The original motivation for this is to perform a 8-term-to-12-term conversion for e.g. the UnknownThru calibration in the case that no switch terms are provided. In this case gamma_f and gamma_r are zero, leading to a division by zero and thus Etf/Etr being NaN.

This extension covers the implementation as defined in [1], eqs. (36)-(39), where the conversion is conducted without the switch terms being provided.

The current test cases do not cover this, as random switch terms are always provided. The test coverage could extended to another set of tests with no switch terms provided. This would then cause the convert_8term_2_12term to return zero Etf/Etr, which is wrong.

Up to you, if we should also extend the tests in this regard.

Best regards
Florian

[1] Marks, Roger B. 1997. ‘Formulations of the Basic Vector Network Analyzer Error Model Including Switch-Terms’. In 50th ARFTG Conference Digest, 32:115–26. https://doi.org/10.1109/ARFTG.1997.327265.
