### PR TITLE
Adding S-parameter definition in Touchstone V1 comment

### DIFF
--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -496,7 +496,14 @@ class Touchstone:
             #if state.ansys_data_type == "terminal":
             #    self.z0 = np.diagonal(self.z0.reshape(-1, self.rank, self.rank), axis1=1, axis2=2)
 
-            self.s_def = S_DEF_HFSS_DEFAULT
+            # Load the reference impedance convention from the comments
+            is_hfss_s_def = True
+            for s_def in ('power', 'traveling', 'pseudo'):
+                if f"{s_def} convention" in ''.join(self.comments):
+                    # If the s_def definition is found in the comments, use it.
+                    self.s_def = s_def
+                    is_hfss_s_def = False
+            self.s_def = S_DEF_HFSS_DEFAULT if is_hfss_s_def else self.s_def
             self.has_hfss_port_impedances = True
         elif self.reference is None:
             self.z0 = np.broadcast_to(self.resistance, (len(state.f), state.rank)).copy()

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -496,14 +496,12 @@ class Touchstone:
             #if state.ansys_data_type == "terminal":
             #    self.z0 = np.diagonal(self.z0.reshape(-1, self.rank, self.rank), axis1=1, axis2=2)
 
-            # Load the reference impedance convention from the comments
             self.s_def = S_DEF_HFSS_DEFAULT
             self.has_hfss_port_impedances = True
-            # If the s_def definition is found in the comments, use it.
+            # Load the reference impedance convention from the comments
             for s_def in S_DEFINITIONS:
-                if f"{s_def} convention" in self.comments:
+                if f'S-parameter uses the {s_def} definition' in self.comments:
                     self.s_def = s_def
-
         elif self.reference is None:
             self.z0 = np.broadcast_to(self.resistance, (len(state.f), state.rank)).copy()
         else:

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -36,7 +36,7 @@ from typing import Callable
 
 import numpy as np
 
-from ..constants import FREQ_UNITS, S_DEF_HFSS_DEFAULT
+from ..constants import FREQ_UNITS, S_DEF_HFSS_DEFAULT, S_DEFINITIONS
 from ..media import DefinedGammaZ0
 from ..network import Network
 from ..util import get_fid
@@ -497,14 +497,13 @@ class Touchstone:
             #    self.z0 = np.diagonal(self.z0.reshape(-1, self.rank, self.rank), axis1=1, axis2=2)
 
             # Load the reference impedance convention from the comments
-            is_hfss_s_def = True
-            for s_def in ('power', 'traveling', 'pseudo'):
-                if f"{s_def} convention" in ''.join(self.comments):
-                    # If the s_def definition is found in the comments, use it.
-                    self.s_def = s_def
-                    is_hfss_s_def = False
-            self.s_def = S_DEF_HFSS_DEFAULT if is_hfss_s_def else self.s_def
+            self.s_def = S_DEF_HFSS_DEFAULT
             self.has_hfss_port_impedances = True
+            # If the s_def definition is found in the comments, use it.
+            for s_def in S_DEFINITIONS:
+                if f"{s_def} convention" in self.comments:
+                    self.s_def = s_def
+
         elif self.reference is None:
             self.z0 = np.broadcast_to(self.resistance, (len(state.f), state.rank)).copy()
         else:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2409,7 +2409,7 @@ class Network:
             # exactly this format, to work
             # [HZ/KHZ/MHZ/GHZ] [S/Y/Z/G/H] [MA/DB/RI] [R n]
             if write_z0:
-                output.write('!Data is not renormalized\n')
+                output.write(f'! Data is not renormalized according to the {self.s_def} convention.\n')
                 output.write(f'# {ntwk.frequency.unit} S {form} R\n')
             else:
                 # Write "r_ref.real" instead of "r_ref", so we get a real number "a" instead

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2409,7 +2409,8 @@ class Network:
             # exactly this format, to work
             # [HZ/KHZ/MHZ/GHZ] [S/Y/Z/G/H] [MA/DB/RI] [R n]
             if write_z0:
-                output.write(f'! Data is not renormalized according to the {self.s_def} convention.\n')
+                output.write('! Data is not renormalized\n')
+                output.write(f'! S-parameter uses the {self.s_def} definition\n')
                 output.write(f'# {ntwk.frequency.unit} S {form} R\n')
             else:
                 # Write "r_ref.real" instead of "r_ref", so we get a real number "a" instead

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1066,6 +1066,8 @@ class NetworkTestCase(unittest.TestCase):
         ntwk_orig.write_touchstone(os.path.join(self.test_dir, pwfile_skrf), write_z0=True, form='RI')
         ntwk_skrf = rf.Network(os.path.join(self.test_dir, pwfile_skrf))
 
+        # check if the s_def could be correctly recovered from scikit-rf's Touchstone file
+        self.assertTrue(ntwk_orig.s_def == ntwk_skrf.s_def)
         self.assertTrue(ntwk_orig == ntwk_skrf)
 
     def test_network_from_z_or_y(self):

--- a/skrf/tests/tmp_skrf_oneport_powerwave.s1p
+++ b/skrf/tests/tmp_skrf_oneport_powerwave.s1p
@@ -9,7 +9,8 @@
 !Data is not renormalized
 !
 ! Created with skrf (http://scikit-rf.org).
-! Data is not renormalized according to the power convention.
+! Data is not renormalized
+! S-parameter uses the power definition
 # GHz S RI R
 ! Port[1] = 1
 !freq ReS11 ImS11

--- a/skrf/tests/tmp_skrf_oneport_powerwave.s1p
+++ b/skrf/tests/tmp_skrf_oneport_powerwave.s1p
@@ -8,8 +8,8 @@
 ! YY = 1
 !Data is not renormalized
 !
-!Created with skrf (http://scikit-rf.org).
-!Data is not renormalized
+! Created with skrf (http://scikit-rf.org).
+! Data is not renormalized according to the power convention.
 # GHz S RI R
 ! Port[1] = 1
 !freq ReS11 ImS11


### PR DESCRIPTION
### **Description of the PR**
Try to fix the issue https://github.com/scikit-rf/scikit-rf/issues/1116.

In this PR, the reference impedance convention (`s_def`) will be included in the TouchStone file if `write_z0=True` is set in the  `write_touchstone` method.

### **Touchstone File saving change**
For example, the comments in the `skrf/tests/tmp_skrf_oneport_powerwave.s1p` file created by `scikit-rf` are updated from:
```
!Created with skrf (http://scikit-rf.org).
!Data is not renormalize
```
to:
```
! Created with skrf (http://scikit-rf.org).
! Data is not renormalized according to the power convention.
```
The keywords `power convention`, `pseudo convention` and `traveling convention` are used in comments to identify the reference impedance convention (`s_def`).

### **Touchstone File loading change**
If the reference impedance convention (`s_def`) is specified in the comments, that convention will be used. Otherwise, the default `S_DEF_HFSS_DEFAULT` (i.e. the `traveling` definition) will be applied in `hfss_impedance` pattern.