### PR TITLE
Fix plot_minmax_bounds_component docs

### DIFF
--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -957,7 +957,7 @@ class NetworkSet:
         filename : string
             Output MDIF file name.
         values : dictionary or None. Default is None.
-            The keys of the dictionnary are MDIF variables and its values are
+            The keys of the dictionary are MDIF variables and its values are
             a list of the parameter values.
             If None, then the values will be set to the NetworkSet names
             and the datatypes will be set to "string".
@@ -1052,12 +1052,12 @@ class NetworkSet:
 
     def has_params(self) -> bool:
         """
-        Check is all Networks in the NetworkSet have a similar params dictionnary.
+        Check is all Networks in the NetworkSet have a similar params dictionary.
 
         Returns
         -------
         bool
-            True is all Networks have a .params dictionnay (of same size),
+            True is all Networks have a .params dictionary (of same size),
             False otherwise
 
         """
@@ -1100,7 +1100,7 @@ class NetworkSet:
     @property
     def params_values(self) -> dict | None:
         """
-        Return a dictionnary containing all parameters and their values.
+        Return a dictionary containing all parameters and their values.
 
         Returns
         -------
@@ -1122,7 +1122,7 @@ class NetworkSet:
     @property
     def params_types(self) -> dict | None:
         """
-        Return a dictionnary describing the data type of each parameters.
+        Return a dictionary describing the data type of each parameters.
 
         Returns
         -------
@@ -1214,7 +1214,7 @@ class NetworkSet:
             return NetworkSet()
 
         if not isinstance(indexers, dict):
-            raise TypeError('indexers should be a dictionnary.')
+            raise TypeError('indexers should be a dictionary.')
 
         for p in indexers.keys():
             if p not in self.dims:

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -1266,7 +1266,7 @@ def plot_uncertainty_bounds_component(
         tbd
     type : str
         if type=='bar', this controls frequency of error bars
-    ax : matplotlib axe object
+    ax : matplotlib axes object
         Axes to plot on. Default is None.
     ppf : function
         post processing function. a function applied to the
@@ -1347,20 +1347,23 @@ def plot_uncertainty_bounds_component(
 
 @axes_kwarg
 def plot_minmax_bounds_component(self: NetworkSet, attribute: str, m: int = 0, n: int = 0,
-                                 type: str = 'shade', n_deviations: int = 3,
-                                 alpha: float = .3, color_error: str | None = None,
+                                 type: str = 'shade', alpha: float = .3, color_error: str | None = None,
                                  markevery_error: int = 20, ax: plt.Axes = None,
                                  ppf: bool = None, kwargs_error: dict = None,
                                  **kwargs):
     r"""
-    Plots mean value of the NetworkSet with +/- uncertainty bounds in an Network's attribute.
+    Plots mean value of the NetworkSet with minimum and maximum bounds in an Network's attribute.
 
-    This is designed to represent uncertainty in a scalar component of the s-parameter. For example
-    plotting the uncertainty in the magnitude would be expressed by
+    This is designed to represent min/max in a scalar component of the s-parameter. For example
+    plotting the min/max in the magnitude would be expressed by
 
     .. math::
 
-        mean(|s|) \pm std(|s|)
+        min(|s|)
+
+        mean(|s|)
+
+        max(|s|)
 
     The order of mean and abs is important.
 
@@ -1374,17 +1377,15 @@ def plot_minmax_bounds_component(self: NetworkSet, attribute: str, m: int = 0, n
         second index of attribute matrix
     type : str
         ['shade' | 'bar'], type of plot to draw
-    n_deviations : int
-        number of std deviations to plot as bounds
     alpha : float
         passed to matplotlib.fill_between() command. [number, 0-1]
     color_error : str
-        color of the +- std dev fill shading. Default is None.
+        color of the min/max fill shading. Default is None.
     markevery_error : float
         tbd
     type : str
         if type=='bar', this controls frequency of error bars
-    ax : matplotlib axe object
+    ax : matplotlib axes object
         Axes to plot on. Default is None.
     ppf : function
         post processing function. a function applied to the


### PR DESCRIPTION
A quick PR to fix the documentation for `NetworkSet.plot_minmax_bounds_component`, which was a copy of `NetworkSet.plot_uncertainty_bounds_component`. Also removes an unused parameter and fixes some other docs typos.