### PR TITLE
Fixed the issue that the Network copy method lost some attributes.

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2029,6 +2029,12 @@ class Network:
           ntwk.noise = self.noise.copy()
           ntwk.noise_freq = self.noise_freq.copy()
 
+        # copy special attributes (such as _is_circuit_port) but skip methods
+        for attr in (set(dir(self)) - set(dir(ntwk))):
+            if callable(getattr(self, attr)):
+                continue
+            setattr(ntwk, attr, copy(getattr(self, attr)))
+
         try:
             ntwk.port_names = copy(self.port_names)
         except(AttributeError):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -73,6 +73,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
+        n._test_attr = 'test'
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)
         self.assertNotEqual( id(n.frequency), id(n2.frequency))
@@ -80,6 +81,8 @@ class NetworkTestCase(unittest.TestCase):
 
         n.frequency.f[0] = 0
         self.assertNotEqual(n2.frequency.f[0], 0)
+
+        self.assertEqual('test', getattr(n2, '_test_attr', None))
 
     def test_two_port_reflect(self):
         number_of_data_points = 10


### PR DESCRIPTION
This PR addresses the issue where the Network class's copy method fails to retain certain attributes. For example:
```python
>>> import skrf as rf
>>> frequency = rf.Frequency(1, 10, 101, 'ghz')
>>> P1 = rf.Circuit.Port(frequency=frequency, name='p1')
>>> P2 = P1.copy()
>>> P1._is_circuit_port
True
>>> P2._is_circuit_port
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/skrf/network.py", line 951, in __getattr__
    raise AttributeError
AttributeError
```
To ensure safety, the copy method only copies attributes and skips methods.