### PR TITLE
Optimize interpolation performance by pre-cropping data.

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -5232,7 +5232,7 @@ class LMR16(SixteenTerm):
         if switch_terms is None:
             warn('No switch terms provided', stacklevel=2)
 
-        if type(ideals) == Network:
+        if isinstance(ideals, Network):
             ideals = [ideals]
         if len(ideals) != 1:
             raise ValueError("One ideal must be given: Through or reflect definition.")

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2791,10 +2791,12 @@ class Network:
             f_kwargs = {}
         result = self.copy()
 
+        is_rational = False
         if kwargs.get('kind', None) == 'rational':
             f_interp = mf.rational_interp
             #Not supported by rational_interp
             del kwargs['kind']
+            is_rational = True
         else:
             f_interp = interp1d
 
@@ -2821,8 +2823,10 @@ class Network:
         f_new = new_frequency.f
 
         # Pre-cropped the frequency
-        l_idx = max(np.searchsorted(f, f_new[0], side="left") - 1, 0)
-        r_idx = min(np.searchsorted(f, f_new[-1], side="right") + 1, len(f))
+        l_idx = max(np.searchsorted(f, f_new[0], side="left") - 8, 0)
+        r_idx = min(np.searchsorted(f, f_new[-1], side="right") + 8, len(f))
+        if is_rational:
+            l_idx, r_idx = 0, len(f)
         f_cropped = f[l_idx:r_idx]
 
         # interpolate z0  ( this must happen first, because its needed

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2735,6 +2735,10 @@ class Network:
             return the interpolated array instead of re-assigning it to
             a given attribute
         **kwargs : keyword arguments
+            passed to interpolate method.
+            `freq_cropped` kwarg controls whether to use pre-cropped frequency
+            points for interpolation. Defaults to True.
+
             passed to :func:`scipy.interpolate.interp1d` initializer.
             `kind` controls interpolation type.
 
@@ -2750,7 +2754,11 @@ class Network:
 
         Note
         ----
-        The interpolation coordinate system (`coords`)  makes  a big
+        Frequency cropping is only supported with methods from
+        `scipy.interpolate.interpolate.interp1d`. The 'rational' method does
+        not support frequency cropping.
+
+        The interpolation coordinate system (`coords`)  makes a big
         difference for large amounts of interpolation. polar works well
         for duts with slowly changing magnitude. try them all.
 
@@ -2825,7 +2833,9 @@ class Network:
         # Pre-cropped the frequency
         l_idx = max(np.searchsorted(f, f_new[0], side="left") - 8, 0)
         r_idx = min(np.searchsorted(f, f_new[-1], side="right") + 8, len(f))
-        if is_rational:
+
+        # rational method or prohibit frequency clipping
+        if is_rational or not kwargs.get('freq_cropped', True):
             l_idx, r_idx = 0, len(f)
         f_cropped = f[l_idx:r_idx]
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2820,6 +2820,11 @@ class Network:
         f = self.frequency.f
         f_new = new_frequency.f
 
+        # Pre-cropped the frequency
+        l_idx = max(np.searchsorted(f, f_new[0], side="left") - 1, 0)
+        r_idx = min(np.searchsorted(f, f_new[-1], side="right") + 1, len(f))
+        f_cropped = f[l_idx:r_idx]
+
         # interpolate z0  ( this must happen first, because its needed
         # to compute the basis transform below (like y2s), if basis!='s')
         if np.all(self.z0 == self.z0[0]):
@@ -2828,17 +2833,18 @@ class Network:
             z0_shape[0] = len(f_new)
             result._z0 = np.ones(z0_shape) * self.z0[0]
         else:
-            result._z0 = f_interp(f, self.z0, axis=0, **kwargs)(f_new)
+            result._z0 = f_interp(f_cropped, self.z0[l_idx:r_idx], axis=0, **kwargs)(f_new)
 
-        # interpolate  parameter for a given basis
-        x = getattr(self, basis)
+        # interpolate parameter for a given basis
+        x: np.ndarray = getattr(self, basis)
+        x_cropped = x[l_idx:r_idx]
         if coords == 'cart':
-            x_new = f_interp(f, x, axis=0, **kwargs)(f_new)
+            x_new = f_interp(f_cropped, x_cropped, axis=0, **kwargs)(f_new)
         elif coords == 'polar':
-            rad = np.unwrap(np.angle(x), axis=0)
-            mag = np.abs(x)
-            interp_rad = f_interp(f, rad, axis=0, **kwargs)
-            interp_mag = f_interp(f, mag, axis=0, **kwargs)
+            rad = np.unwrap(np.angle(x_cropped), axis=0)
+            mag = np.abs(x_cropped)
+            interp_rad = f_interp(f_cropped, rad, axis=0, **kwargs)
+            interp_mag = f_interp(f_cropped, mag, axis=0, **kwargs)
             x_new = interp_mag(f_new) * np.exp(1j * interp_rad(f_new))
         else:
             raise ValueError(f'Unknown coords {coords}')

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2800,6 +2800,7 @@ class Network:
         result = self.copy()
 
         is_rational = False
+        freq_cropped = kwargs.pop('freq_cropped', True)
         if kwargs.get('kind', None) == 'rational':
             f_interp = mf.rational_interp
             #Not supported by rational_interp
@@ -2835,7 +2836,7 @@ class Network:
         r_idx = min(np.searchsorted(f, f_new[-1], side="right") + 8, len(f))
 
         # rational method or prohibit frequency clipping
-        if is_rational or not kwargs.get('freq_cropped', True):
+        if is_rational or not freq_cropped:
             l_idx, r_idx = 0, len(f)
         f_cropped = f[l_idx:r_idx]
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1263,6 +1263,14 @@ class NetworkTestCase(unittest.TestCase):
         self.assertTrue(b.z0[1] == 0.5*(a.z0[0] + a.z0[1]))
         self.assertTrue(b.z0[-1] == a.z0[-1])
 
+    def test_interpolate_freq_cropped(self):
+        a = rf.N(f=np.arange(20), s=np.arange(20)*(1+1j),z0=1, f_unit="ghz")
+        freq = rf.F.from_f(np.linspace(1,2,3,endpoint=True), unit='GHz')
+        for method in ('linear', 'cubic', 'quadratic', 'rational'):
+            b = a.interpolate(freq, freq_cropped=False, kind=method)
+            c = a.interpolate(freq, kind=method)
+            self.assertTrue(np.allclose(b.s, c.s))
+
     def test_interpolate_self(self):
         """Test resample."""
         a = rf.N(f=[1,2], s=[1+2j, 3+4j], z0=1)


### PR DESCRIPTION
I observed performance bottlenecks in the `Network.interpolate` function while performing computations with a large number of frequency slices/interpolations.

To address this, I've optimized the interpolation method by implementing frequency and basis slicing in advance. This approach avoids **unnecessary calculations (using the whole frequency range)** during interpolation while ensuring the same interpolation results using only **local data (wrapping the target frequency range)**.

To verify that the interpolation relies solely on local data, I conducted several tests.
```python
import time

import numpy as np

import skrf as rf

if __name__ == "__main__":
    # Set up some constants
    np.random.seed(0)
    ncalls, nfreq, nports = 1000, 5001, 20

    # Create a random network
    freq = rf.Frequency(1, 10, nfreq, "ghz")
    gen_d = lambda f, p: 2.0 * np.random.rand(f, p, p) - 1.0
    s_paras = 1.j * gen_d(nfreq, nports) + gen_d(nfreq, nports)

    ntwk = rf.Network(frequency=freq, s=s_paras)

    # Create a new frequency object
    new_freq = rf.Frequency(4, 5, 1001, "ghz")

    # Interpolate the network using the interpolate method
    ntwk_interp_direct = ntwk.interpolate(new_freq)

    # Interpolation with Pre-cropped Network
    l_idx = np.searchsorted(ntwk.f, new_freq.f[0], side="left") - 1
    r_idx = np.searchsorted(ntwk.f, new_freq.f[-1], side="right") + 1
    cropped_ntwk = ntwk[f"{ntwk.f[l_idx]}-{ntwk.f[r_idx]}hz"]
    ntwk_interp_cropped = cropped_ntwk.interpolate(new_freq)

    print(f"Is the interpolated network the same? {ntwk_interp_direct == ntwk_interp_cropped}")
```
and the result is:
```bash
Is the interpolated network the same? True
```

Your feedback and suggestions on this optimization are welcome!