### PR TITLE
Add shallow_copy parameter to Network.copy() method

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2043,7 +2043,7 @@ class Network:
         return True
 
     ## CLASS METHODS
-    def copy(self, shallow_copy: bool = False) -> Network:
+    def copy(self, *, shallow_copy: bool = False) -> Network:
         """
         Return a copy of this Network.
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2043,12 +2043,29 @@ class Network:
         return True
 
     ## CLASS METHODS
-    def copy(self) -> Network:
+    def copy(self, shallow_copy: bool = False) -> Network:
         """
         Return a copy of this Network.
 
         Needed to allow pass-by-value for a Network instead of
         pass-by-reference
+
+        Parameters
+        ----------
+        shallow_copy : bool, optional
+            If True, the method creates a new Network object with empty s-parameters that share the same shape
+            as the original Network, but without copying the actual s-parameters data. This is useful when you
+            plan to immediately modify the s-parameters after creating the Network, as a deep copy would be
+            unnecessary and costly. Using `shallow_copy` improves performance by leveraging lazy initialization
+            through `numpy's np.empty()`, which allocates virtual memory without immediate physical memory
+            allocation, deferring actual memory initialization until first access. This approach can significantly
+            enhance `copy()` performance when dealing with large `Network` objects, when you are intended for
+            immediate modification after the Network's creation.
+
+        Note
+        ----
+        If you require a complete copy of the `Network` instance or need to perform operation on the s-parameters
+        of the copied Network, it is essential not to use the `shallow_copy` parameter!
 
         Returns
         -------
@@ -2058,7 +2075,11 @@ class Network:
         """
         ntwk = Network(z0=self.z0, s_def=self.s_def, comments=self.comments)
 
-        ntwk._s = self.s.copy()
+        ntwk._s = (
+            np.empty(shape=self.s.shape, dtype=self.s.dtype)
+            if shallow_copy
+            else self.s.copy()
+        )
         ntwk.frequency._f = self.frequency._f.copy()
         ntwk.frequency.unit = self.frequency.unit
         ntwk.port_modes = self.port_modes.copy()

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5100,8 +5100,8 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     # mismatch, which takes into account the effect of differing port
     # impedances.
     # import pdb;pdb.set_trace()
-    z0_equal = not assert_z0_at_ports_equal(ntwkA, k, ntwkB, l)
-    if z0_equal:
+    z0_equal = assert_z0_at_ports_equal(ntwkA, k, ntwkB, l)
+    if not z0_equal:
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
         mismatch = impedance_mismatch(ntwkA.z0[:, k], ntwkB.z0[:, l], s_def)
@@ -5113,7 +5113,7 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
         ntwkC.renumber(from_ports=[ntwkC.nports - 1] + list(range(k, ntwkC.nports - 1)),
                        to_ports=list(range(k, ntwkC.nports)))
     # call s-matrix connection function
-    ntwkC.s = connect_s(ntwkC.s if z0_equal else ntwkA.s, k, ntwkB.s, l, num)
+    ntwkC.s = connect_s(ntwkC.s if not z0_equal else ntwkA.s, k, ntwkB.s, l, num)
 
     # combine z0 arrays and remove ports which were `connected`
     ntwkC.z0 = np.hstack(
@@ -5495,9 +5495,9 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
 
     s_def_original = ntwkC.s_def
 
-    z0_equal = not (ntwkC.z0[:, k] == ntwkC.z0[:, l]).all()
+    z0_equal = (ntwkC.z0[:, k] == ntwkC.z0[:, l]).all()
 
-    if z0_equal:
+    if not z0_equal:
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
         mismatch = impedance_mismatch(ntwkA.z0[:, k], ntwkA.z0[:, l], ntwkA.s_def)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5510,7 +5510,7 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
                        to_ports=list(range(k, ntwkC.nports)))
 
     # call s-matrix connection function
-    ntwkC.s = innerconnect_s(ntwkC.s if z0_equal else ntwkA.s, k, l)
+    ntwkC.s = innerconnect_s(ntwkC.s if not z0_equal else ntwkA.s, k, l)
 
     # update the characteristic impedance matrix
     ntwkC.z0 = np.delete(ntwkC.z0, list(range(k, k + 1)) + list(range(l, l + 1)), 1)


### PR DESCRIPTION
I noticed that when performing `connect()/innerconnect()` on a large `Network`, such as those derived from `HFSS` files with numerous ports, the process of calculating `s-parameters` is accompanied by a significant overhead due to the `copy()` operation on the `s-parameters` `ndarray` during `Network copy()` also takes a certain amount of time.

However, the copied `s-parameters` are **mostly overwritten after their creation**, so the time-consuming `ndarray.copy()` becomes unnecessary.

Therefore, this PR introduces the `shallow_copy` attribute in the `Network.copy()` method, allowing `np.empty()` to create an `s-parameters` that is not initialized in memory during `Network.copy()`, thereby avoiding the abnormal time-consuming on `Network.copy()` method.

This enhancement aims to streamline the `Network.copy()` operation, particularly for large networks, by reducing the time spent on unnecessary memory operations.

Here are an testing example:
```python3
Python 3.11.10 (main, Oct 23 2024, 15:23:20) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import skrf as rf; from timeit import timeit; from pathlib import Path
matplotlib not found while setting up plotting

In [2]: Path('/home/Test.s19p').stat().st_size / 1024**2
Out[2]: 199.82172203063965

In [3]: rf.__file__
Out[3]: '/home/Git/scikit-rf/skrf/__init__.py'

In [4]: timeit('ntwk.copy()', setup="import skrf as rf;ntwk=rf.Network('//home/Test.s19p')", number=100)/100
Out[4]: 0.008774315863847732

In [5]: timeit('ntwk.copy(shallow_copy=True)', setup="import skrf as rf;ntwk=rf.Network('/home/Test.s19p')", number=100)/100
Out[5]: 0.00013228077441453933

In [6]: timeit('rf.innerconnect(ntwk, 0, 1)', setup="import skrf as rf;ntwk=rf.Network('/home/Test.s19p')", number=100)/100
Out[6]: 0.04823315484449267
```
For a 200 MB SNP file, the traditional `Network.copy()` operation within `innerconnect()` consumes a considerable portion of the total computation time for `s-parameters`, specifically accounting for **approximately 15%** of the overall time (calculated as 8.77 / (48.23+8.77)).

Moreover, the implementation of `shallow_copy` has dramatically decreased the duration of `Network.copy()`, from about 8.77 milliseconds to a mere 0.000132 milliseconds, representing a significant enhancement.