### PR TITLE
Fix Djordjevic-Svensson dispersion lead to negative tanD in DefinedAEpTandZ0

### DIFF
--- a/skrf/media/definedAEpTandZ0.py
+++ b/skrf/media/definedAEpTandZ0.py
@@ -170,13 +170,10 @@ class DefinedAEpTandZ0(Media):
         f = self.frequency.f
         if self.model == 'djordjevicsvensson':
             # compute the slope for a log frequency scale, tanD dependent.
-            k = log((f_high + 1j * f_ep) / (f_low + 1j * f_ep))
-            fd = log((f_high + 1j * f) / (f_low + 1j * f))
-            ep_d = -tand * ep_r  / imag(k)
+            m = (ep_r*tand) * (pi/(2*log(10)))
             # value for frequency above f_high
-            ep_inf = ep_r * (1. + tand * real(k) / imag(k))
-            # compute complex permitivity
-            return ep_inf + ep_d * fd
+            ep_inf = (ep_r - 1j*ep_r*tand - m*log((f_high + 1j*f_ep)/(f_low + 1j*f_ep)))
+            return ep_inf + m*log((f_high + 1j*f)/(f_low + 1j*f))
         elif self.model == 'frequencyinvariant':
             return ones(self.frequency.f.shape) * (ep_r - 1j*ep_r*tand)
         else:

--- a/skrf/media/definedAEpTandZ0.py
+++ b/skrf/media/definedAEpTandZ0.py
@@ -170,10 +170,13 @@ class DefinedAEpTandZ0(Media):
         f = self.frequency.f
         if self.model == 'djordjevicsvensson':
             # compute the slope for a log frequency scale, tanD dependent.
-            m = (ep_r*tand) * (pi/(2*log(10)))
+            k = log((f_high + 1j * f_ep) / (f_low + 1j * f_ep))
+            fd = log((f_high + 1j * f) / (f_low + 1j * f))
+            ep_d = -tand * ep_r  / imag(k)
             # value for frequency above f_high
-            ep_inf = (ep_r - 1j*ep_r*tand - m*log((f_high + 1j*f_ep)/(f_low + 1j*f_ep)))
-            return ep_inf + m*log((f_high + 1j*f)/(f_low + 1j*f))
+            ep_inf = ep_r * (1. + tand * real(k) / imag(k))
+            # compute complex permitivity
+            return ep_inf + ep_d * fd
         elif self.model == 'frequencyinvariant':
             return ones(self.frequency.f.shape) * (ep_r - 1j*ep_r*tand)
         else:

--- a/skrf/media/definedAEpTandZ0.py
+++ b/skrf/media/definedAEpTandZ0.py
@@ -169,11 +169,14 @@ class DefinedAEpTandZ0(Media):
         f_low, f_high, f_ep = self.f_low, self.f_high, self.f_ep
         f = self.frequency.f
         if self.model == 'djordjevicsvensson':
-            # compute the slope for a log frequency scale, tanD dependent.
-            m = (ep_r*tand) * (pi/(2*log(10)))
-            # value for frequency above f_high
-            ep_inf = (ep_r - 1j*ep_r*tand - m*log((f_high + 1j*f_ep)/(f_low + 1j*f_ep)))
-            return ep_inf + m*log((f_high + 1j*f)/(f_low + 1j*f))
+           # compute the slope for a log frequency scale, tanD dependent.
+           k = log((f_high + 1j * f_ep) / (f_low + 1j * f_ep))
+           fd = log((f_high + 1j * f) / (f_low + 1j * f))
+           ep_d = -tand * ep_r  / imag(k)
+           # value for frequency above f_high
+           ep_inf = ep_r * (1. + tand * real(k) / imag(k))
+           # compute complex permitivity
+           return ep_inf + ep_d * fd
         elif self.model == 'frequencyinvariant':
             return ones(self.frequency.f.shape) * (ep_r - 1j*ep_r*tand)
         else:


### PR DESCRIPTION
Fix #1185 
Should looks like this:
![376227333-58c752d9-9cac-4d4b-820c-0c883a90ebc6](https://github.com/user-attachments/assets/b2eb7144-ba73-4d77-ad6f-97217e27dad2)

Before the fix, tanD is going below zero at low and high frequencies outside the poles:
![376227824-97dd8a81-01b9-47e7-82b9-d8a9560d07e8](https://github.com/user-attachments/assets/e697acad-b0a1-4a13-89fd-597375226dc6)

After the fix, tanD tanD tends toward zero and keep positive:
![djordjevicsvensson](https://github.com/user-attachments/assets/7e12e35d-7753-4c27-a1d1-dc1808489290)
