### PR TITLE
Use the Network provided by media to re-implement the Open and Ground

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -743,13 +743,11 @@ class Circuit:
         There is a numerical bottleneck in this function,
         when creating the block diagonal matrice [X] from the [X]_k matrices.
         """
-        Xks = [self._Xk(cnx) for cnx in self.connections]
-
-        Xf = np.zeros((len(self.frequency), self.dim, self.dim), dtype='complex')
-        off = np.array([0, 0])
-        for Xk in Xks:
-            Xf[:, off[0]:off[0] + Xk.shape[1], off[1]:off[1]+Xk.shape[2]] = Xk
-            off += Xk.shape[1:]
+        idx, Xf = 0, np.zeros((len(self.frequency), self.dim, self.dim), dtype='complex')
+        for cnx in self.connections:
+            idx_s, idx_e = idx, idx + len(cnx)
+            Xf[:, idx_s:idx_e, idx_s:idx_e] = self._Xk(cnx)
+            idx = idx_e
 
         return Xf
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1497,10 +1497,10 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     if split_ground:
         tmp_cnxs = []
         for cnx in connections:
-            ground_ntwk = next((ntwk for ntwk, _ in cnx if Circuit._is_ground(ntwk)), None)
+            gnd_ntwk, gnd_p = next(((ntwk, p) for (ntwk, p) in cnx if Circuit._is_ground(ntwk)), (None, None))
 
             # If there is no ground network or if the connection has exactly 2 elements, append it as is
-            if not ground_ntwk or len(cnx) == 2:
+            if not gnd_ntwk or len(cnx) == 2:
                 tmp_cnxs.append(cnx)
                 continue
 
@@ -1508,12 +1508,10 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             for ntwk, port in cnx:
                 if Circuit._is_ground(ntwk):
                     continue
-                tmp_gnd = Circuit.Ground(frequency=ground_ntwk.frequency,
-                                         name=f'G_{ntwk.name}_{port}',
-                                         z0=ground_ntwk.z0)
 
-                # Transfet the ground Network to a short Network
-                tmp_gnd = tmp_gnd.subnetwork(ports=(0,))
+                # Use the 1-port short Network to replace the Ground Network
+                line = media.DefinedGammaZ0(frequency=gnd_ntwk.frequency, z0_port=gnd_ntwk.z0[:, gnd_p])
+                tmp_gnd = line.short(name=f'G_{ntwk.name}_{port}')
 
                 tmp_cnxs.append([(ntwk, port), (tmp_gnd, 0)])
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1497,10 +1497,10 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     if split_ground:
         tmp_cnxs = []
         for cnx in connections:
-            gnd_ntwk, gnd_p = next(((ntwk, p) for (ntwk, p) in cnx if Circuit._is_ground(ntwk)), (None, None))
+            ground_ntwk = next((ntwk for ntwk, _ in cnx if Circuit._is_ground(ntwk)), None)
 
-            # If there is no ground network, append it to the list
-            if not gnd_ntwk:
+            # If there is no ground network or if the connection has exactly 2 elements, append it as is
+            if not ground_ntwk or len(cnx) == 2:
                 tmp_cnxs.append(cnx)
                 continue
 
@@ -1509,10 +1509,9 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
                 if Circuit._is_ground(ntwk):
                     continue
 
-                # Use the 1-port short Network to replace the Ground Network
-                line = media.DefinedGammaZ0(frequency=gnd_ntwk.frequency, z0_port=gnd_ntwk.z0[:, gnd_p])
-                tmp_gnd = line.short(name=f'G_{ntwk.name}_{port}')
-
+                tmp_gnd = Circuit.Ground(frequency=ground_ntwk.frequency,
+                                         name=f'G_{ntwk.name}_{port}',
+                                         z0=ground_ntwk.z0)
                 tmp_cnxs.append([(ntwk, port), (tmp_gnd, 0)])
 
         connections = tmp_cnxs

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -97,7 +97,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from .constants import INF, S_DEF_DEFAULT, NumberLike
+from .constants import S_DEF_DEFAULT, NumberLike
 from .media import media
 from .network import Network, connect, innerconnect, s2s
 from .util import subplots
@@ -303,6 +303,13 @@ class Circuit:
         return ntw._ext_attrs.get("_is_circuit_ground", False)
 
     @classmethod
+    def _is_open(cls, ntw: Network):
+        """
+        Return True is the network is a open, False otherwise
+        """
+        return ntw._ext_attrs.get("_is_circuit_open", False)
+
+    @classmethod
     def Port(cls, frequency: Frequency, name: str, z0: float = 50) -> Network:
         """
         Return a 1-port Network to be used as a Circuit port.
@@ -426,11 +433,11 @@ class Circuit:
     @classmethod
     def Ground(cls, frequency: Frequency, name: str, z0: float = 50) -> Network:
         """
-        Return a 2-port network of a grounded link.
+        Return a 1-port network of a grounded link.
 
         Passing the frequency and a name is mandatory.
 
-        The ground link is modelled as an infinite shunt admittance.
+        The ground link is implemented by media.short object.
 
         Parameters
         ----------
@@ -444,7 +451,7 @@ class Circuit:
         Returns
         -------
         ground : :class:`~skrf.network.Network` object
-            2-port network
+            1-port network
 
         Examples
         --------
@@ -458,18 +465,19 @@ class Circuit:
             In [18]: ground = rf.Circuit.Ground(freq, name='GND')
 
         """
-        ground = cls.ShuntAdmittance(frequency, Y=INF, name=name)
+        _media = media.DefinedGammaZ0(frequency, z0=z0)
+        ground = _media.short(name=name)
         ground._ext_attrs['_is_circuit_ground'] = True
         return ground
 
     @classmethod
     def Open(cls, frequency: Frequency, name: str, z0: float = 50) -> Network:
         """
-        Return a 2-port network of an open link.
+        Return a 1-port network of an open link.
 
         Passing the frequency and name is mandatory.
 
-        The open link is modelled as an infinite series impedance.
+        The open link is implemented by media.open object.
 
         Parameters
         ----------
@@ -483,7 +491,7 @@ class Circuit:
         Returns
         -------
         open : :class:`~skrf.network.Network` object
-            2-port network
+            1-port network
 
         Examples
         --------
@@ -497,7 +505,10 @@ class Circuit:
             In [18]: open = rf.Circuit.Open(freq, name='open')
 
         """
-        return cls.SeriesImpedance(frequency, Z=INF, name=name)
+        _media = media.DefinedGammaZ0(frequency, z0=z0)
+        Open = _media.open(name=name)
+        Open._ext_attrs['_is_circuit_open'] = True
+        return Open
 
     def networks_dict(self,
                       connections: list[list[tuple[Network, int]]] | None = None,
@@ -1508,10 +1519,9 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             for ntwk, port in cnx:
                 if Circuit._is_ground(ntwk):
                     continue
-
                 tmp_gnd = Circuit.Ground(frequency=ground_ntwk.frequency,
-                                         name=f'G_{ntwk.name}_{port}',
-                                         z0=ground_ntwk.z0)
+                                         name=f'G_{ntwk.name}_{port}')
+                tmp_gnd.z0 = ground_ntwk.z0
                 tmp_cnxs.append([(ntwk, port), (tmp_gnd, 0)])
 
         connections = tmp_cnxs

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1499,8 +1499,8 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
         for cnx in connections:
             gnd_ntwk, gnd_p = next(((ntwk, p) for (ntwk, p) in cnx if Circuit._is_ground(ntwk)), (None, None))
 
-            # If there is no ground network or if the connection has exactly 2 elements, append it as is
-            if not gnd_ntwk or len(cnx) == 2:
+            # If there is no ground network, append it to the list
+            if not gnd_ntwk:
                 tmp_cnxs.append(cnx)
                 continue
 

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -178,7 +178,7 @@ class CircuitClassMethods(unittest.TestCase):
                     self.media.shunt(self.media.load(rf.zl_2_Gamma0(z0, 1/Y))).s
                     )
 
-        # Y=INF is a a 2-ports short, aka a ground
+        # Y=INF is a a 2-ports short
         assert_array_almost_equal(
             rf.Circuit.ShuntAdmittance(self.freq, rf.INF, 'imp').s,
             self.media.short(nports=2).s

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -131,8 +131,7 @@ class CircuitClassMethods(unittest.TestCase):
 
         gnd = rf.Circuit.Ground(self.freq, 'gnd')
         gnd_ref = rf.Network(frequency=self.freq,
-                             s=np.tile(np.array([[-1, 0],
-                                                 [0, -1]]),
+                             s=np.tile(np.array([[-1,]]),
                                        (len(self.freq),1,1)))
 
         assert_array_almost_equal(gnd.s, gnd_ref.s)
@@ -148,8 +147,7 @@ class CircuitClassMethods(unittest.TestCase):
 
         opn = rf.Circuit.Open(self.freq, 'open')
         opn_ref = rf.Network(frequency=self.freq,
-                             s=np.tile(np.array([[1, 0],
-                                                 [0, 1]]),
+                             s=np.tile(np.array([[1]]),
                                        (len(self.freq),1,1)))
 
         assert_array_almost_equal(opn.s, opn_ref.s)
@@ -183,7 +181,7 @@ class CircuitClassMethods(unittest.TestCase):
         # Y=INF is a a 2-ports short, aka a ground
         assert_array_almost_equal(
             rf.Circuit.ShuntAdmittance(self.freq, rf.INF, 'imp').s,
-            rf.Circuit.Ground(self.freq, 'ground').s
+            self.media.short(nports=2).s
             )
 
 class CircuitTestWilkinson(unittest.TestCase):


### PR DESCRIPTION
## Introduction
The concept of `Circuit.Ground` was introduced in https://github.com/scikit-rf/scikit-rf/issues/626:
> A `Circuit.Ground` is indeed a 2-port Network, as it models an infinite shunt admittance.

Using `Ground` in the `Circuit` seems straightforward. However, the issue also mentions that if you only want to short one port, it's better to **short it and connect it directly**.

## Optimization through Short Networks
1. Considering that `short Network` is a 1-port Network, connecting a short with an `N-Port Network` results in an `(N-1)-Port network`. This means that using a `short Network` will gradually reduce the total number of ports in the `Circuit` involved in the calculation while obtaining the same result.
2. In the `reduce_circuit()` method, we observed that performance can be improved by handling Ground specifically, as shown in https://github.com/scikit-rf/scikit-rf/pull/1080. In which, we added a mechanism to **automatically handle `Ground Network`**.

Therefore, I thought it would be an interesting idea to automatically convert `Ground` to `short` in the `reduce_circuit()` method.

## Benchmark Results
Benchmark code can be found in https://github.com/scikit-rf/scikit-rf/pull/1080, and the results are as follows:
```bash

(skrf) (base) ➜  scikit-rf git:(master) ✗ python circuit_performance.py
skrf path: /home/lansus/WorkFile/Git/scikit-rf/skrf/__init__.py
Total time in Easy example: 3.8372 ms, min: 3.6426 ms, std: 0.2304 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 8.4084 ms, min: 7.9572 ms, std: 0.3509 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 46.3497 ms, min: 43.3400 ms, std: 2.7975 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 41.2589 ms, min: 38.5571 ms, std: 1.7028 ms
Standard (47) and Optimized (13) results are equal: True

(skrf) (base) ➜  scikit-rf git:(master) ✗ git switch CircuitPerformance
(skrf) (base) ➜  scikit-rf git:(CircuitPerformance) ✗ python circuit_performance.py   
skrf path: /home/lansus/WorkFile/Git/scikit-rf/skrf/__init__.py
Total time in Easy example: 4.1243 ms, min: 3.7518 ms, std: 0.4754 ms
Standard (10) and Optimized (10) results are equal: True

Total time in Simple example: 7.5973 ms, min: 7.0727 ms, std: 0.4545 ms
Standard (18) and Optimized (9) results are equal: True

Total time in Complex example: 44.6984 ms, min: 41.3613 ms, std: 2.6458 ms
Standard (80) and Optimized (26) results are equal: True

Total time in HFSS example: 24.1429 ms, min: 23.2019 ms, std: 0.7935 ms
Standard (47) and Optimized (13) results are equal: True
```
## Conclusion
Automatically converting `Ground` to `short` in the `reduce_circuit()` method can effectively reduce the total number of ports involved in calculations, resulting in performance improvements. The benchmark results demonstrate that this approach maintains accuracy while optimizing computation time.