### PR TITLE
fix possible division by zero in quadratic formula in TUGMultilineTRL

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -3552,12 +3552,12 @@ class TUGMultilineTRL(EightTerm):
     References
     ----------
     .. [1] Z. Hatab, M. Gadringer and W. Bösch, "Improving The Reliability of The Multiline TRL Calibration Algorithm,"
-        _2022 98th ARFTG Microwave Measurement Conference (ARFTG)_, Las Vegas, NV, USA, 2022, pp. 1-5,
+        2022 98th ARFTG Microwave Measurement Conference (ARFTG), Las Vegas, NV, USA, 2022, pp. 1-5,
         doi: https://doi.org/10.1109/ARFTG52954.2022.9844064
 
-    .. [2] Z. Hatab, M. Gadringer and W. Bösch, "Propagation of Linear Uncertainties through Multiline
-        Thru-Reflect-Line Calibration,"
-            2023, e-print: https://arxiv.org/abs/2301.09126
+    .. [2] Z. Hatab, M. Gadringer and W. Bösch, "Propagation of Linear Uncertainties Through Multiline Thru-Reflect-Line Calibration," 
+        in IEEE Transactions on Instrumentation and Measurement, vol. 72, pp. 1-9, 2023, 
+        doi: https://doi.org/10.1109/TIM.2023.3296123
 
     .. [3] https://ziadhatab.github.io/posts/multiline-trl-calibration/
 
@@ -3751,13 +3751,13 @@ class TUGMultilineTRL(EightTerm):
                 k2 = -v11*v22*v24/v12 + v11*v14*v22**2/v12**2 + v21*v24 - v14*v21*v22/v12
                 k1 = v11*v24/v12 - 2*v11*v14*v22/v12**2 - v23 + v13*v22/v12 + v14*v21/v12
                 k0 = v11*v14/v12**2 - v13/v12
-                c2 = np.array([(-k1 - np.sqrt(-4*k0*k2 + k1**2))/(2*k2), (-k1 + np.sqrt(-4*k0*k2 + k1**2))/(2*k2)])
+                c2 = np.roots([k2,k1,k0])*np.ones(2)
                 c1 = (1 - c2*v22)/v12
             else:
                 k2 = -v11*v12*v24/v22 + v11*v14 + v12**2*v21*v24/v22**2 - v12*v14*v21/v22
                 k1 = v11*v24/v22 - 2*v12*v21*v24/v22**2 + v12*v23/v22 - v13 + v14*v21/v22
                 k0 = v21*v24/v22**2 - v23/v22
-                c1 = np.array([(-k1 - np.sqrt(-4*k0*k2 + k1**2))/(2*k2), (-k1 + np.sqrt(-4*k0*k2 + k1**2))/(2*k2)])
+                c1 = np.roots([k2,k1,k0])*np.ones(2)
                 c2 = (1 - c1*v12)/v22
             x = np.array( [v1*x + v2*y for x,y in zip(c1,c2)] )  # 2 solutions
             mininx = np.argmin( abs(x - x_est).sum(axis=1) )

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -3555,9 +3555,9 @@ class TUGMultilineTRL(EightTerm):
         2022 98th ARFTG Microwave Measurement Conference (ARFTG), Las Vegas, NV, USA, 2022, pp. 1-5,
         doi: https://doi.org/10.1109/ARFTG52954.2022.9844064
 
-    .. [2] Z. Hatab, M. Gadringer and W. Bösch, "Propagation of Linear Uncertainties Through Multiline Thru-Reflect-Line Calibration," 
-        in IEEE Transactions on Instrumentation and Measurement, vol. 72, pp. 1-9, 2023, 
-        doi: https://doi.org/10.1109/TIM.2023.3296123
+    .. [2] Z. Hatab, M. Gadringer and W. Bösch, "Propagation of Linear Uncertainties Through Multiline
+        Thru-Reflect-Line Calibration," in IEEE Transactions on Instrumentation and Measurement,
+        vol. 72, pp. 1-9, 2023, doi: https://doi.org/10.1109/TIM.2023.3296123
 
     .. [3] https://ziadhatab.github.io/posts/multiline-trl-calibration/
 


### PR DESCRIPTION
Hi!

I noticed that when I imported the code here, I solved the quadratic equation using the standard quadratic formula. However, I forgot to replace it with `np.roots()`. The problem with the standard formula is that it can lead to division by zero, for example:
```python
c2 = np.array([(-k1 - np.sqrt(-4*k0*k2 + k1**2))/(2*k2), (-k1 + np.sqrt(-4*k0*k2 + k1**2))/(2*k2)])
```
the coefficient `k2` belong to the quadratic term. In the very special case when the equation collapses to linear, this term is zero. Generally, this case would only happen when the error box is the identity matrix. Here is an example how to get the error:
```python
import numpy as np
import skrf as rf
from skrf.media import CPW

f = np.linspace(1e9, 150e9, 512)
freq = rf.Frequency.from_f(f, unit='hz')
# CPW model parameters 
w, s, wg, t = 49.1e-6, 25.5e-6, 273.3e-6, 4.9e-6
Dk = 9.9
Df = 0.0002
sig_r = 0.7
sig_cu = 58e6 # (s/m)
sig = sig_cu*sig_r  # conductivity of Gold    
cpw = CPW(frequency=freq, w=w, s=s, t=t, h=1.55e-3, 
          ep_r=Dk, tand=Df, rho=1/sig, z0_port=50)

# short standard
short_offset = 100e-6
short = cpw.delay_short(short_offset, unit='m', z0=50)
short = rf.two_port_reflect(short, short)

# line standards
lengths = np.array([0, 1, 8, 12, 14, 17])*0.3e-3    
lines = [cpw.line(d=x, unit='m', z0=50) for x in lengths]

cal = rf.TUGMultilineTRL(line_meas=lines, line_lengths=lengths, er_est=5.2, 
                         reflect_meas=short, reflect_est=-1, reflect_offset=short_offset)

print(cal.er_eff)
```

The function `np.roots()` from numpy can handle all cases and solves the issue.

While I was at it, I fixed one of the literature references.