### PR TITLE
Add a comment to the circuit's default behavior.

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -161,6 +161,8 @@ class Circuit:
             Each connection is a described by a list of tuple.
             Each tuple contains (network, network_port_nb).
             Port number indexing starts from zero.
+            Network's port not explicitly listed will be treated as matched.
+            Network's port listed individually will be treated as open.
         name : string, optional
             Name assigned to the circuit (Network). Default is None.
         auto_reduce : bool, optional
@@ -216,6 +218,35 @@ class Circuit:
                 [(port3, 0), (ntw, 2)]
             ]
 
+        Example of a connection between three 1-port networks (port1, port2 and open)
+        and a 3-ports network (ntw):
+        ::
+            connections = [
+                [(port1, 0), (ntw, 0)],
+                [(open, 0), (ntw, 1)],
+                [(port3, 0), (ntw, 2)]
+            ]
+            # or equivalently
+            connections = [
+                [(port1, 0), (ntw, 0)],
+                [(ntw, 1)],
+                [(port3, 0), (ntw, 2)]
+            ]
+
+        Example of a connection between three 1-port networks (port1, port2 and match)
+        and a 3-ports network (ntw):
+        ::
+            connections = [
+                [(port1, 0), (ntw, 0)],
+                [(match, 0), (ntw, 1)],
+                [(port3, 0), (ntw, 2)]
+            ]
+            # or equivalently
+            connections = [
+                [(port1, 0), (ntw, 0)],
+                [(port3, 0), (ntw, 2)]
+            ]
+
         NB1: Creating 1-port network to be used as a port should be made with :func:`Port`
 
         NB2: The external ports indexing is defined by the order of appearance of
@@ -224,6 +255,10 @@ class Circuit:
         the second network identified as a port will be the second port (index 1),
         etc.
 
+        NB3: When a port of a network is listed individually in the connections, the circuit
+        will treat this port with a reflection coefficient of 1, equivalent to an Open.
+        Conversely, if a port is not explicitly included in the connections,the circuit will
+        treat it as matched.
 
         """
         self._connections = connections

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -224,13 +224,13 @@ class Circuit:
             connections = [
                 [(port1, 0), (ntw, 0)],
                 [(open, 0), (ntw, 1)],
-                [(port3, 0), (ntw, 2)]
+                [(port2, 0), (ntw, 2)]
             ]
             # or equivalently
             connections = [
                 [(port1, 0), (ntw, 0)],
                 [(ntw, 1)],
-                [(port3, 0), (ntw, 2)]
+                [(port2, 0), (ntw, 2)]
             ]
 
         Example of a connection between three 1-port networks (port1, port2 and match)
@@ -239,12 +239,12 @@ class Circuit:
             connections = [
                 [(port1, 0), (ntw, 0)],
                 [(match, 0), (ntw, 1)],
-                [(port3, 0), (ntw, 2)]
+                [(port2, 0), (ntw, 2)]
             ]
             # or equivalently
             connections = [
                 [(port1, 0), (ntw, 0)],
-                [(port3, 0), (ntw, 2)]
+                [(port2, 0), (ntw, 2)]
             ]
 
         NB1: Creating 1-port network to be used as a port should be made with :func:`Port`

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -363,6 +363,9 @@ class CircuitTestCascadeNetworks(unittest.TestCase):
         # circuit external ports
         self.port1 = rf.Circuit.Port(self.freq, name='Port1')
         self.port2 = rf.Circuit.Port(self.freq, name='Port2')
+        self.open = rf.Circuit.Open(self.freq, name='PortO')
+        _media = rf.media.DefinedGammaZ0(frequency=self.freq)
+        self.match = _media.match(name='match')
 
     def test_cascade(self):
         """
@@ -400,6 +403,49 @@ class CircuitTestCascadeNetworks(unittest.TestCase):
         circuit = rf.Circuit(connections)
         ntw = self.ntwk2 ** self.ntwk1
         assert_array_almost_equal(circuit.s_external, ntw.s)
+
+    def test_open_condensation(self):
+        """
+        Test the impact of omitting an open termination in the circuit connections.
+        Compare the result of a conventional circuit setup with an open termination
+        to a condensed setup that assumes an open termination by default.
+        """
+        # Conventional setup including open termination
+        cnx_con = [  [(self.port1, 0), (self.ntwk1, 0)],
+                     [(self.ntwk1, 1), (self.ntwk2, 0), (self.port2, 0)],
+                     [(self.ntwk2, 1), (self.open, 0)] ]
+        ckt_con = rf.Circuit(cnx_con)
+
+        # Condensed setup where open termination is implied
+        cnx_cds = [  [(self.port1, 0), (self.ntwk1, 0)],
+                     [(self.ntwk1, 1), (self.ntwk2, 0), (self.port2, 0)],
+                     [(self.ntwk2, 1)] # Open termination is implied
+                     ]
+
+        ckt_cds = rf.Circuit(cnx_cds)
+
+        assert_array_almost_equal(ckt_con.s_external, ckt_cds.s_external)
+
+    def test_match_condensation(self):
+        """
+        Test the impact of omitting a matching network in the circuit connections.
+        Compare the result of a conventional circuit setup with a matching network
+        to a condensed setup that assumes the matching network by default.
+        """
+        # Conventional setup including matching network
+        cnx_con = [  [(self.port1, 0), (self.ntwk1, 0)],
+                     [(self.ntwk1, 1), (self.ntwk2, 0), (self.port2, 0)],
+                     [(self.ntwk2, 1), (self.match, 0)] ]
+        ckt_con = rf.Circuit(cnx_con)
+
+        # Condensed setup where matching network is implied
+        cnx_cds = [  [(self.port1, 0), (self.ntwk1, 0)],
+                     [(self.ntwk1, 1), (self.ntwk2, 0), (self.port2, 0)]
+                     ]
+
+        ckt_cds = rf.Circuit(cnx_cds)
+
+        assert_array_almost_equal(ckt_con.s_external, ckt_cds.s_external)
 
 class CircuitTestMultiPortCascadeNetworks(unittest.TestCase):
     """


### PR DESCRIPTION
Added clarifications in `Circuit.__init__` to explain two specific behaviors, addressing issue [#1159](https://github.com/scikit-rf/scikit-rf/issues/1159).