### PR TITLE
Version v1.5.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-rf" %}
-{% set version = "1.4.1" %}
+{% set version = "1.5.0" %}
 {% set hash_val = "8223204281599ba14b685d7e28b7e361" %}
 
 package:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,8 @@ select = ["B", "E", "F", "FA", "I", "NPY", "UP", "W"]
 
 # Ignore some rules for all files
 # E741: ambiguous-variable-name
-ignore = ["E741"]
+# UP031: Use format specifiers instead of percent format
+ignore = ["E741", "UP031"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore some rules for some specific files

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python.
 """
 
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 ## Import all  module names for coherent reference of name-space
 #import io
 


### PR DESCRIPTION
## What's Changed
* Use trapezoid rule from scipy by @FranzForstmayr in https://github.com/scikit-rf/scikit-rf/pull/1200
* Use RLGC distortion model and nominal impedance in DefinedAEpTandZ0 media by @mhuser in https://github.com/scikit-rf/scikit-rf/pull/1202
* Modify the input arguments order in plot_s_db_time method. by @Asachoo in https://github.com/scikit-rf/scikit-rf/pull/1201
* definedAEpTandZ0 keep z0 parameter as raw characteristic impedance if array-llike by @mhuser in https://github.com/scikit-rf/scikit-rf/pull/1203
* line_floating S-parameter definition by @Ttl in https://github.com/scikit-rf/scikit-rf/pull/1207
* Fix uninitialized memory use in touchstone parser by @Ttl in https://github.com/scikit-rf/scikit-rf/pull/1208
* Use s-parameter to build lumped components. by @Asachoo in https://github.com/scikit-rf/scikit-rf/pull/1206
* New circuit synthesizer write_spice_subcircuit_s_new() reduces node a… by @fnordpole in https://github.com/scikit-rf/scikit-rf/pull/1198
* Bugfix to avoid instance name collisions. Bug occurs for networks wi by @fnordpole in https://github.com/scikit-rf/scikit-rf/pull/1209
* Fixed another bug of similar type that only occurs for number of port  by @fnordpole in https://github.com/scikit-rf/scikit-rf/pull/1210
* Allow pass network name as kwarg for streams by @FranzForstmayr in https://github.com/scikit-rf/scikit-rf/pull/1212
* Fix the issue in parse csv frequency. by @Asachoo in https://github.com/scikit-rf/scikit-rf/pull/1193

## New Contributors
* @fnordpole made their first contribution in https://github.com/scikit-rf/scikit-rf/pull/1198

**Full Changelog**: https://github.com/scikit-rf/scikit-rf/compare/v1.4.1...v1.5.0