### PR TITLE
WIP: Try Jax as GPU accelerator

### DIFF
--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -5,9 +5,10 @@ import os
 import warnings
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any
-import numpy as np
-import jax.numpy as jnp
+
 import jax
+import jax.numpy as jnp
+import numpy as np
 from scipy.integrate import trapezoid
 
 from .util import Axes, axes_kwarg
@@ -705,9 +706,9 @@ class VectorFitting:
 
         else:
             return None
-        
 
-    
+
+
     @staticmethod
     def _qr(arr: np.ndarray) -> np.ndarray:
         #return np.array([jnp.linalg.qr(e, mode='r') for e in arr])

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -6,8 +6,11 @@ import warnings
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any
 
-import jax
-import jax.numpy as jnp
+try:
+    from jax.numpy.linalg import qr
+except ImportError:
+    from numpy.linalg import qr
+
 import numpy as np
 from scipy.integrate import trapezoid
 
@@ -19,7 +22,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
 
 class VectorFitting:
     """
@@ -65,7 +67,6 @@ class VectorFitting:
     .. [#vectfit_website] Vector Fitting website: https://www.sintef.no/projectweb/vectorfitting/
     """
 
-    @profile
     def __init__(self, network: Network):
         self.network = network
         """ Instance variable holding the Network to be fitted. This is the Network passed during initialization,
@@ -372,7 +373,6 @@ class VectorFitting:
                               '`passivity_enforce()` to enforce passivity before using this model.',
                               UserWarning, stacklevel=2)
 
-    @profile
     def auto_fit(self, n_poles_init_real: int = 3, n_poles_init_cmplx: int = 3, n_poles_add: int = 3,
                  model_order_max: int = 100, iters_start: int = 3, iters_inter: int = 3, iters_final: int = 5,
                  target_error: float = 1e-2, alpha: float = 0.03, gamma: float = 0.03, nu_samples: float = 1.0,
@@ -707,16 +707,7 @@ class VectorFitting:
         else:
             return None
 
-
-
     @staticmethod
-    def _qr(arr: np.ndarray) -> np.ndarray:
-        #return np.array([jnp.linalg.qr(e, mode='r') for e in arr])
-        qr_vmap = jax.vmap(lambda e: jnp.linalg.qr(e, mode='r'), in_axes=0)
-        return qr_vmap(arr)
-
-    @staticmethod
-    @profile
     def _pole_relocation(poles, freqs, freq_responses, weights_responses, fit_constant, fit_proportional):
         n_responses, n_freqs = np.shape(freq_responses)
         n_samples = n_responses * n_freqs
@@ -821,9 +812,7 @@ class VectorFitting:
         # workaround for old numpy:
         #R = np.empty((n_responses, dim_k, n_cols_unused + n_cols_used))
         A_ri = np.hstack((A.real, A.imag))
-        #for i in range(n_responses):
-        #    R[i] = np.linalg.qr(A_ri[i], mode='r')
-        R = VectorFitting._qr(A_ri)
+        R = np.array([qr(e, mode='r') for e in A_ri])
 
         # only R22 is required to solve for c_res and d_res
         # R12 and R22 can have a different number of rows, depending on K
@@ -1055,7 +1044,6 @@ class VectorFitting:
 
         return idx_freqs_start[i_sort], idx_freqs_stop[i_sort], idx_freqs_max[i_sort], delta_mean_bands[i_sort]
 
-    @profile
     def get_rms_error(self, i=-1, j=-1, parameter_type: str = 's'):
         r"""
         Returns the root-mean-square (rms) error magnitude of the fit, i.e.


### PR DESCRIPTION
This is a first try to use Jax as GPU accelerator.

VectorFitting process is mainly depending on `qr` decomposition, so I just replaced `numpy.linalg.qr` with `jax.numpy.linalg.qr`.

I did some tests with the s4p file from [here](https://github.com/scikit-rf/scikit-rf/issues/553#issuecomment-957003759).
The matrix shape for `qr` composition starts at (16,2992,20) and ends at (16,2992,640) after adding some poles, so i benchmarked the last dimension from 20 to 2000.

```python
import numpy as np
import perfplot
import jax
jax.config.update("jax_enable_x64", True)
import jax.numpy as jnp

rng = np.random.default_rng()

qr_vmap = jax.vmap(lambda e: jnp.linalg.qr(e, mode='r'), in_axes=0)

perfplot.show(
    setup=lambda n: rng.random((16, 2992, n)),
    kernels=[
        lambda arr: np.linalg.qr(arr, mode="r"),
        lambda arr: np.array([np.linalg.qr(e, mode="r") for e in arr]),
        lambda arr: np.array([jnp.linalg.qr(e, mode="r") for e in arr]),
        lambda arr: np.array(qr_vmap(arr)),
    ],
    labels=["np vectorized", "np loop", "jax loop", "jax vectorized"],
    n_range=np.linspace(10,2000,20),
    xlabel="matrix shape(16,2992,x)",
)
```

Tests are done on Ubuntu 24.04, Ryzen 5 5600X, 32GB RAM, RTX3070 (8GB)

Result with jax[cpu]:
![cpu_2000](https://github.com/user-attachments/assets/0e8e3740-a8dc-46c3-a62c-c6694315eec9)

Bascally no difference

Result with jax[cuda12]:
![gpu_2000](https://github.com/user-attachments/assets/36ade79d-1133-4586-aa7d-9015da23aaa3)

Estimated ~30% ..  50% gain on GPU.