### PR TITLE
Add line_floating method to Media

### DIFF
--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -126,7 +126,7 @@ To run all the tests (except the virtual instruments)
     cd scikit-rf
     # Create environment and install dependencies, needed only once.
     python -m venv .venv
-    python -e[test,visa,netw,xlsx,plot,docs,testspice]
+    pip install -e .[test,visa,netw,xlsx,plot,docs,testspice] --compile
 
     # Activate Environment, needed for all following steps.
     # on Linux Systems

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1057,7 +1057,7 @@ class Media(ABC):
 
         theta = self.electrical_length(self.to_meters(d=d, unit=unit))
 
-        if np.abs(theta) < ZERO:
+        if np.abs(theta).all() < ZERO:
             result.s = 1/2* np.array([[1, 1, 1, -1],
                                       [1, 1, -1, 1],
                                       [1, -1, 1, 1],

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1066,9 +1066,9 @@ class Media(ABC):
         
         result.y = \
                 np.array([[ y11,  y12, -y11, -y12],
-                        [ y21,  y22, -y21, -y22],
-                        [-y11, -y12,  y11,  y12],
-                        [-y21, -y22,  y21,  y22]]).transpose().reshape(-1, 4, 4)
+                          [ y21,  y22, -y21, -y22],
+                          [-y11, -y12,  y11,  y12],
+                          [-y21, -y22,  y21,  y22]]).transpose().reshape(-1, 4, 4)
         
         # renormalize (or embed) into z0_port if required
         if self.z0_port is not None:

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1001,6 +1001,81 @@ class Media(ABC):
         result.renormalize(result.z0, s_def=s_def)
 
         return result
+    
+    def line_floating(self, d: NumberLike, unit: str = 'deg',
+                z0: NumberLike | str | None = None, **kwargs) -> Network:    
+        r"""
+        Floating transmission line of a given length and impedance.
+
+        This method returns a transmission line with floating shields.
+        This is a four-port network, as opposed to the two-port _line_ method.
+        Ports 1 and 3 are one side of the line, and electrically connect to
+        ports 2 and 4 on the other side, respectively.
+
+        The units of `length` are interpreted according to the value
+        of `unit`. If `z0` is not None, then a line specified impedance
+        is produced.
+
+        Parameters
+        ----------
+        d : number
+                the length of transmission line (see unit argument)
+        unit : ['deg','rad','m','cm','um','in','mil','s','us','ns','ps']
+                the units of d.  See :func:`to_meters`, for details
+        z0 : number, string, or array-like or None
+            the characteristic impedance of the line, if different
+            from media.z0. To set z0 in terms of normalized impedance,
+            pass a string, like `z0='1+.2j'`
+        \*\*kwargs : key word arguments
+            passed to :func:`match`, which is called initially to create a
+            'blank' network.
+
+        Returns
+        -------
+        line_floating : :class:`~skrf.network.Network` object
+            matched, floating transmission line of given length
+
+        Examples
+        --------
+        >>> my_media.line_floating(1, 'mm', z0=100)
+        >>> my_media.line_floating(90, 'deg', z0='2') # set z0 as normalized impedance
+
+        """
+        if isinstance(z0,str):
+            z0 = self.parse_z0(z0)* self.z0
+
+        if z0 is None:
+            z0 = self.z0
+
+        s_def = kwargs.pop('s_def', S_DEF_DEFAULT)
+
+        # The use of either traveling or pseudo waves s-parameters definition
+        # is required here.
+        # The definition of the reflection coefficient for power waves has
+        # conjugation.
+        result = self.match(nports=4, z0 = z0, s_def='traveling', **kwargs)
+
+        theta = self.electrical_length(self.to_meters(d=d, unit=unit))
+
+        # From AWR docs on TLINP4. The math below could
+        # be re-worked directly into its S-parameter formulation
+        y11 = 1 / (z0 * np.tanh(theta))
+        y12 = -1 / (z0 * np.sinh(theta))
+        y22 = y11
+        y21 = y12
+        
+        result.y = \
+                np.array([[ y11,  y12, -y11, -y12],
+                        [ y21,  y22, -y21, -y22],
+                        [-y11, -y12,  y11,  y12],
+                        [-y21, -y22,  y21,  y22]]).transpose().reshape(-1, 4, 4)
+        
+        # renormalize (or embed) into z0_port if required
+        if self.z0_port is not None:
+            result.renormalize(self.z0_port)
+        result.renormalize(result.z0, s_def=s_def)
+
+        return result    
 
 
     def delay_load(self, Gamma0: NumberLike, d: Number, unit: str = 'deg', **kwargs) -> Network:

--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -1001,9 +1001,9 @@ class Media(ABC):
         result.renormalize(result.z0, s_def=s_def)
 
         return result
-    
+
     def line_floating(self, d: NumberLike, unit: str = 'deg',
-                z0: NumberLike | str | None = None, **kwargs) -> Network:    
+                z0: NumberLike | str | None = None, **kwargs) -> Network:
         r"""
         Floating transmission line of a given length and impedance.
 
@@ -1063,19 +1063,19 @@ class Media(ABC):
         y12 = -1 / (z0 * np.sinh(theta))
         y22 = y11
         y21 = y12
-        
+
         result.y = \
                 np.array([[ y11,  y12, -y11, -y12],
                           [ y21,  y22, -y21, -y22],
                           [-y11, -y12,  y11,  y12],
                           [-y21, -y22,  y21,  y22]]).transpose().reshape(-1, 4, 4)
-        
+
         # renormalize (or embed) into z0_port if required
         if self.z0_port is not None:
             result.renormalize(self.z0_port)
         result.renormalize(result.z0, s_def=s_def)
 
-        return result    
+        return result
 
 
     def delay_load(self, Gamma0: NumberLike, d: Number, unit: str = 'deg', **kwargs) -> Network:

--- a/skrf/media/tests/test_all_construction.py
+++ b/skrf/media/tests/test_all_construction.py
@@ -59,6 +59,9 @@ class MediaTestCase:
     def test_line(self):
         self.media.line(1)
 
+    def test_line_floating(self):
+        self.media.line_floating(1)
+
     def test_delay_load(self):
         self.media.delay_load(1,2)
 

--- a/skrf/media/tests/test_media.py
+++ b/skrf/media/tests/test_media.py
@@ -368,6 +368,29 @@ class DefinedGammaZ0TestCase(unittest.TestCase):
         skrf_ntwk = self.dummy_media.isolator(name = name)
         self.assertEqual(name, skrf_ntwk.name)
 
+    def test_line_floating(self):
+        """
+        Test the naming of the network. When circuit is used to connect a
+        topology of networks, they should have unique names.
+        """
+        name = 'floating_line'
+        self.dummy_media.frequency = Frequency(1, 1, 1, unit='GHz')
+        skrf_ntwk = self.dummy_media.line_floating(90, 'deg', name=name)
+        self.assertEqual(name, skrf_ntwk.name)
+
+        # Expected to be a 4-port network
+        self.assertEqual(skrf_ntwk.nports, 4)
+
+        # zero length case
+        s_zero = 1/2 * np.array([[1, 1, 1, -1],
+                                 [1, 1, -1, 1],
+                                 [1, -1, 1, 1],
+                                 [-1, 1, 1, 1]]
+                                ).transpose().reshape(-1,4,4)
+        for z0 in [50, 1]:
+            zero_length = self.dummy_media.line_floating(d=0, z0=z0)
+            assert_array_almost_equal(zero_length.s, s_zero)
+
 
     def test_scalar_gamma_z0_media(self):
         """


### PR DESCRIPTION
It is often useful to have a "floating" transmission line, which is a 4-port network with isolated ground terminals. This is useful in modeling e.g. baluns, as in my project. AWR Microwave Office provides this in their "TLINP4" element.

I have implemented this in the "line_floating" method on the Media class using the Y-parameter math in the TLINP4 documentation. It could be re-worked directly into an S-parameter formulation, but I have briefly tested it and it seems to work for now.

Hope everything is formatted correctly! :)