### PR TITLE
[docs] correct optional dep for using vi module

### DIFF
--- a/doc/source/tutorials/Installation.ipynb
+++ b/doc/source/tutorials/Installation.ipynb
@@ -64,7 +64,7 @@
     "To use the vi module, you must install all of its dependencies. This can be done\n",
     "with\n",
     "\n",
-    "$ pip install scikit-rf[vi]\n",
+    "$ pip install scikit-rf[visa]\n",
     "\n",
     "which will install the following:\n",
     "\n",


### PR DESCRIPTION
Per the `pyproject`, it seems the correct optional dep to install pyvisa is `visa`, not `vi`.