### PR TITLE
Enforce Network.port_names to be list even after renumbering

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3349,6 +3349,7 @@ class Network:
         if self.port_names is not None:
             self.port_names = np.array(self.port_names)
             self.port_names[to_ports] = self.port_names[from_ports]
+        self.port_names = list(self.port_names)
 
     def renumbered(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> Network:
         """

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3347,9 +3347,9 @@ class Network:
             self.s[:, :, to_ports] = self.s[:, :, from_ports]  # renumber columns
         self.z0[:, to_ports] = self.z0[:, from_ports]
         if self.port_names is not None:
-            self.port_names = np.array(self.port_names)
-            self.port_names[to_ports] = self.port_names[from_ports]
-        self.port_names = list(self.port_names)
+            _port_names = np.array(self.port_names)
+            _port_names[to_ports] = _port_names[from_ports]
+            self.port_names = _port_names.tolist()
 
     def renumbered(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> Network:
         """

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -744,7 +744,7 @@ class NetworkTestCase(unittest.TestCase):
         ntwk.port_names = from_ports_name
         ntwk_renum = ntwk.renumbered(from_ports_num, to_ports_num)
 
-        np.array_equal(to_ports_name, ntwk_renum.port_names)
+        assert to_ports_name == ntwk_renum.port_names
 
     def test_de_embed_by_inv(self):
         self.assertEqual(self.ntwk1.inv ** self.ntwk3, self.ntwk2)


### PR DESCRIPTION
## Problem Statement

After renumbering the `skrf.Network`, it cannot export touchstone for the reason that `skrf.Network.port_names` becomes `np.ndarray`.

One can execute the following code and repeat this error

### Codes

```python
import numpy as np
import skrf as rf
import os 

output_dir = r'D:\.'
s_params = np.array([[[0.5 + 0.5j, 0.1 + 0.1j], 
                      [0.1 + 0.1j, 0.5 + 0.5j]]])

frequencies = np.array([1e9,])

network = rf.Network(frequency=rf.Frequency.from_f(frequencies, unit='hz'), s=s_params)
network.port_names = ['PortA', 'PortB']
print(network.port_names) # ['PortA', 'PortB']
network.write_touchstone(os.path.join(output_dir, 'before.s2p')) # Succeed

network.renumber([0,1], [1,0])
print(network.port_names) # ['PortB', 'PortA']
network.write_touchstone(os.path.join(output_dir, 'after.s2p')) # Raise ValueError
```

### Error
```python
  File ~\Desktop\Python\__VENV\QtPy311\Lib\site-packages\skrf\network.py:2426 in write_touchstone
    if ntwk.port_names and len(ntwk.port_names) == ntwk.number_of_ports:

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```


## Solution

After using `renumber`, renumbered `port_names`  becomes `np.ndarray`. 
Please look at code at `site-packages\skrf\network.py` from line 2425 to line 2432
```python
            try:
                if ntwk.port_names and len(ntwk.port_names) == ntwk.number_of_ports:
                    ports = ''
                    for port_idx, port_name in enumerate(ntwk.port_names):
                        ports += f'! Port[{port_idx+1}] = {port_name}\n'
                    output.write(ports)
            except AttributeError:
                pass
```
`write_touchstone` will check if the portname exists or not, so `if ntwk.port_names` will trigger the error
`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`



Hence, just enforce the final `port_names` to be `list`