### PR TITLE
Add MDIF functionality for improved interaction with ADS

### DIFF
--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -365,9 +365,10 @@ class Mdif:
               filename : str,
               values: dict | None = None,
               data_types: dict | None = None,
-              ads_compatible: bool = True,
+              *,
               comments: str | None = None,
-              skrf_comment: bool = True):
+              skrf_comment: bool = True,
+              ads_compatible: bool = True):
         """
         Write a MDIF file from a NetworkSet.
 
@@ -385,14 +386,14 @@ class Mdif:
         data_types: dictionary or None. Default is None.
             The keys are MDIF variables and the value are datatypes
             specified by the following strings: "int", "double", and "string"
-        ads_compatible: bool. Default is True.
-            Indicates whether to write the file in a format that
-            ADS will read properly.
         comments: list of strings
             Comments to add to output_file.
             Each list items is a separate comment line
         skrf_comment : bool, optional
             write `created by skrf` comment
+        ads_compatible: bool. Default is True.
+            Indicates whether to write the file in a format that
+            ADS will read properly.
 
         See Also
         --------

--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -444,11 +444,11 @@ class Mdif:
                     if p not in data_types:
                         data_types[p] = "double"
 
-                    var_type = "" if ads_compatible else f" {p}({dict_types[data_types[p]]})"
+                    var_type = "" if ads_compatible else f"({dict_types[data_types[p]]})"
                     if data_types[p] == "string":
-                        var_def_str = f'VAR{var_type} = "{values[p][filenumber]}"'
+                        var_def_str = f'VAR {p}{var_type} = "{values[p][filenumber]}"'
                     else:
-                        var_def_str = f"VAR{var_type} = {values[p][filenumber]}"
+                        var_def_str = f"VAR {p}{var_type} = {values[p][filenumber]}"
                     mdif.write(var_def_str + "\n")
 
                 mdif.write("\nBEGIN ACDATA\n")

--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -365,7 +365,9 @@ class Mdif:
               filename : str,
               values: dict | None = None,
               data_types: dict | None = None,
-              comments = None):
+              ads_compatible: bool = True,
+              comments: str | None = None,
+              skrf_comment: bool = True):
         """
         Write a MDIF file from a NetworkSet.
 
@@ -383,9 +385,14 @@ class Mdif:
         data_types: dictionary or None. Default is None.
             The keys are MDIF variables and the value are datatypes
             specified by the following strings: "int", "double", and "string"
+        ads_compatible: bool. Default is True.
+            Indicates whether to write the file in a format that
+            ADS will read properly.
         comments: list of strings
             Comments to add to output_file.
             Each list items is a separate comment line
+        skrf_comment : bool, optional
+            write `created by skrf` comment
 
         See Also
         --------
@@ -437,16 +444,17 @@ class Mdif:
                     if p not in data_types:
                         data_types[p] = "double"
 
+                    var_type = "" if ads_compatible else f" {p}({dict_types[data_types[p]]})"
                     if data_types[p] == "string":
-                        var_def_str = f'VAR {p}({dict_types[data_types[p]]}) = "{values[p][filenumber]}"'
+                        var_def_str = f'VAR{var_type} = "{values[p][filenumber]}"'
                     else:
-                        var_def_str = f"VAR {p}({dict_types[data_types[p]]}) = {values[p][filenumber]}"
+                        var_def_str = f"VAR{var_type} = {values[p][filenumber]}"
                     mdif.write(var_def_str + "\n")
 
                 mdif.write("\nBEGIN ACDATA\n")
                 mdif.write(optionstring + "\n")
                 mdif.write("! network name: " + ntwk.name + "\n")
-                data = ntwk.write_touchstone(return_string=True)
+                data = ntwk.write_touchstone(return_string=True, skrf_comment=skrf_comment)
                 mdif.write(data)
                 mdif.write("END\n\n")
 

--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -365,8 +365,8 @@ class Mdif:
               filename : str,
               values: dict | None = None,
               data_types: dict | None = None,
-              *,
               comments: str | None = None,
+              *,
               skrf_comment: bool = True,
               ads_compatible: bool = True):
         """

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2400,7 +2400,7 @@ class Network:
             except AttributeError:
                 pass
             if skrf_comment:
-                commented_header += '!Created with skrf (http://scikit-rf.org).\n'
+                commented_header += '! Created with skrf (http://scikit-rf.org).\n'
 
             output.write(commented_header)
 

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -948,7 +948,9 @@ class NetworkSet:
                    filename: str,
                    values: dict | None = None,
                    data_types: dict | None = None,
-                   comments = None):
+                   ads_compatible: bool = True,
+                   comments: str | None = None,
+                   skrf_comment: bool = True):
         """Convert a scikit-rf NetworkSet object to a Generalized MDIF file.
 
         Parameters
@@ -963,9 +965,14 @@ class NetworkSet:
         data_types: dictionary or None. Default is None.
             The keys are MDIF variables and the value are datatypes
             specified by the following strings: "int", "double", and "string"
+        ads_compatible: bool. Default is True.
+            Indicates whether to write the file in a format that
+            ADS will read properly.
         comments: list of strings
             Comments to add to output_file.
             Each list items is a separate comment line
+        skrf_comment : bool, optional
+            write `created by skrf` comment
 
         See Also
         --------
@@ -978,7 +985,8 @@ class NetworkSet:
         if comments is None:
             comments = []
         Mdif.write(ns=self, filename=filename, values=values,
-                             data_types=data_types, comments=comments)
+                   data_types=data_types, ads_compatible=ads_compatible,
+                   comments=comments, skrf_comment=skrf_comment)
 
     def ntwk_attr_2_df(self, attr='s_db',m=0, n=0, *args, **kwargs):
         """

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -948,9 +948,10 @@ class NetworkSet:
                    filename: str,
                    values: dict | None = None,
                    data_types: dict | None = None,
-                   ads_compatible: bool = True,
                    comments: str | None = None,
-                   skrf_comment: bool = True):
+                   *,
+                   skrf_comment: bool = True,
+                   ads_compatible: bool = True):
         """Convert a scikit-rf NetworkSet object to a Generalized MDIF file.
 
         Parameters
@@ -965,14 +966,14 @@ class NetworkSet:
         data_types: dictionary or None. Default is None.
             The keys are MDIF variables and the value are datatypes
             specified by the following strings: "int", "double", and "string"
-        ads_compatible: bool. Default is True.
-            Indicates whether to write the file in a format that
-            ADS will read properly.
         comments: list of strings
             Comments to add to output_file.
             Each list items is a separate comment line
         skrf_comment : bool, optional
             write `created by skrf` comment
+        ads_compatible: bool. Default is True.
+            Indicates whether to write the file in a format that
+            ADS will read properly.
 
         See Also
         --------

--- a/skrf/tests/test_networkSet.py
+++ b/skrf/tests/test_networkSet.py
@@ -402,6 +402,29 @@ class NetworkSetTestCase(unittest.TestCase):
                                   data_types=self.ns_params.params_types)
         ns_params = rf.NetworkSet.from_mdif(test_file)
         self.assertEqual(ns_params, self.ns_params)
+
+        # with parameters and passing explicitly values but not types and ads_compatible
+        self.ns_params.write_mdif(test_file,
+                                  values=self.ns_params.params_values,
+                                  ads_compatible=True)
+        ns_params = rf.NetworkSet.from_mdif(test_file)
+        self.assertEqual(ns_params, self.ns_params)
+
+        # with parameters and passing explicitly types but not values and ads_compatible
+        self.ns_params.write_mdif(test_file,
+                                  data_types=self.ns_params.params_types,
+                                  ads_compatible=True)
+        ns_params = rf.NetworkSet.from_mdif(test_file)
+        self.assertEqual(ns_params, self.ns_params)
+
+        # with parameters and passing explicitly values and types and ads_compatible
+        self.ns_params.write_mdif(test_file,
+                                  values=self.ns_params.params_values,
+                                  data_types=self.ns_params.params_types,
+                                  ads_compatible=True)
+        ns_params = rf.NetworkSet.from_mdif(test_file)
+        self.assertEqual(ns_params, self.ns_params)
+
         os.remove(test_file)
 
     def test_from_citi(self):


### PR DESCRIPTION
network.py
- Add a space in the SKRF comment

networkSet.py
- Two more booleans for the write_mdif method:
    - One to change how the variables are written which allows ADS to read the file properly
    - One to allow the user to remove the SKRF comment

io/mdif.py
- Pass through the same two booleans from the networkSet.py write_mdif method