### PR TITLE
Reorder port names

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3316,6 +3316,9 @@ class Network:
         self.s[:, to_ports, :] = self.s[:, from_ports, :]  # renumber rows
         self.s[:, :, to_ports] = self.s[:, :, from_ports]  # renumber columns
         self.z0[:, to_ports] = self.z0[:, from_ports]
+        if self.port_names is not None:
+            self.port_names = np.array(self.port_names)
+            self.port_names[to_ports] = self.port_names[from_ports]
 
     def renumbered(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> Network:
         """

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -730,6 +730,18 @@ class NetworkTestCase(unittest.TestCase):
         c = rf.connect(gain,1,flipped,0)
         self.assertTrue(np.all(np.abs(c.s - np.array([[0,1],[1,0]])) < 1e-6))
 
+    def test_renumber(self):
+        ntwk = self.ntwk1
+        from_ports_num = [0,1]
+        to_ports_num = [1,0]
+        from_ports_name = ["A", "B"]
+        to_ports_name = ["B", "A"]
+
+        ntwk.port_names = from_ports_name
+        ntwk_renum = ntwk.renumbered(from_ports_num, to_ports_num)
+
+        np.array_equal(to_ports_name, ntwk_renum.port_names)
+
     def test_de_embed_by_inv(self):
         self.assertEqual(self.ntwk1.inv ** self.ntwk3, self.ntwk2)
         self.assertEqual(self.ntwk3 ** self.ntwk2.inv, self.ntwk1)


### PR DESCRIPTION
This PR updates `Network.port_names` when renumbering as requested in #1074 and adds associated test.