### PR TITLE
Bugfix to avoid instance name collisions. Bug occurs for networks wi

### DIFF
--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2339,7 +2339,7 @@ class VectorFitting:
                 sqrt_Z0_n=np.sqrt(np.real(self.network.z0[0, n]))
 
                 # Port reference impedance Z0
-                f.write(f'R{n + 1} p{n+1} a{n + 1} {np.real(self.network.z0[0, n])}\n')
+                f.write(f'R_ref_{n + 1} p{n+1} a{n + 1} {np.real(self.network.z0[0, n])}\n')
 
                 # CCVS implementing the reflected wave b.
                 # Also used as current sensor to measure the input current


### PR DESCRIPTION
Bug occurs for networks with 11 or more ports.

Then, the reference impedance resistor will be called R11 and this will collide with the transfer impedance R11 for transfer from port 1 to port 1.

