### PR TITLE
Optimize Circuit Performance with Dynamic Network Handling and Selective Reductions

### DIFF
--- a/doc/source/tutorials/Circuit.ipynb
+++ b/doc/source/tutorials/Circuit.ipynb
@@ -424,7 +424,7 @@
     "print(\"Unreduced Circuit calculate Network in \"\n",
     "      f\"{timeit(lambda: cir.network, number=n_times)/n_times:.4f}s\")\n",
     "print(\"Auto-reduced Circuit calculate Network in \"\n",
-    "      \"{timeit(lambda: auto_reduced_cir.network, number=n_times)/n_times:.4f}s\")\n",
+    "      f\"{timeit(lambda: auto_reduced_cir.network, number=n_times)/n_times:.4f}s\")\n",
     "\n",
     "print(\"Manually reduced circuit has the same s-parameters as the original circuit: \"\n",
     "      f\"{np.allclose(ntw.s, fully_reduced_ntw.s)}\")\n",

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -146,7 +146,7 @@ class Circuit:
         split_ground: NotRequired[bool]
         split_multi: NotRequired[bool]
         max_nports: NotRequired[int]
-        ignore_networks: NotRequired[tuple[Network]]
+        dynamic_networks: NotRequired[tuple[Network, ...]]
 
     def __init__(self,
                  connections: list[list[tuple[Network, int]]],
@@ -186,7 +186,7 @@ class Circuit:
             circuit's dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
 
-            `ignore_networks` kwarg is a tuple of Networks to be ignored during the reduction process.
+            `dynamic_networks` kwarg is a tuple of Networks to be skipped during the reduction process.
             Default is an empty tuple.
 
 
@@ -366,12 +366,12 @@ class Circuit:
             circuit's dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
 
-            `ignore_networks` kwarg is a tuple of Networks to be ignored during the reduction process.
+            `dynamic_networks` kwarg is a tuple of Networks to be skipped during the reduction process.
             Default is an empty tuple.
 
         Returns
         -------
-        circuit : Circuit
+        Circuit or None if inplace=True
             The updated `Circuit` with the specified networks.
 
 
@@ -1607,7 +1607,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
                    split_ground: bool = True,
                    split_multi: bool = False,
                    max_nports: int = 20,
-                   ignore_networks: tuple[Network] = tuple()) -> list[list[tuple[Network, int]]]:
+                   dynamic_networks: tuple[Network, ...] = tuple()) -> list[list[tuple[Network, int]]]:
     """
     Return a reduced equivalent circuit connections with fewer components.
 
@@ -1632,7 +1632,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             circuit has a number of ports (nports), using the Network.connect() method to reduce the circuit's
             dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
-    ignore_networks : tuple[Network], optional.
+    dynamic_networks : tuple[Network, ...], optional.
             A tuple of Networks to ignore in the reduction process. Default is an empty list.
 
 
@@ -1654,8 +1654,8 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     >>> np.allclose(ntwkA.s, ntwkB.s)
     True
     """
-    # Pre-processing the ignore_networks tuple
-    ignore_ntwk_names: set[str] = set(ntw.name for ntw in ignore_networks)
+    # Pre-processing the dynamic_networks tuple
+    ignore_ntwk_names: set[str] = set(ntw.name for ntw in dynamic_networks)
 
     def invalide_to_reduce(cnx: list[tuple[Network, int]]) -> bool:
         return (
@@ -1840,5 +1840,5 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
         split_ground=False,
         split_multi=False,
         max_nports=max_nports,
-        ignore_networks=ignore_networks,
+        dynamic_networks=dynamic_networks,
     )

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1703,7 +1703,9 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             # Create a splitter for the connection
             _media = media.DefinedGammaZ0(cnx[0][0].frequency)
             splitter = _media.splitter(
-                name=f"Splt_{'&'.join(ntwk.name for ntwk, _ in cnx)}", nports=len(cnx)
+                name=f"Splt_{'&'.join(ntwk.name for ntwk, _ in cnx)}",
+                nports=len(cnx),
+                z0=np.array([ntwk.z0[:, p] for ntwk, p in cnx]).T
             )
 
             # Connect the splitter to the connection

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1505,13 +1505,13 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
 
     Parameters
     ----------
-    connections : list.
+    connections : list[list[tuple[Network, int]]].
             The connection list to reduce.
     check_duplication : bool, optional.
             If True, check if the connections have duplicate names. Default is True.
     split_ground : bool, optional.
             If True, split the global ground connection to independant ground connections. Default is False.
-    max_nports : int
+    max_nports : int, optional.
             The maximum number of ports of a Network that can be reduced in circuit. If a Network in the
             circuit has a number of ports (nports), using the Network.connect() method to reduce the circuit's
             dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -253,20 +253,12 @@ class Circuit:
         # Check that a (ntwk, port) combination appears only once in the connexion map
         Circuit.check_duplicate_names(self.connections_list)
 
-        # Automatically enable auto_reduce if any relevant kwargs are provided
-        auto_reduce = auto_reduce or any(
-            k in self._REDUCE_OPTIONS.__annotations__.keys() for k in kwargs.keys()
-        )
+        # Get the keyword arguments for the reduce_circuit method
+        kwargs_reduce = {k: kwargs[k] for k in self._REDUCE_OPTIONS.__annotations__.keys() if k in kwargs}
 
-        # Reduce the circuit if requested
-        if auto_reduce:
-            check_duplication = kwargs.get('check_duplication', False)
-            split_ground = kwargs.get('split_ground', True)
-            max_nports = kwargs.get('max_nports', 20)
-            self.connections = reduce_circuit(self.connections,
-                                              check_duplication=check_duplication,
-                                              split_ground=split_ground,
-                                              max_nports=max_nports)
+        # Reduce the circuit if directly requested or any relevant kwargs are provided
+        if auto_reduce or any(kwargs_reduce):
+            self.connections = reduce_circuit(self.connections, **kwargs_reduce)
 
     @property
     def connections(self) -> list[list[tuple[Network, int]]]:

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -334,7 +334,8 @@ class Circuit:
         self, networks: tuple[Network],
         name: str | None = None,
         *,
-        auto_reduce: bool = False, **kwargs: Unpack[_REDUCE_OPTIONS]) -> Circuit:
+        inplace: bool = False,
+        auto_reduce: bool = False, **kwargs: Unpack[_REDUCE_OPTIONS]) -> Circuit | None:
         """
         Update the circuit connections with a new set of networks.
 
@@ -344,6 +345,8 @@ class Circuit:
             A tuple of Networks to be updated in the circuit.
         name : string, optional
             Name assigned to the circuit (Network). Default is None.
+        inplace : bool, optional
+            If True, the circuit connections will be updated inplace. Default is False.
         auto_reduce : bool, optional
             If True, the circuit will be automatically reduced using :func:`reduce_circuit`.
             This will change the circuit connections description, affecting inner current and voltage distributions.
@@ -398,31 +401,11 @@ class Circuit:
         if auto_reduce or any(kwargs_reduce):
             connections = reduce_circuit(connections, **kwargs_reduce)
 
+        if inplace:
+            self.connections = connections
+            return None
+
         return Circuit(connections=connections, name=name)
-
-    def update_networks_self(self, networks: tuple[Network]) -> None:
-        """
-        Update the circuit connections with a new set of networks (inplace).
-
-        This method is similar to `update_networks` but it updates the circuit
-        connections inplace, and does not support the `auto_reduce` and `**kwargs`
-        arguments.
-
-        Parameters
-        ----------
-        connections : tuple[Network]
-            A tuple of Networks to be updated in the circuit.
-
-        Returns
-        -------
-        None
-            The interpolation is performed inplace.
-
-        See Also
-        --------
-        update_networks
-        """
-        self.connections = self.update_networks(networks).connections
 
     @classmethod
     def check_duplicate_names(cls, connections_list: list):

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1771,12 +1771,10 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     (ntwkA, k), (ntwkB, l) = cnx_to_reduce
     ntwks_name = (ntwkA.name, ntwkB.name)
 
-    # Generate the connected network and the original port index
-    ntwk_cnt = Network()
-
     # Get the Networks' names
     name_cnt, name_a, name_b = "", str(ntwkA.name), str(ntwkB.name)
 
+    # Generate the connected network and the original port index
     if ntwkA.name == ntwkB.name:
         ntwk_cnt = innerconnect(ntwkA=ntwkA, k=k, l=l)
         name_cnt = f"<{name_a}>"

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -294,6 +294,62 @@ class Circuit:
         for item in ('s', 'X', 'C'):
             self.__dict__.pop(item, None)
 
+    def update_networks(
+        self, networks: tuple[Network], name: str | None = None
+    ) -> Circuit:
+        """
+        Update the circuit connections with a new set of networks.
+
+        Parameters
+        ----------
+        networks : tuple[Network]
+            A tuple of Networks to be updated in the circuit.
+        name : string, optional
+            Name assigned to the circuit (Network). Default is None.
+
+        Returns
+        -------
+        circuit : Circuit
+            The updated `Circuit` with the specified networks.
+
+        """
+        # Get current connection_dict
+        cnx_dict = self.networks_dict()
+
+        # Update the connection dict with the new networks
+        for ntw in networks:
+            if ntw.name in cnx_dict:
+                cnx_dict[ntw.name] = ntw
+            else:
+                raise ValueError(f"Network {ntw.name} not found in circuit.")
+
+        # Update the circuit connections with the new networks
+        connections = [
+            [(cnx_dict[n.name], p) for n, p in cnx] for cnx in self.connections
+        ]
+
+        return Circuit(connections=connections, name=name)
+
+    def update_networks_self(self, networks: tuple[Network]) -> None:
+        """
+        Update the circuit connections with a new set of networks (inplace).
+
+        Parameters
+        ----------
+        connections : tuple[Network]
+            A tuple of Networks to be updated in the circuit.
+
+        Returns
+        -------
+        None
+            The interpolation is performed inplace.
+
+        See Also
+        --------
+        update_networks
+        """
+        self.connections = self.update_networks(networks).connections
+
     @classmethod
     def check_duplicate_names(cls, connections_list: list):
         """

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1678,7 +1678,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
 
         for cnx in connections:
             # Check if the connection has more than 2 components
-            if len(cnx) == 2:
+            if len(cnx) <= 2:
                 tmp_cnxs.append(cnx)
                 continue
 

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1631,10 +1631,19 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
 
     # Generate the connected network and the original port index
     ntwk_cnt = Network()
+
+    # Get the Networks' names
+    name_cnt, name_a, name_b = "", str(ntwkA.name), str(ntwkB.name)
+
     if ntwkA.name == ntwkB.name:
         ntwk_cnt = innerconnect(ntwkA=ntwkA, k=k, l=l)
+        name_cnt = f"<{name_a}>"
     else:
         ntwk_cnt = connect(ntwkA=ntwkA, k=k, ntwkB=ntwkB, l=l)
+        name_cnt = f"({name_a}**{name_b})"
+
+    # Update the name of the connected network
+    ntwk_cnt.name = name_cnt
 
     # Generate the port index, the index is the original port index
     # and the value is the new port index, -1 means the port is removed.

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1491,7 +1491,7 @@ class Circuit:
 ## Functions operating on Circuit
 def reduce_circuit(connections: list[list[tuple[Network, int]]],
                    check_duplication: bool = True,
-                   split_ground: bool = False,
+                   split_ground: bool = True,
                    max_nports: int = 20,
                    ignore_networks: tuple[Network] = tuple()) -> list[list[tuple[Network, int]]]:
     """
@@ -1507,7 +1507,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     check_duplication : bool, optional.
             If True, check if the connections have duplicate names. Default is True.
     split_ground : bool, optional.
-            If True, split the global ground connection to independant ground connections. Default is False.
+            If True, split the global ground connection to independant ground connections. Default is True.
     max_nports : int, optional.
             The maximum number of ports of a Network that can be reduced in circuit. If a Network in the
             circuit has a number of ports (nports), using the Network.connect() method to reduce the circuit's
@@ -1686,6 +1686,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
     return reduce_circuit(
         connections=reduced_cnxs,
         check_duplication=False,
+        split_ground=False,
         max_nports=max_nports,
         ignore_networks=ignore_networks,
     )

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -309,7 +309,7 @@ class Circuit:
             A tuple of Networks to be updated in the circuit.
         name : string, optional
             Name assigned to the circuit (Network). Default is None.
-                auto_reduce : bool, optional
+        auto_reduce : bool, optional
             If True, the circuit will be automatically reduced using :func:`reduce_circuit`.
             This will change the circuit connections description, affecting inner current and voltage distributions.
             Suitable for cases where only the S-parameters of the final circuit ports are of interest. Default is False.

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -93,7 +93,7 @@ from __future__ import annotations
 
 from functools import cached_property
 from itertools import chain
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Sequence, TypedDict
 
 import numpy as np
 from typing_extensions import NotRequired, Unpack
@@ -146,7 +146,7 @@ class Circuit:
         split_ground: NotRequired[bool]
         split_multi: NotRequired[bool]
         max_nports: NotRequired[int]
-        dynamic_networks: NotRequired[tuple[Network, ...]]
+        dynamic_networks: NotRequired[Sequence[Network]]
 
     def __init__(self,
                  connections: list[list[tuple[Network, int]]],
@@ -186,7 +186,7 @@ class Circuit:
             circuit's dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
 
-            `dynamic_networks` kwarg is a tuple of Networks to be skipped during the reduction process.
+            `dynamic_networks` kwarg is a sequence of Networks to be skipped during the reduction process.
             Default is an empty tuple.
 
 
@@ -366,7 +366,7 @@ class Circuit:
             circuit's dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
 
-            `dynamic_networks` kwarg is a tuple of Networks to be skipped during the reduction process.
+            `dynamic_networks` kwarg is a sequence of Networks to be skipped during the reduction process.
             Default is an empty tuple.
 
         Returns
@@ -1607,7 +1607,7 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
                    split_ground: bool = True,
                    split_multi: bool = False,
                    max_nports: int = 20,
-                   dynamic_networks: tuple[Network, ...] = tuple()) -> list[list[tuple[Network, int]]]:
+                   dynamic_networks: Sequence[Network] = tuple()) -> list[list[tuple[Network, int]]]:
     """
     Return a reduced equivalent circuit connections with fewer components.
 
@@ -1632,8 +1632,8 @@ def reduce_circuit(connections: list[list[tuple[Network, int]]],
             circuit has a number of ports (nports), using the Network.connect() method to reduce the circuit's
             dimensions becomes less efficient compared to directly calculating it with Circuit.s_external.
             This value depends on the performance of the computer and the scale of the circuit. Default is 20.
-    dynamic_networks : tuple[Network, ...], optional.
-            A tuple of Networks to ignore in the reduction process. Default is an empty list.
+    dynamic_networks : Sequence[Network], optional.
+            A sequence of Networks to ignore in the reduction process. Default is an empty tuple.
 
 
     Returns

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -846,7 +846,7 @@ class Circuit:
         return edge_labels
 
 
-    def _Xk(self, cnx_k: list[tuple]) -> np.ndarray:
+    def _Xk(self, cnx_k: list[tuple[Network, int]]) -> np.ndarray:
         """
         Return the scattering matrices [X]_k of the individual intersections k.
         The results in [#]_ do not agree due to an error in the formula (3)
@@ -1411,7 +1411,7 @@ class Circuit:
         Returns
         -------
         V : complex array of shape (nfreqs, nports)
-            Voltages in Amperes [A] (peak) at internal ports.
+            Voltages in Volt [V] (peak) at internal ports.
 
         """
         a = self._a(self._a_external(power, phase))

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -111,6 +111,10 @@ class CircuitTestConstructor(unittest.TestCase):
                        [(ntwk3, 1), (self.port2, 0)]]
         circuit = rf.Circuit(connections, ignore_networks=(ntwk3,))
 
+        # should raise an exception if passing a network not in the circuit
+        with self.assertRaises(ValueError):
+            _ = circuit.update_networks(networks=(self.ntwk2,))
+
         # Update the circuit with the self.ntwk2
         ntwk3.s = self.ntwk2.s
         circuit_updated = circuit.update_networks(networks=(ntwk3,))

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -117,11 +117,15 @@ class CircuitTestConstructor(unittest.TestCase):
 
         # Update the circuit with the self.ntwk2
         ntwk3.s = self.ntwk2.s
+
+        # Check the result type and values
         circuit_updated = circuit.update_networks(networks=(ntwk3,))
+        self.assertTrue(isinstance(circuit_updated, rf.Circuit))
         assert_array_almost_equal(self.circuit.s_external, circuit_updated.s_external)
 
-        # Update the circuit inplace
-        circuit.update_networks(networks=(ntwk3,), inplace=True)
+        # Check the result type and values when updating the circuit inplace
+        none_result = circuit.update_networks(networks=(ntwk3,), inplace=True)
+        self.assertIsNone(none_result)
         assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
 
     def test_cache_attributes(self):

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -376,6 +376,18 @@ class CircuitTestWilkinson(unittest.TestCase):
         # s_act should be equal to s33 if a = [0,0,1]
         assert_array_almost_equal(self.C.network.s_active([0, 0, 1])[:,2], self.C.s_external[:,2,2])
 
+    def test_circuit_reduce_with_split_multi(self):
+        """
+        Test the reduce_circuit method with split_multi=True.
+        """
+        ntw_C = self.C.network
+
+        C_reduced = rf.Circuit(self.connections, split_multi=True)
+        ntw_C_reduced = C_reduced.network
+
+        self.assertNotEqual(self.C.dim, C_reduced.dim)
+        assert_array_almost_equal(ntw_C.s, ntw_C_reduced.s)
+
 class CircuitTestCascadeNetworks(unittest.TestCase):
     """
     Build a circuit made of two Networks cascaded and compare the result

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -90,8 +90,8 @@ class CircuitTestConstructor(unittest.TestCase):
         """
         Test the auto_reduce parameter of the Circuit constructor with passed arguments
         """
-        # Test with max_nports=1, ignore_networks=ntwk2
-        kwargs = {'max_nports': 1, 'ignore_networks': (self.ntwk2,)}
+        # Test with max_nports=1, dynamic_networks=ntwk2
+        kwargs = {'max_nports': 1, 'dynamic_networks': (self.ntwk2,)}
 
         # No connections should be reduced
         for key, value in kwargs.items():
@@ -109,7 +109,7 @@ class CircuitTestConstructor(unittest.TestCase):
         connections = [[(self.port1, 0), (self.ntwk1, 0)],
                        [(self.ntwk1, 1), (ntwk3, 0)],
                        [(ntwk3, 1), (self.port2, 0)]]
-        circuit = rf.Circuit(connections, ignore_networks=(ntwk3,))
+        circuit = rf.Circuit(connections, dynamic_networks=(ntwk3,))
 
         # should raise an exception if passing a network not in the circuit
         with self.assertRaises(ValueError):

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -90,10 +90,14 @@ class CircuitTestConstructor(unittest.TestCase):
         """
         Test the auto_reduce parameter of the Circuit constructor with passed arguments
         """
-        # Test with max_nports=1, no connections should be reduced
-        circuit = rf.Circuit(self.connections, auto_reduce=True, max_nports=1)
-        assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
-        self.assertEqual(circuit.connections, self.connections)
+        # Test with max_nports=1, ignore_networks=ntwk2
+        kwargs = {'max_nports': 1, 'ignore_networks': (self.ntwk2,)}
+
+        # No connections should be reduced
+        for key, value in kwargs.items():
+            circuit = rf.Circuit(self.connections, **{key: value})
+            assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
+            self.assertEqual(circuit.connections, self.connections)
 
     def test_cache_attributes(self):
         """

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -90,11 +90,13 @@ class CircuitTestConstructor(unittest.TestCase):
         """
         Test the auto_reduce parameter of the Circuit constructor with passed arguments
         """
-        # Test with max_nports=1, dynamic_networks=ntwk2
-        kwargs = {'max_nports': 1, 'dynamic_networks': (self.ntwk2,)}
+        # Test with max_nports=1 and dynamic_networks in a tuple or a list
+        kwargs = [('max_nports', 1),
+                  ('dynamic_networks', (self.ntwk2,)),
+                  ('dynamic_networks', [self.ntwk2])]
 
         # No connections should be reduced
-        for key, value in kwargs.items():
+        for key, value in kwargs:
             circuit = rf.Circuit(self.connections, **{key: value})
             assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
             self.assertEqual(circuit.connections, self.connections)

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -99,6 +99,27 @@ class CircuitTestConstructor(unittest.TestCase):
             assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
             self.assertEqual(circuit.connections, self.connections)
 
+    def test_update_networks(self):
+        """
+        Test the update_networks method of the Circuit class
+        """
+        # Create an abnormal circuit with a random network
+        ntwk3 = self.ntwk1.copy()
+        ntwk3.name = 'ntwk3'
+        connections = [[(self.port1, 0), (self.ntwk1, 0)],
+                       [(self.ntwk1, 1), (ntwk3, 0)],
+                       [(ntwk3, 1), (self.port2, 0)]]
+        circuit = rf.Circuit(connections, ignore_networks=(ntwk3,))
+
+        # Update the circuit with the self.ntwk2
+        ntwk3.s = self.ntwk2.s
+        circuit_updated = circuit.update_networks(networks=(ntwk3,))
+        assert_array_almost_equal(self.circuit.s_external, circuit_updated.s_external)
+
+        # Update the circuit inplace
+        circuit.update_networks_self(networks=(ntwk3,))
+        assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
+
     def test_cache_attributes(self):
         """
         Test the cached attributes of the Circuit

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -121,7 +121,7 @@ class CircuitTestConstructor(unittest.TestCase):
         assert_array_almost_equal(self.circuit.s_external, circuit_updated.s_external)
 
         # Update the circuit inplace
-        circuit.update_networks_self(networks=(ntwk3,))
+        circuit.update_networks(networks=(ntwk3,), inplace=True)
         assert_array_almost_equal(self.circuit.s_external, circuit.s_external)
 
     def test_cache_attributes(self):


### PR DESCRIPTION
## Summary
This PR enhances the efficiency of handling circuit updates by adding methods to update only specific Networks within a circuit. Additionally, it introduces a parameter to control which `Networks` should remain untouched during circuit reductions, improving flexibility and performance in circuit computations.

## Background & Motivation
My goal is to optimize the performance of **batch circuit computations**, where only the **dynamic** `Networks` are updated, while the **static** `Networks` remain untouched, avoiding the need to recalculate the entire `circuit`.

In this context, **dynamic** `Networks` refer to the components of a circuit that are expected to change during simulations or design iterations. On the other hand, **static** `Networks` are stable components that remain constant throughout the computation. By focusing on the **dynamic portions**, we can streamline updates and minimize redundant calculations.

Recent work in `scikit-rf` has brought significant improvements in improving the computational efficiency of an individual `Circuit` object. This was primarily achieved through **optimizations in the `s_external` method** and **reduced circuit's connections** via the `reduce_circuit` method.

However, rather than focusing solely on optimizing single-circuit calculations, it's time to create a framework for **efficient updates to circuits** where only the **dynamic** `Networks` change, leaving the **static** `Networks` untouched.

By leveraging the `reduce_circuit` method, we can connect all **static** `Networks` within a circuit while leaving the **dynamic** `Networks` (those expected to change) outside the reduction process (similar to integrating static `Networks` into an HFSS file). This way, we can then simply update the **dynamic** `Networks` in the circuit without re-calculating everything.

## Key Updates
In this PR, I’ve made four specific changes to help achieve this:
1. Added the `Circuit.update_networks()` and `Circuit.update_networks_self()` methods to handle `Networks` updates within a circuit.
2. Introduced the `dynamic_networks` parameter to `reduce_circuit()` to prevent dynamic Networks from being included in circuit reductions.
3. Added the `split_multi` parameter to `reduce_circuit()` to control whether to use a `splitter` for connections involving more than two components, enabling more thorough circuit reduction for complex connections.
4. Ensured that merged `Networks` in `reduce_circuit` are assigned new names, distinguishing them from their previous `Networks`.
5. Simplified the parameter-passing logic to make the code cleaner and more concise.

## Future Work
Next, I plan to implement an `optimize_circuit()` method that will utilize [`scipy.optimize`](https://docs.scipy.org/doc/scipy-1.14.0/reference/optimize.html#module-scipy.optimize) to perform `advanced circuit-level numerical optimization`. This will include tasks such as **_Impedance Matching_**, **_Custom De-embedding_**, and **_Circuit Design_**, etc. These enhancements will significantly extend the flexibility and capabilities of the `Circuit` class within `scikit-rf`.