### PR TITLE
Spice test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,11 @@ test = [
     "pytest-cov >=4.0",
     "nbval >=0.9",
     "pyarrow >= 10.0",
-    "pyspice >= 1.5"
 ]
 
 plot = [
-    "matplotlib >=3.5"
+    "matplotlib >=3.5",
+    "pyspice >= 1.5",
 ]
 
 xlsx = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ test = [
     "flake8 >=5.0",
     "pytest-cov >=4.0",
     "nbval >=0.9",
-    "pyarrow >= 10.0"
+    "pyarrow >= 10.0",
+    "pyspice >= 1.5"
 ]
 
 plot = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,12 @@ test = [
     "pyarrow >= 10.0",
 ]
 
-plot = [
-    "matplotlib >=3.5",
+testspice = [
     "pyspice >= 1.5",
+]
+
+plot = [
+    "matplotlib >=3.5"
 ]
 
 xlsx = [

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from PySpice.Spice.Parser import SpiceParser
 
 import skrf
 
@@ -90,8 +91,13 @@ class VectorFittingTestCase(unittest.TestCase):
 
         # written tmp file should contain 69 lines
         with open(name) as f:
-            n_lines = len(f.readlines())
-        self.assertEqual(n_lines, 69)
+            parser = SpiceParser(name)
+        
+        assert len(parser.subcircuits[0]._statements) == 52
+        assert len(parser.subcircuits[1]._statements) == 2
+        assert len(parser.subcircuits[2]._statements) == 4
+
+
         os.remove(name)
 
     def test_read_write_npz(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -94,8 +94,8 @@ class VectorFittingTestCase(unittest.TestCase):
             parser = SpiceParser(name)
         
         assert len(parser.subcircuits[0]._statements) == 52
-        assert len(parser.subcircuits[1]._statements) == 2
-        assert len(parser.subcircuits[2]._statements) == 4
+        assert len(parser.subcircuits[1]._statements) == 4
+        assert len(parser.subcircuits[2]._statements) == 2
 
 
         os.remove(name)

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -1,13 +1,12 @@
-from contextlib import suppress
 import os
 import sys
 import tempfile
 import unittest
+from contextlib import suppress
 from pathlib import Path
 
 import numpy as np
 import pytest
-
 
 with suppress(ImportError):
     from PySpice.Spice.Parser import SpiceParser

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -92,7 +92,7 @@ class VectorFittingTestCase(unittest.TestCase):
         # written tmp file should contain 69 lines
         with open(name) as f:
             parser = SpiceParser(name)
-        
+
         assert len(parser.subcircuits[0]._statements) == 52
         assert len(parser.subcircuits[1]._statements) == 4
         assert len(parser.subcircuits[2]._statements) == 2

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from PySpice.Spice.Parser import SpiceParser
 
 import skrf
 
@@ -78,6 +77,8 @@ class VectorFittingTestCase(unittest.TestCase):
         "matplotlib" not in sys.modules,
         reason="Spice subcircuit uses Engformatter which is not available without matplotlib.")
     def test_spice_subcircuit(self):
+        from PySpice.Spice.Parser import SpiceParser
+
         # fit ring slot example network
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import os
 import sys
 import tempfile
@@ -6,6 +7,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+
+
+with suppress(ImportError):
+    from PySpice.Spice.Parser import SpiceParser
 
 import skrf
 
@@ -74,11 +79,9 @@ class VectorFittingTestCase(unittest.TestCase):
         self.assertLess(vf.get_rms_error(), 0.2)
 
     @pytest.mark.skipif(
-        "matplotlib" not in sys.modules,
+        "PySpice" not in sys.modules,
         reason="Spice subcircuit uses Engformatter which is not available without matplotlib.")
     def test_spice_subcircuit(self):
-        from PySpice.Spice.Parser import SpiceParser
-
         # fit ring slot example network
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2349,7 +2349,7 @@ class VectorFitting:
                     # add CCCS to generate the scattered current I_nj at port n
                     # control current is measured by the dummy voltage source at the transfer network Y_nj
                     # the scattered current is injected into the port (source positive connected to ground)
-                    f.write(f'F{n + 1}{j + 1} 0 a{n + 1} V{n + 1}{j + 1}'
+                    f.write(f'F{n + 1}{j + 1} 0 a{n + 1} V{n + 1}{j + 1} '
                             f'{formatter(1 / np.real(self.network.z0[0, n]))}\n')
                     f.write(f'F{n + 1}{j + 1}_inv a{n + 1} 0 V{n + 1}{j + 1}_inv '
                             f'{formatter(1 / np.real(self.network.z0[0, n]))}\n')

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ extras =
     xlsx
     plot
     docs
+    testspice
 commands =
     python -m pytest -n=auto {posargs} --junitxml=test-results/junit-{envname}.xml --junit-prefix={envname}
 
@@ -53,5 +54,6 @@ extras =
     xlsx
     plot
     docs
+    testspice
 commands =
     python -m pytest -n=auto {posargs} --junitxml=test-results/junit-{envname}.xml --junit-prefix={envname}


### PR DESCRIPTION
A Bug came into spice export from vectorfitting. This PR solves this issue again. I use an third party spice parser to validate the files now, so syntax issues like could be detected in the future.

https://github.com/scikit-rf/scikit-rf/commit/1e20a15505e8ba1f2de398d3506426776080ad00