### PR TITLE
Optimize the performance of Network copy mehod

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -251,18 +251,18 @@ class Circuit:
             return True
 
     @classmethod
-    def _is_port(cls, ntw):
+    def _is_port(cls, ntw: Network):
         """
         Return True is the network is a port, False otherwise
         """
-        return getattr(ntw, "_is_circuit_port", False)
+        return ntw._ext_attrs.get("_is_circuit_port", False)
 
     @classmethod
-    def _is_ground(cls, ntw):
+    def _is_ground(cls, ntw: Network):
         """
         Return True is the network is a ground, False otherwise
         """
-        return getattr(ntw, "_is_circuit_ground", False)
+        return ntw._ext_attrs.get("_is_circuit_ground", False)
 
     @classmethod
     def Port(cls, frequency: Frequency, name: str, z0: float = 50) -> Network:
@@ -296,8 +296,7 @@ class Circuit:
         """
         _media = media.DefinedGammaZ0(frequency, z0=z0)
         port = _media.match(name=name)
-        port._is_circuit_port = True
-        port._ext_attrs.append('_is_circuit_port')
+        port._ext_attrs['_is_circuit_port'] = True
         return port
 
     @classmethod
@@ -422,8 +421,7 @@ class Circuit:
 
         """
         ground = cls.ShuntAdmittance(frequency, Y=INF, name=name)
-        ground._is_circuit_ground = True
-        ground._ext_attrs.append('_is_circuit_ground')
+        ground._ext_attrs['_is_circuit_ground'] = True
         return ground
 
     @classmethod

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -296,7 +296,7 @@ class Circuit:
         """
         _media = media.DefinedGammaZ0(frequency, z0=z0)
         port = _media.match(name=name)
-        setattr(port, '_is_circuit_port', True)
+        port._is_circuit_port = True
         port._ext_attrs.append('_is_circuit_port')
         return port
 
@@ -422,7 +422,7 @@ class Circuit:
 
         """
         ground = cls.ShuntAdmittance(frequency, Y=INF, name=name)
-        setattr(ground, '_is_circuit_ground', True)
+        ground._is_circuit_ground = True
         ground._ext_attrs.append('_is_circuit_ground')
         return ground
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -296,7 +296,8 @@ class Circuit:
         """
         _media = media.DefinedGammaZ0(frequency, z0=z0)
         port = _media.match(name=name)
-        port._is_circuit_port = True
+        setattr(port, '_is_circuit_port', True)
+        port._ext_attrs.append('_is_circuit_port')
         return port
 
     @classmethod
@@ -421,7 +422,8 @@ class Circuit:
 
         """
         ground = cls.ShuntAdmittance(frequency, Y=INF, name=name)
-        ground._is_circuit_ground = True
+        setattr(ground, '_is_circuit_ground', True)
+        ground._ext_attrs.append('_is_circuit_ground')
         return ground
 
     @classmethod

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -487,6 +487,7 @@ class Media(ABC):
         result = Network(**kwargs)
         result.frequency = self.frequency
         result.s = np.zeros((self.frequency.npoints, nports, nports), dtype=complex)
+        result.port_modes = np.array(["S"] * result.nports)
         if z0 is None:
             if self.z0_port is None:
                 z0 = self.z0
@@ -538,6 +539,7 @@ class Media(ABC):
         result.s = np.array(Gamma0).reshape(-1, 1, 1) * \
             np.eye(nports, dtype=complex).reshape((-1, nports, nports)).\
             repeat(self.frequency.npoints, 0)
+        result.port_modes = np.array(["S"] * result.nports)
         return result
 
     def short(self, nports: int = 1,
@@ -1565,6 +1567,7 @@ class Media(ABC):
         """
         result = self.match(nports = n_ports, **kwargs)
         result.s = mf.rand_c(self.frequency.npoints, n_ports,n_ports)
+        result.port_modes = np.array(["S"] * result.nports)
         if reciprocal and n_ports>1:
             for m in range(n_ports):
                 for n in range(n_ports):

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2017,8 +2017,8 @@ class Network:
         """
         ntwk = Network(z0=self.z0, s_def=self.s_def, comments=self.comments)
 
-        ntwk.s = self.s
-        ntwk.frequency = self.frequency.copy()
+        ntwk._s = self.s.copy()
+        ntwk.frequency = self.frequency
         ntwk.port_modes = self.port_modes.copy()
 
         if self.params is not None:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2014,11 +2014,10 @@ class Network:
             Copy of the Network
 
         """
-        ntwk = Network(s=self.s,
-                       frequency=self.frequency,
-                       z0=self.z0, s_def=self.s_def,
-                       comments=self.comments
-                       )
+        ntwk = Network(z0=self.z0, s_def=self.s_def, comments=self.comments)
+
+        ntwk.s = self.s
+        ntwk.frequency = self.frequency.copy()
 
         if self.params is not None:
             ntwk.params = self.params.copy()

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5750,6 +5750,9 @@ def subnetwork(ntwk: Network, ports: int, offby:int = 1) -> Network:
     subntwk = Network(frequency=ntwk.frequency, z0=ntwk.z0[:,ports], name=subntwk_name)
     # keep requested rows and columns of the s-matrix. ports can be not contiguous
     subntwk.s = ntwk.s[np.ix_(np.arange(ntwk.s.shape[0]), ports, ports)]
+    # keep port_modes
+    if hasattr(ntwk, 'port_modes'):
+        subntwk.port_modes = [ntwk.port_modes[idx] for idx in ports]
     # keep port_names
     if ntwk.port_names:
         subntwk.port_names = [ntwk.port_names[idx] for idx in ports]

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -416,7 +416,7 @@ class Network:
         self.noise = None
         self.noise_freq = None
         self._z0 = np.array(50, dtype=complex)
-        self._ext_attrs = []
+        self._ext_attrs = {}
 
         if s_def not in S_DEFINITIONS and s_def is not None:
             raise ValueError('s_def parameter should be either:', S_DEFINITIONS)
@@ -2031,8 +2031,7 @@ class Network:
           ntwk.noise_freq = self.noise_freq.copy()
 
         # copy special attributes (such as _is_circuit_port) but skip methods
-        for attr in self._ext_attrs:
-            setattr(ntwk, attr, copy(getattr(self, attr)))
+        ntwk._ext_attrs = self._ext_attrs.copy()
 
         try:
             ntwk.port_names = copy(self.port_names)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -416,6 +416,7 @@ class Network:
         self.noise = None
         self.noise_freq = None
         self._z0 = np.array(50, dtype=complex)
+        self._ext_attrs = []
 
         if s_def not in S_DEFINITIONS and s_def is not None:
             raise ValueError('s_def parameter should be either:', S_DEFINITIONS)
@@ -2029,9 +2030,7 @@ class Network:
           ntwk.noise_freq = self.noise_freq.copy()
 
         # copy special attributes (such as _is_circuit_port) but skip methods
-        for attr in (set(dir(self)) - set(dir(ntwk))):
-            if callable(getattr(self, attr)):
-                continue
+        for attr in self._ext_attrs:
             setattr(ntwk, attr, copy(getattr(self, attr)))
 
         try:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2019,6 +2019,7 @@ class Network:
 
         ntwk.s = self.s
         ntwk.frequency = self.frequency.copy()
+        ntwk.port_modes = self.port_modes.copy()
 
         if self.params is not None:
             ntwk.params = self.params.copy()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -74,7 +74,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
-        setattr(n, '_test_attr', 'test')
+        n._test_attr = 'test'
         n._ext_attrs.append('_test_attr')
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -74,8 +74,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
-        n._test_attr = 'test'
-        n._ext_attrs.append('_test_attr')
+        n._ext_attrs['_test_attr'] = 'test'
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)
         self.assertNotEqual( id(n.frequency), id(n2.frequency))
@@ -84,7 +83,7 @@ class NetworkTestCase(unittest.TestCase):
         n.frequency.f[0] = 0
         self.assertNotEqual(n2.frequency.f[0], 0)
 
-        self.assertEqual('test', getattr(n2, '_test_attr', None))
+        self.assertEqual('test', n2._ext_attrs.get('_test_attr', None))
 
     def test_two_port_reflect(self):
         number_of_data_points = 10

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -74,7 +74,8 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
-        n._test_attr = 'test'
+        setattr(n, '_test_attr', 'test')
+        n._ext_attrs.append('_test_attr')
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)
         self.assertNotEqual( id(n.frequency), id(n2.frequency))


### PR DESCRIPTION
This PR aims to improve the performance of copy method. The `Network.copy()` method is widely called in the skrf package, such as `rf.connect()`, `Network.interpolate()` and other time-consuming methos.

This PR improves efficiency in two aspects:
1. **Direct Assignment to `ntwk._s`**: Since `self.s` is already broadcast-safety, directly assign values ​​to `ntwk._s` is efficient, instead of passing the s-parameters through the `ntwk.__init__()` method and using `s.setter` with `fix_param_shape()`.
2. In order to solve the issue https://github.com/scikit-rf/scikit-rf/pull/1085, `set(self.dir()) - set(ntwk.dir())` is used to identify extended attributes. Profiling revealed that `dir()` is quite slow, so I've added a `_ext_attrs` list to record extended attributes. **Note:** This approach requires manually adding the attribute's name to `_ext_attrs` list when setting the extended attributes. While this approach is efficient, it may not a robust solution (maybe we should create a `Network.set_ext_attr()` method to auto add attribute's name to `_ext_attrs` and set the value?).

Rather than directly comparing the performance of `Network.copy()`, it might be more meaningful to focus on more commonly used scenarios such as `rf.connect()`. These optimizations have shown nearly 35% performance improvement in my benchmarks.

Your feedback and suggestions on this optimization are welcome!

Benchmark Code:
```python
from time import time

import matplotlib.pyplot as plt
import numpy as np

import skrf as rf

if __name__ == "__main__":
    np.random.seed(0)

    fcalls = 500
    ts = []
    ports = range(2, 10)

    freqn, Bports = 501, 2
    freq = rf.Frequency(start=1, stop=10, npoints=freqn, unit="ghz")
    ntwkB = rf.Network(freqquency=freq)
    ntwkB.s = np.random.rand(freqn, Bports, Bports) + 1j * np.random.rand(
        freqn, Bports, Bports
    )

    for n in ports:
        np.random.seed(0)
        ntwkA = rf.Network(freqquency=freq)

        ntwkA.s = np.random.rand(freqn, n, n) + 1j * np.random.rand(freqn, n, n)

        tmp = []
        for _ in range(fcalls):
            s = -time()
            rf.connect(ntwkA, n - 1, ntwkB, 1)
            s += time()
            tmp.append(s * 1000)
        ts.append(np.min(tmp))

    plt.plot(ports, ts)
    plt.xlabel("Number of ports")
    plt.ylabel("Time taken (ms)")
    plt.ylim([0.1, 0.8])
    plt.show()
```
master branch benchmark:
![Master](https://github.com/scikit-rf/scikit-rf/assets/50561614/3b9a0575-9945-4184-b760-f6bb7e033b2e)
this branch benchmark:
![SpeedUp](https://github.com/scikit-rf/scikit-rf/assets/50561614/260ace8f-f319-4a57-9a73-d423c1ada4b4)
Speed up:
![1363a3e0-b3b7-48e2-963f-e0e623b49c13](https://github.com/scikit-rf/scikit-rf/assets/50561614/07b6f21d-ec1c-4e49-aa37-4476460f596c)