### PR TITLE
Fixed the issue of incorrect voltage results in circuit connections.

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1233,7 +1233,11 @@ class Circuit:
         b = self._b(a)
         z0s = self.z0
         directions = self._currents_directions
-        Vs = (b[:,directions[:,0]] + b[:,directions[:,1]])*np.sqrt(z0s)
+        i_l, i_r = directions[:,0], directions[:,1]
+
+        z0_sqrt = np.sqrt(z0s)
+        gamma = (z0s[:,i_r]-z0s[:,i_l]) / (z0s[:,i_r]+z0s[:,i_l])
+        Vs = (b[:,i_l] * z0_sqrt[:,i_r] + b[:,i_r] * z0_sqrt[:,i_l]) * np.sqrt(1 - gamma**2)
         return Vs
 
     def currents_external(self, power: NumberLike, phase: NumberLike) -> np.ndarray:

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1203,7 +1203,11 @@ class Circuit:
         b = self._b(a)
         z0s = self.z0
         directions = self._currents_directions
-        Is = (b[:,directions[:,0]] - b[:,directions[:,1]])/np.sqrt(z0s)
+        i_l, i_r = directions[:,0], directions[:,1]
+
+        z0_sqrt = np.sqrt(z0s)
+        gamma = (z0s[:,i_r]-z0s[:,i_l]) / (z0s[:,i_r]+z0s[:,i_l])
+        Is = (b[:,i_l] / z0_sqrt[:,i_r] - b[:,i_r] / z0_sqrt[:,i_l]) * np.sqrt(1 - gamma**2)
         return Is
 
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1203,11 +1203,11 @@ class Circuit:
         b = self._b(a)
         z0s = self.z0
         directions = self._currents_directions
-        i_l, i_r = directions[:,0], directions[:,1]
+        i_l, i_r = directions[:, 0], directions[:, 1]
 
         z0_sqrt = np.sqrt(z0s)
-        gamma = (z0s[:,i_r]-z0s[:,i_l]) / (z0s[:,i_r]+z0s[:,i_l])
-        Is = (b[:,i_l] / z0_sqrt[:,i_r] - b[:,i_r] / z0_sqrt[:,i_l]) * np.sqrt(1 - gamma**2)
+        Is = (b[:,i_l] / z0_sqrt[:,i_r] - b[:,i_r] / z0_sqrt[:,i_l]) \
+            * (2*z0_sqrt[:,i_l] * z0_sqrt[:,i_r]) / (z0s[:,i_l] + z0s[:,i_r])
         return Is
 
 
@@ -1237,11 +1237,11 @@ class Circuit:
         b = self._b(a)
         z0s = self.z0
         directions = self._currents_directions
-        i_l, i_r = directions[:,0], directions[:,1]
+        i_l, i_r = directions[:, 0], directions[:, 1]
 
         z0_sqrt = np.sqrt(z0s)
-        gamma = (z0s[:,i_r]-z0s[:,i_l]) / (z0s[:,i_r]+z0s[:,i_l])
-        Vs = (b[:,i_l] * z0_sqrt[:,i_r] + b[:,i_r] * z0_sqrt[:,i_l]) * np.sqrt(1 - gamma**2)
+        Vs = (b[:,i_l] * z0_sqrt[:,i_r] + b[:,i_r] * z0_sqrt[:,i_l]) \
+            * (2*z0_sqrt[:,i_l] * z0_sqrt[:,i_r]) / (z0s[:,i_l] + z0s[:,i_r])
         return Vs
 
     def currents_external(self, power: NumberLike, phase: NumberLike) -> np.ndarray:

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -1061,6 +1061,29 @@ class CircuitTestVoltagesCurrents(unittest.TestCase):
         # (toward the Circuit's Port)
         np.testing.assert_allclose(self.I_out, -1*I_ports[:,1])
 
+    def test_tline_with_different_impedance(self):
+        ' Test voltages and currents for a simple transmission line with different impedances '
+        line = self.line.copy()
+        line.renormalize(z_new=1./self.Z)
+
+        # Equivalent model with Circuit
+        port1 = rf.Circuit.Port(frequency=self.freq, name='port1', z0=self.Z)
+        port2 = rf.Circuit.Port(frequency=self.freq, name='port2', z0=self.Z)
+        cnx = [
+            [(port1, 0), (line, 0)],
+            [(port2, 0), (line, 1)]
+        ]
+        crt = rf.Circuit(cnx)
+
+        V_ports_uni_z = crt.voltages(self.power, self.phase)
+        I_ports_uni_z = crt.currents(self.power, self.phase)
+
+        V_ports_dif_z = self.crt.voltages(self.power, self.phase)
+        I_ports_dif_z = self.crt.currents(self.power, self.phase)
+
+        np.testing.assert_allclose(I_ports_uni_z, I_ports_dif_z)
+        np.testing.assert_allclose(V_ports_uni_z, V_ports_dif_z)
+
 class CircuitTestVoltagesNonReciprocal(unittest.TestCase):
     def test_isolator(self):
         # Isolator that passes from port 1 to 2


### PR DESCRIPTION
Try to fix the issue https://github.com/scikit-rf/scikit-rf/issues/1106, In this PR, the output of the case mentioned in the Issue are shown as blow:
```bash
Result for z0: [[50.+0.j 50.+0.j]]:
[[[-0.21995821+1.22760113j -0.25338403-1.11897886j]
  [-0.27041083-0.0546119j   0.99939488+1.82918502j]]] S-parameters in external port
[[ 7.80041793+12.27601126j  7.80041793+12.27601126j
  -1.44312993 +1.28197898j -1.44312993 +1.28197898j
  -2.70410829 -0.546119j   -2.70410829 -0.546119j  ]] Voltage across ports

Result for z0: [[40.+0.j 40.+0.j]]:
[[[-0.21995821+1.22760113j -0.25338403-1.11897886j]
  [-0.27041083-0.0546119j   0.99939488+1.82918502j]]] S-parameters in external port
[[ 7.80041793+12.27601126j  7.80041793+12.27601126j
  -1.44312993 +1.28197898j -1.44312993 +1.28197898j
  -2.70410829 -0.546119j   -2.70410829 -0.546119j  ]] Voltage across ports
```
But I am still not sure whether the modification in this PR is completely correct, and I hope to get your suggestions. If this modification is proven to be correct, I will modify the calculation method of `Circuit.current()`.

Your feedback and suggestions on this optimization are welcome!