### PR TITLE
Optimize the performance of Circuit s_external mehod

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -859,8 +859,11 @@ class Circuit:
         D_idx = (slice(None), idx_d, idx_d.T)
 
         # Get the buffer of global matrix X, C and intermediate temporary matrix t
-        x, c = self.X, self.C
-        t = np.identity(x.shape[-1]) - c @ x
+        x, t = self.X, self.C
+        np.matmul(t, x, out=t)
+        np.negative(t, out=t)
+        idx = np.arange(x.shape[-1])
+        t[:, idx, idx] += (1.0+0.j)
 
         # Get the sub-matrices of inverse of intermediate temporary matrix t
         tmp_mat = np.linalg.solve(t[D_idx], t[C_idx])

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -863,13 +863,13 @@ class Circuit:
         t = np.identity(x.shape[-1]) - c @ x
 
         # Get the sub-matrices of inverse of intermediate temporary matrix t
-        tmp_mat = np.linalg.inv(t[D_idx]) @ t[C_idx]
-        tA_inv = np.linalg.inv(t[A_idx] - t[B_idx] @ tmp_mat)
-        tC_inv = -tmp_mat @ tA_inv
+        tmp_mat = np.linalg.solve(t[D_idx], t[C_idx])
 
         # Get the external S-parameters for the external ports
         # Calculated by multiplying the sub-matrices of x and t
-        S_ext = x[A_idx] @ tA_inv + x[B_idx] @ tC_inv
+        S_ext = (x[A_idx] - x[B_idx] @ tmp_mat) @ np.linalg.inv(
+            t[A_idx] - t[B_idx] @ tmp_mat
+        )
 
         S_ext = s2s(S_ext, self.port_z0, S_DEF_DEFAULT, 'traveling')
         return S_ext  # shape (nb_frequency, nb_ports, nb_ports)

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -859,13 +859,11 @@ class Circuit:
         D_idx = (slice(None), idx_d, idx_d.T)
 
         # Get the buffer of global matrix X, C and intermediate temporary matrix t
-        x, t = self.X, self.C
-        np.matmul(t, x, out=t)
-        np.negative(t, out=t)
-        idx = np.arange(x.shape[-1])
-        t[:, idx, idx] += (1.0+0.j)
+        x, c = self.X, self.C
+        t = np.identity(x.shape[-1]) - c @ x
 
         # Get the sub-matrices of inverse of intermediate temporary matrix t
+        # The method np.linalg.solve(A, B) is equivalent to np.inv(A) @ B, but more efficient
         tmp_mat = np.linalg.solve(t[D_idx], t[C_idx])
 
         # Get the external S-parameters for the external ports


### PR DESCRIPTION
This PR aims to improve the performance of s_external method. Related to https://github.com/scikit-rf/scikit-rf/issues/1011 https://github.com/scikit-rf/scikit-rf/pull/1070

This optimization accelerates the method by using `np.linalg.solve(A, B)` instead of `np.inv(A) @ B`. The benefits of this change become more pronounced as the circuit size increases. Benchmark code can be found in https://github.com/scikit-rf/scikit-rf/pull/1080, and the results are as follows:
master branch benchmark:
```bash
Total time in Easy example: 3.8792 ms, min: 3.7143 ms, std: 0.2074 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 8.1559 ms, min: 7.9134 ms, std: 0.2884 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 48.4151 ms, min: 43.9246 ms, std: 2.5155 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 48.1889 ms, min: 47.2999 ms, std: 0.8018 ms
Standard (47) and Optimized (13) results are equal: True
```
this branch benchmark:
```bash
Total time in Easy example: 3.5822 ms, min: 3.3584 ms, std: 0.1777 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 7.8416 ms, min: 7.4914 ms, std: 0.2966 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 41.4574 ms, min: 37.2748 ms, std: 3.1524 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 48.1995 ms, min: 47.0262 ms, std: 1.0177 ms
Standard (47) and Optimized (13) results are equal: True
```
If we set the `auto_reduce=False`, thus disable optimization to fully calculate the s-parameters of the entire circuit without pre-simplification, the results are as follows:
master branch benchmark:
```bash
Total time in Easy example: 4.3446 ms, min: 3.9978 ms, std: 0.4021 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 11.2693 ms, min: 10.0007 ms, std: 0.9517 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 328.7104 ms, min: 314.2743 ms, std: 5.3674 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 132.3545 ms, min: 126.2543 ms, std: 3.2932 ms
Standard (47) and Optimized (13) results are equal: True
```
this branch benchmark:
```bash
Total time in Easy example: 3.7349 ms, min: 3.4740 ms, std: 0.2870 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 10.4233 ms, min: 9.3174 ms, std: 0.5318 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 231.0316 ms, min: 224.7889 ms, std: 3.8924 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 83.1854 ms, min: 78.1748 ms, std: 2.6112 ms
Standard (47) and Optimized (13) results are equal: True
```
It can be seen that when `auto_reduce=False` is not performed, the speed of complex model and HFSS model with **more than 40 nodes** can be improved by nearly **30%**.

If necessary, I can submit a performance comparison between `np.linalg.solve(A, B)` and `np.inv(A) @ B` for different matrix sizes to clearly demonstrate the optimization effect.

Additionally, according to my current profiling, after applying this PR, the performance bottleneck will be concentrated on `np.matmul(t, x, out=t)`, that is to say `self.C @ self.X`. At present, I have no further ideas for optimizing matrix multiplication.

Your feedback and suggestions on this optimization are welcome!