### PR TITLE
Fixed the Frequency issue when creating a Network using the f_unit and frequency arguments.

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1383,7 +1383,7 @@ class Network:
             self._frequency = new_frequency.copy()
         else:
             try:
-                self._frequency = Frequency.from_f(new_frequency)
+                self._frequency = Frequency.from_f(new_frequency, unit=self.frequency.unit)
             except TypeError as err:
                 raise TypeError('Could not convert argument to a frequency vector') from err
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -110,6 +110,12 @@ class NetworkTestCase(unittest.TestCase):
         empty_network = n[n.f < 0]
         self.assertIn('1-Port Network', repr(empty_network))
 
+    def test_network_sequence_frequency_with_f_unit(self):
+        n=rf.Network(frequency=self.freq.f, f_unit=self.freq.unit)
+        np.allclose(n.f, self.freq.f)
+        n=rf.Network(f=self.freq.f, f_unit=self.freq.unit)
+        np.allclose(n.f, self.freq.f)
+
     def test_timedomain(self):
         t = self.ntwk1.s11.s_time
         s = self.ntwk1.s11.s


### PR DESCRIPTION
When I specify `f_unit` and pass a sequence to `frequency`, I cannot create the expected `Network.frequency`.

Below is the code to reproduce this issue:
 
```python
Python 3.9.19 (main, May  6 2024, 19:43:03) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import skrf as rf
>>> rf.Network(f_unit='ghz', frequency=(1,2,3))
0-Port Network: '',  1.0-3.0 Hz, 3 pts, z0=(50+0j)
>>> rf.Network(f_unit='ghz', f=(1,2,3))
0-Port Network: '',  1.0-3.0 GHz, 3 pts, z0=(50+0j)
>>> 
```
It seems that the `frequency.setter` method does not retain the user-specified `f_unit` when dealing with a `sequence`.

https://github.com/scikit-rf/scikit-rf/blob/a4f21e19ea5a6454f1d1caa7b628c3199295cfda/skrf/network.py#L1377-L1388