### PR TITLE
Fixed the issue where the Network connect() method inherited properties that should be discarded

### DIFF
--- a/skrf/constants.py
+++ b/skrf/constants.py
@@ -121,6 +121,7 @@ ComponentFuncT = Literal["re", "im", "mag", "db", "db10", "rad", "deg", "arcl", 
                          "arcl_unwrap", "vswr", "time", "time_db", "time_mag", "time_impulse", "time_step"]
 SparamFormatT = Literal["db", "ri", "ma"]
 PortOrderT = Literal["first", "second", "third", "last", "auto"]
+CircuitComponentT = Literal["_is_circuit_port", "_is_circuit_ground", "_is_circuit_open"]
 
 NumberLike = Union[Number, Sequence[Number], np.ndarray]
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -181,6 +181,7 @@ from .constants import (
     S_DEFINITIONS,
     T0,
     ZERO,
+    CircuitComponentT,
     ComponentFuncT,
     CoordT,
     FrequencyUnitT,
@@ -417,7 +418,7 @@ class Network:
         self.noise_freq = None
         self._z0 = np.array(50, dtype=complex)
         self._port_modes = np.array([])
-        self._ext_attrs = {}
+        self._ext_attrs: dict[CircuitComponentT, bool] = {}
 
         if s_def not in S_DEFINITIONS and s_def is not None:
             raise ValueError('s_def parameter should be either:', S_DEFINITIONS)
@@ -5109,6 +5110,10 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
         ntwkC.renumber(from_ports=from_ports,
                        to_ports=to_ports,
                        only_z0=True)
+
+    # Clear the ntwkC's ext_attrs, since they may have been inherited from ntwkA
+    # If a open, ground or port terminal is connected, this property should not be inherited
+    ntwkC._ext_attrs = {}
 
     # if ntwkA and ntwkB are both 2port, and either one has noise, calculate ntwkC's noise
     either_are_noisy = False

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -75,7 +75,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
-        n._ext_attrs['_test_attr'] = True
+        n._ext_attrs['_is_circuit_port'] = True
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)
         self.assertNotEqual( id(n.frequency), id(n2.frequency))
@@ -84,7 +84,7 @@ class NetworkTestCase(unittest.TestCase):
         n.frequency.f[0] = 0
         self.assertNotEqual(n2.frequency.f[0], 0)
 
-        self.assertEqual(True, n2._ext_attrs.get('_test_attr', None))
+        self.assertEqual(True, n2._ext_attrs.get('_is_circuit_port', False))
 
     def test_two_port_reflect(self):
         number_of_data_points = 10
@@ -675,11 +675,11 @@ class NetworkTestCase(unittest.TestCase):
 
         # Connect the network to another standard network
         ntwk_connected = rf.connect(ntwk_tmp, 1, self.ntwk2, 0)
-        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open'))
+        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open', False))
 
         # Connect the network to another standard network
         ntwk_connected = rf.connect(self.ntwk2, 0, ntwk_tmp, 1)
-        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open'))
+        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open', False))
 
     def test_interconnect_complex_ports(self):
         """ Test that connecting two complex ports in a network

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -75,7 +75,7 @@ class NetworkTestCase(unittest.TestCase):
 
     def test_network_copy(self):
         n = self.ntwk1
-        n._ext_attrs['_test_attr'] = 'test'
+        n._ext_attrs['_test_attr'] = True
         n2 = n.copy()
         self.assertEqual( n.frequency, n2.frequency)
         self.assertNotEqual( id(n.frequency), id(n2.frequency))
@@ -84,7 +84,7 @@ class NetworkTestCase(unittest.TestCase):
         n.frequency.f[0] = 0
         self.assertNotEqual(n2.frequency.f[0], 0)
 
-        self.assertEqual('test', n2._ext_attrs.get('_test_attr', None))
+        self.assertEqual(True, n2._ext_attrs.get('_test_attr', None))
 
     def test_two_port_reflect(self):
         number_of_data_points = 10
@@ -664,6 +664,22 @@ class NetworkTestCase(unittest.TestCase):
                 np.testing.assert_almost_equal(net3_ref.z0, net12.z0)
                 np.testing.assert_almost_equal(net12.s, net3_ref.s)
                 np.testing.assert_almost_equal(net3_z, net3_ref.z)
+
+    def test_connect_drop_ext_attrs(self):
+        """Test that connecting a network created using the Circuit's class
+        method, which has '_ext_attr' attributes, to another standard network.
+        """
+        # Create a network with '_ext_attr' attributes
+        ntwk_tmp = self.ntwk1.copy()
+        ntwk_tmp._ext_attrs['_is_circuit_open'] = True
+
+        # Connect the network to another standard network
+        ntwk_connected = rf.connect(ntwk_tmp, 1, self.ntwk2, 0)
+        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open'))
+
+        # Connect the network to another standard network
+        ntwk_connected = rf.connect(self.ntwk2, 0, ntwk_tmp, 1)
+        self.assertFalse(ntwk_connected._ext_attrs.get('_is_circuit_open'))
 
     def test_interconnect_complex_ports(self):
         """ Test that connecting two complex ports in a network


### PR DESCRIPTION
In the `Circuit` class, the `Networks` created by `Port()`, `Ground()`, or `Open()` will have an additional `_ext_attrs` attribute to support the circuit calculations.

However, in the `reduce_circuit()` method, `Ground` and `Open` objects will participate in the calculations via the `Network.connect()` method. Consequently, the connected `Network` must discard the `_ext_attrs` attribute to prevent it from being mistakenly recognized as a `Ground` or `Open` object in subsequent calculations.

The following example and output demonstrate how the `connect()` method in the master branch raises exception for `Network` instances with `_ext_attrs`:

```python3
Python 3.11.9 (main, Apr 19 2024, 11:43:47) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import skrf as rf
>>> 
>>> freq = rf.Frequency(1, 6, 101, unit='GHz')
>>> media = rf.media.DefinedGammaZ0(frequency=freq)
>>> 
>>> r1 = media.resistor(R=50)
>>> r2 = media.resistor(R=50)
>>> r2._ext_attrs['_is_circuit_ground'] = True
>>> 
>>> r = r1 ** r2
>>> r._ext_attrs.get('_is_circuit_ground', False)
False
>>> 
>>> r = r2 ** r1
>>> r._ext_attrs.get('_is_circuit_ground', False)
True
>>> 
```