### PR TITLE
Update comment handling for NetworkSets

### DIFF
--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -1271,7 +1271,7 @@ class NetworkSet:
                 ntwk_list.append(k)
 
         if ntwk_list:
-            return ntwk_list[0] if len(ntwk_list) == 1 else NetworkSet(ntwk_list)
+            return NetworkSet(ntwk_list)
         else:  # no match found
             return NetworkSet()
 

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -1194,7 +1194,7 @@ class NetworkSet:
             return None
 
 
-    def sel(self, indexers: Mapping[Any, Any] = None) -> NetworkSet:
+    def sel(self, indexers: Mapping[Any, Any] = None) -> Network | NetworkSet:
         """
         Select Network(s) in the NetworkSet from a given value of a parameter.
 
@@ -1207,9 +1207,10 @@ class NetworkSet:
 
         Returns
         -------
-        ns : NetworkSet
-            NetworkSet containing the selected Networks or
-            empty NetworkSet if no match found
+        ns : Network or NetworkSet
+            Network if only one network is selected, otherwise,
+            a NetworkSet containing the selected Networks or
+            an empty NetworkSet if no match is found
 
         Example
         -------
@@ -1270,7 +1271,7 @@ class NetworkSet:
                 ntwk_list.append(k)
 
         if ntwk_list:
-            return NetworkSet(ntwk_list)
+            return ntwk_list[0] if len(ntwk_list) == 1 else NetworkSet(ntwk_list)
         else:  # no match found
             return NetworkSet()
 

--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -1194,7 +1194,7 @@ class NetworkSet:
             return None
 
 
-    def sel(self, indexers: Mapping[Any, Any] = None) -> Network | NetworkSet:
+    def sel(self, indexers: Mapping[Any, Any] = None) -> NetworkSet:
         """
         Select Network(s) in the NetworkSet from a given value of a parameter.
 
@@ -1207,10 +1207,9 @@ class NetworkSet:
 
         Returns
         -------
-        ns : Network or NetworkSet
-            Network if only one network is selected, otherwise,
-            a NetworkSet containing the selected Networks or
-            an empty NetworkSet if no match is found
+        ns : NetworkSet
+             NetworkSet containing the selected Networks or
+             an empty NetworkSet if no match is found
 
         Example
         -------

--- a/skrf/tests/test_networkSet.py
+++ b/skrf/tests/test_networkSet.py
@@ -312,6 +312,9 @@ class NetworkSetTestCase(unittest.TestCase):
         self.assertRaises(TypeError, self.ns_params.sel, 'wrong')
         self.assertRaises(TypeError, self.ns_params.sel, 1)
 
+        # Should return a single Network
+        self.assertIsInstance(self.ns_params.sel({'a': 0, 'X': 10, 'c': 'A'}), rf.Network)
+
         # searching for a parameter which do not exist returns empty networkset
         self.assertEqual(self.ns.sel({'a': 1}), rf.NetworkSet())
         self.assertEqual(self.ns_params.sel({'ho ho': 1}), rf.NetworkSet())
@@ -323,7 +326,6 @@ class NetworkSetTestCase(unittest.TestCase):
         self.assertEqual(len(self.ns_params.sel({'a': [0,1]})), 4)
         self.assertEqual(len(self.ns_params.sel({'a': range(0,2)})), 4)
         # Multiple parameters
-        self.assertEqual(len(self.ns_params.sel({'a': 0, 'X': 10})), 1)
         self.assertEqual(len(self.ns_params.sel({'a': 0, 'X': [10,20]})), 2)
         self.assertEqual(len(self.ns_params.sel({'a': [0,1], 'X': [10,20]})), 4)
 

--- a/skrf/tests/test_networkSet.py
+++ b/skrf/tests/test_networkSet.py
@@ -312,9 +312,6 @@ class NetworkSetTestCase(unittest.TestCase):
         self.assertRaises(TypeError, self.ns_params.sel, 'wrong')
         self.assertRaises(TypeError, self.ns_params.sel, 1)
 
-        # Should return a single Network
-        self.assertIsInstance(self.ns_params.sel({'a': 0, 'X': 10, 'c': 'A'}), rf.Network)
-
         # searching for a parameter which do not exist returns empty networkset
         self.assertEqual(self.ns.sel({'a': 1}), rf.NetworkSet())
         self.assertEqual(self.ns_params.sel({'ho ho': 1}), rf.NetworkSet())


### PR DESCRIPTION
Retain comments on a per-Network basis rather than trying to put all comments into the NetworkSet. The NetworkSet can have comments independent of the ones for the child Networks. These will be at the top of the file before any data blocks.