### PR TITLE
Optimize the performance of loading TouchStone files.

### DIFF
--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -440,12 +440,17 @@ class Touchstone:
 
             line_l = line.lower()
 
-            for k, v in self._parse_dict.items():
-                if line_l.startswith(k):
-                    v(line)
-                    break
-            else:
-                values = [float(v) for v in line.partition("!")[0].split()]
+            is_s_line = True
+            if line_l[0] in {"!", "#", "["}:
+                for k, v in self._parse_dict.items():
+                    if line_l.startswith(k):
+                        v(line)
+                        is_s_line = False
+                        break
+            if is_s_line:
+                if "!" in line:
+                    line = line.partition("!")[0]
+                values = [float(v) for v in line.split()]
                 if not values:
                     continue
 

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -98,6 +98,8 @@ class ParserState:
     @rank.setter
     def rank(self, x: int) -> None:
         self._rank = x
+
+        # If the rank changes, 'numbers_per_line' needs to be recalculated.
         if "numbers_per_line" in self.__dict__:
             self.__dict__.pop("numbers_per_line")
 
@@ -440,17 +442,19 @@ class Touchstone:
 
             line_l = line.lower()
 
-            is_s_line = True
+            is_data_line = True
+            # Avoid traversing the self._parse_dict for each line by checking the first letter
+            # {"!", "#", "["} covers all the first letters of the key of the current self._parse_dict
             if line_l[0] in {"!", "#", "["}:
                 for k, v in self._parse_dict.items():
                     if line_l.startswith(k):
                         v(line)
-                        is_s_line = False
+                        is_data_line = False
                         break
-            if is_s_line:
+            if is_data_line:
                 if "!" in line:
                     line = line.partition("!")[0]
-                values = [float(v) for v in line.split()]
+                values = list(map(float, line.split()))
                 if not values:
                     continue
 

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -53,7 +53,7 @@ def remove_prefix(text: str, prefix: str) -> str:
 class ParserState:
     """Class to hold dynamic variables while parsing the touchstone file.
     """
-    _rank: int | None = None
+    rank: int | None = None
     option_line_parsed: bool = False
     hfss_gamma: list[list[float]] = field(default_factory=list)
     hfss_impedance: list[list[float]] = field(default_factory=list)
@@ -90,19 +90,6 @@ class ParserState:
         #    return self.rank**2 * 2
 
         return self.rank * 2
-
-    @property
-    def rank(self) -> int:
-        return self._rank
-
-    @rank.setter
-    def rank(self, x: int) -> None:
-        self._rank = x
-
-        # If the rank changes, 'numbers_per_line' needs to be recalculated.
-        if "numbers_per_line" in self.__dict__:
-            self.__dict__.pop("numbers_per_line")
-
 
     @cached_property
     def numbers_per_line(self) -> int:

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -32,6 +32,7 @@ import typing
 import warnings
 import zipfile
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Callable
 
 import numpy as np
@@ -52,7 +53,7 @@ def remove_prefix(text: str, prefix: str) -> str:
 class ParserState:
     """Class to hold dynamic variables while parsing the touchstone file.
     """
-    rank: int | None = None
+    _rank: int | None = None
     option_line_parsed: bool = False
     hfss_gamma: list[list[float]] = field(default_factory=list)
     hfss_impedance: list[list[float]] = field(default_factory=list)
@@ -91,6 +92,17 @@ class ParserState:
         return self.rank * 2
 
     @property
+    def rank(self) -> int:
+        return self._rank
+
+    @rank.setter
+    def rank(self, x: int) -> None:
+        self._rank = x
+        if "numbers_per_line" in self.__dict__:
+            self.__dict__.pop("numbers_per_line")
+
+
+    @cached_property
     def numbers_per_line(self) -> int:
         """Returns data points per frequency point.
 


### PR DESCRIPTION
Cache the `numbers_per_line` object and perform preliminary checks on strings to avoid unnecessary function executions.

Files of different sizes show a performance improvement of about **35%**.

The test results log is as follows:
```bash
(skrf) (base) ➜  scikit-rf git:(master) ✗ python load_performance.py
/home/xxx/scikit-rf/skrf/__init__.py
Time taken to load network 0.04 MB: 0.7483 ms (std: 0.0958 ms, min: 0.6616 ms)
Time taken to load network 1.37 MB: 43.2696 ms (std: 0.9668 ms, min: 41.9932 ms)
Time taken to load network 11.32 MB: 217.6757 ms (std: 15.4226 ms, min: 209.6951 ms)
Time taken to load network 78.85 MB: 1218.1206 ms (std: 42.5231 ms, min: 1183.3950 ms)
Time taken to load network 199.82 MB: 3229.8712 ms (std: 184.5385 ms, min: 3074.8850 ms)

(skrf) (base) ➜  scikit-rf git:(master) ✗ git switch TouchStoneFormat

(skrf) (base) ➜  scikit-rf git:(TouchStoneFormat) ✗ python load_performance.py 
/home/xxx/scikit-rf/skrf/__init__.py
Time taken to load network 0.04 MB: 0.5461 ms (std: 0.0830 ms, min: 0.4775 ms)
Time taken to load network 1.37 MB: 24.4713 ms (std: 3.3573 ms, min: 22.8682 ms)
Time taken to load network 11.32 MB: 141.6678 ms (std: 12.5191 ms, min: 134.8704 ms)
Time taken to load network 78.85 MB: 811.5176 ms (std: 45.9418 ms, min: 777.0676 ms)
Time taken to load network 199.82 MB: 2175.9645 ms (std: 164.8075 ms, min: 2027.6028 ms)
```

The test code is as follows:
```python3
import skrf as rf
import os
import numpy as np
from time import time

print(rf.__file__)

files = (
    "XXX.s2p", ...
)
ntimes = 20
for f in files:
    t = []
    for _ in range(ntimes):
        a = time() * 1000
        ntwk = rf.Network(f)
        b = time() * 1000
        t.append(b - a)
    t = np.array(t)
    print(
        f"Time taken to load network {os.path.getsize(f) / 1024**2:.2f} MB: {t.mean():.4f} ms (std: {t.std():.4f} ms, min: {t.min():.4f} ms)"
    )

```