### PR TITLE
Fixed the issue of deteriorating circuit performance with super large-scale networks (like HFSS)

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1453,7 +1453,8 @@ class Circuit:
 ## Functions operating on Circuit
 def reduce_circuit(connections: list[list[tuple[Network, int]]],
                    check_duplication: bool = True,
-                   split_ground: bool = False) -> list[list[tuple[Network, int]]]:
+                   split_ground: bool = False,
+                   max_nports: int = 20) -> list[list[tuple[Network, int]]]:
     """
     Return a reduced equivalent circuit connections with fewer components.
 
@@ -1468,6 +1469,11 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             If True, check if the connections have duplicate names. Default is True.
     split_ground : bool, optional.
             If True, split the global ground connection to independant ground connections. Default is False.
+    max_nports : int
+            The maximum number of ports of a Network that can be reduced in circuit. If a Network in the
+            circuit has a number of ports (nports), using the Network.connect() method to reduce the circuit's
+            dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
+            This value depends on the performance of the computer and the scale of the circuit. Default is 20.
 
 
     Returns
@@ -1489,8 +1495,9 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     True
     """
 
-    def invalide_to_reduce(cnx):
-        return any(Circuit._is_port(ntwk) for ntwk, _ in cnx) or len(cnx) != 2
+    def invalide_to_reduce(cnx: list[tuple[Network, int]]) -> bool:
+        return any((Circuit._is_port(ntwk) or ntwk.nports > max_nports)
+                   for ntwk, _ in cnx) or len(cnx) != 2
 
     if split_ground:
         tmp_cnxs = []


### PR DESCRIPTION
A large `Network` in the circuit (such as `HFSS`) can negatively impact the performance of the `reduce_circuit()` method. By adding a `max_nports` parameter, large `Networks` can be excluded from the reduction process, thus improving performance.

Benchmark code is based on https://github.com/scikit-rf/scikit-rf/pull/1080. This code uses the `HFSS_cnxs()` method to create the circuit's connections and employs `hfss_ntwk.s = np.random.rand(f_n, nports, nports) + 1.0j * np.random.rand(f_n, nports, nports)` to simulate large `Network` cases of different sizes.
The results are as follows:
![Picture1](https://github.com/scikit-rf/scikit-rf/assets/50561614/44576fd0-097f-4913-a364-c40c21ec6699)
