### PR TITLE
Optimize the performance of Network connect method

### DIFF
--- a/skrf/frequency.py
+++ b/skrf/frequency.py
@@ -150,7 +150,9 @@ class Frequency:
         start =  self.multiplier * start
         stop = self.multiplier * stop
 
-        if sweep_type.lower() == 'lin':
+        if npoints == 0:
+            self._f = np.array([])
+        elif sweep_type.lower() == 'lin':
             self._f = linspace(start, stop, npoints)
         elif sweep_type.lower() == 'log' and start > 0:
             self._f = geomspace(start, stop, npoints)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2059,7 +2059,7 @@ class Network:
         ntwk = Network(z0=self.z0, s_def=self.s_def, comments=self.comments)
 
         ntwk._s = self.s.copy()
-        ntwk.frequency = self.frequency
+        ntwk.frequency._f = self.frequency._f.copy()
         ntwk.port_modes = self.port_modes.copy()
 
         if self.params is not None:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2060,6 +2060,7 @@ class Network:
 
         ntwk._s = self.s.copy()
         ntwk.frequency._f = self.frequency._f.copy()
+        ntwk.frequency.unit = self.frequency.unit
         ntwk.port_modes = self.port_modes.copy()
 
         if self.params is not None:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6073,7 +6073,7 @@ def connect_s(A: np.ndarray, k: int, B: np.ndarray, l: int, num: int = 1) -> np.
     nC = nA + nB  # num ports on C
 
     # create composite matrix, appending each sub-matrix diagonally
-    C = np.zeros((nf, nC, nC), dtype='complex')
+    C = np.zeros((nf, nC, nC), dtype='complex', order='F')
 
     # if ntwkB is a 2port, then keep port indices where you expect.
     if nB == 2 and nA > 2 and num == 1:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6083,10 +6083,12 @@ def connect_s(A: np.ndarray, k: int, B: np.ndarray, l: int, num: int = 1) -> np.
         |     | + |B| = |0  B 0 |, rather than |A3 A4 0|
         |A3 A4|         |A3 0 A4|              |0  0  B|
         """
-        C[:, :k, :k] = A[:, :k, :k]
-        C[:, :k, k + nB :] = A[:, :k, k:]
-        C[:, k + nB :, :k] = A[:, k:, :k]
-        C[:, k + nB :, k + nB :] = A[:, k:, k:]
+        # Create A matrix's buffer
+        Alk, Ark = A[:, :, :k], A[:, :, k:]
+        C[:, :k, :k] = Alk[:, :k, :]
+        C[:, :k, k + nB :] = Ark[:, :k, :]
+        C[:, k + nB :, :k] = Alk[:, k:, :]
+        C[:, k + nB :, k + nB :] = Ark[:, k:, :]
         C[:, k : k + nB, k : k + nB] = B
 
         # call innerconnect_s() on composit matrix C

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6178,8 +6178,8 @@ def innerconnect_s(A: np.ndarray, k: int, l: int) -> np.ndarray:
     Ael = A[:, ext_i, l].T
 
     # Create an suit-sized s-matrix, to store the result
-    x, y = np.meshgrid(ext_i, ext_i)
-    C = A[:, y, x]
+    i, j = np.meshgrid(ext_i, ext_i, indexing='ij', sparse=True)
+    C = A[:, i, j]
 
     # create temporary matrices for calculation
     det = (Akl * Alk - Akk * All)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6084,12 +6084,10 @@ def connect_s(A: np.ndarray, k: int, B: np.ndarray, l: int, num: int = 1) -> np.
         |     | + |B| = |0  B 0 |, rather than |A3 A4 0|
         |A3 A4|         |A3 0 A4|              |0  0  B|
         """
-        # Create A matrix's buffer
-        Alk, Ark = A[:, :, :k], A[:, :, k:]
-        C[:, :k, :k] = Alk[:, :k, :]
-        C[:, :k, k + nB :] = Ark[:, :k, :]
-        C[:, k + nB :, :k] = Alk[:, k:, :]
-        C[:, k + nB :, k + nB :] = Ark[:, k:, :]
+        C[:, :k, :k] = A[:, :k, :k]
+        C[:, :k, k + nB :] = A[:, :k, k:]
+        C[:, k + nB :, :k] = A[:, k:, :k]
+        C[:, k + nB :, k + nB :] = A[:, k:, k:]
         C[:, k : k + nB, k : k + nB] = B
 
         # call innerconnect_s() on composit matrix C


### PR DESCRIPTION
This PR focuses on improving the performance of the `connect()` method for Network connections. It introduces three optimizations:

1. Enhanced the initialization of `Network.frequency` for better performance.
2. Utilized a sparse `np.meshgrid` to construct the C matrix more efficiently.
3. Stored the C matrix in an ndarray with `Fortran-contiguous ('F')` order to optimize memory layout.

Speed up:
![img_v3_02eb_c7cb6698-878c-48a7-a10c-ca8e31abedcg](https://github.com/user-attachments/assets/4d1ed94f-d2f8-49fb-b52c-b5a9570ba03a)
A line plot comparing the execution time (in millisecond) for `connect()` with SNP and S2P files across different port number.

![img_v3_02eb_d2a71977-5887-48cc-a190-26e9b496851g](https://github.com/user-attachments/assets/186c8ed5-73c0-448c-a150-892ce98a48a5)
A scatter plot showing the performance comparison between `this branch` and the `master` for the same test cases.