### PR TITLE
Optimize the performance of innerconnect_s method.

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5910,8 +5910,8 @@ def connect_s(A: np.ndarray, k: int, B: np.ndarray, l: int) -> np.ndarray:
 
     # create composite matrix, appending each sub-matrix diagonally
     C = np.zeros((nf, nC, nC), dtype='complex')
-    C[:, :nA, :nA] = A.copy()
-    C[:, nA:, nA:] = B.copy()
+    C[:, :nA, :nA] = A
+    C[:, nA:, nA:] = B
 
     # call innerconnect_s() on composit matrix C
     return innerconnect_s(C, k, nA + l)
@@ -5999,13 +5999,12 @@ def innerconnect_s(A: np.ndarray, k: int, l: int) -> np.ndarray:
 
     # create temporary matrices for calculation
     det = (Akl * Alk - Akk * All)
-    tmp_a = (Ael * Alk + Aek * All) / det
-    tmp_b = (Ael * Akk + Aek * Akl) / det
+    tmp_a = Ael * (Alk / det) + Aek * (All / det)
+    tmp_b = Ael * (Akk / det) + Aek * (Akl / det)
 
     # loop through ports and calculates resultant s-parameters
     for i in range(nA - 2):
-        for j in range(nA - 2):
-            C[:, i, j] += Ake[j] * tmp_a[i] + Ale[j] * tmp_b[i]
+        C[:, i, :] += (Ake * tmp_a[i] + Ale * tmp_b[i]).T
 
     return C
 


### PR DESCRIPTION
This PR aims to improve the performance of innerconnect_s method during Network connection. Related to https://github.com/scikit-rf/scikit-rf/issues/574 https://github.com/scikit-rf/scikit-rf/pull/1071

This PR is to achieve acceleration by reducing the number of for-loops and optimizing the location where `det` is calculated. These optimizations have demonstrated a nearly 20% performance improvement in my benchmarks.

Your feedback and suggestions on this optimization are welcome!

Benchmark Code
```python3
from timeit import timeit

import numpy as np


def comman_code(A: np.ndarray, k: int, l: int):
    if k > A.shape[-1] - 1 or l > A.shape[-1] - 1:
        raise (ValueError("port indices are out of range"))

    nA = A.shape[1]  # num of ports on input s-matrix

    # external ports index
    ext_i = [i for i in range(nA) if i not in (k, l)]

    # Indexing sub-matrices of internal ports (only k, l)
    Akl = 1.0 - A[:, k, l]
    Alk = 1.0 - A[:, l, k]
    Akk = A[:, k, k]
    All = A[:, l, l]

    # Indexing sub-matrices of other external ports
    Ake = A[:, k, ext_i].T
    Ale = A[:, l, ext_i].T
    Aek = A[:, ext_i, k].T
    Ael = A[:, ext_i, l].T

    # Create an suit-sized s-matrix, to store the result
    x, y = np.meshgrid(ext_i, ext_i)
    C = A[:, y, x]

    # create temporary matrices for calculation
    det = Akl * Alk - Akk * All

    return C, det, Ake, Ale, Aek, Ael, Akl, Alk, Akk, All, nA


def init_mehod(A: np.ndarray, k: int, l: int) -> np.ndarray:
    # This is the extracted public code
    C, det, Ake, Ale, Aek, Ael, Akl, Alk, Akk, All, nA = comman_code(A, k, l)

    tmp_a = (Ael * Alk + Aek * All) / det
    tmp_b = (Ael * Akk + Aek * Akl) / det

    # loop through ports and calculates resultant s-parameters
    for i in range(nA - 2):
        for j in range(nA - 2):
            C[:, i, j] += Ake[j] * tmp_a[i] + Ale[j] * tmp_b[i]

    return C


def modi_mehod(A: np.ndarray, k: int, l: int) -> np.ndarray:
    # This is the extracted public code
    C, det, Ake, Ale, Aek, Ael, Akl, Alk, Akk, All, nA = comman_code(A, k, l)

    tmp_a = Ael * (Alk / det) + Aek * (All / det)
    tmp_b = Ael * (Akk / det) + Aek * (Akl / det)

    # loop through ports and calculates resultant s-parameters
    for i in range(nA - 2):
        C[:, i, :] += (Ake * tmp_a[i] + Ale * tmp_b[i]).T

    return C


if __name__ == "__main__":
    nfreq, nports, ncalls = 2001, 16, 2000
    np.random.seed(0)
    A = np.random.rand(nfreq, nports, nports)
    k, l = 2, 3
    print(np.allclose(init_mehod(A.copy(), k, l), modi_mehod(A.copy(), k, l)))

    t1 = timeit(lambda: modi_mehod(A, k, l), number=ncalls) / ncalls * 1000.0
    print(f"Modified nethod: {t1:.4f}ms")

    t2 = timeit(lambda: init_mehod(A, k, l), number=ncalls) / ncalls * 1000.0
    print(f"Initial method: {t2:.4f}ms")

```
And the output is as follows,
```
True
Modified nethod: 1.3667ms
Initial method: 1.8151ms
```