### PR TITLE
extrapolate_to_dc: prevent phase aliasing between DC and first non-interpolated point

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3090,11 +3090,11 @@ class Network:
             interp_rad = interp1d(f, rad, axis=0, fill_value='extrapolate')
             interp_mag = interp1d(f, mag, axis=0, fill_value='extrapolate')
             dc_sparam = interp_mag(0) * np.exp(1j * interp_rad(0))
-            
             # Extrapolate other points and insert
-            fstep = self.frequency.f[1] - self.frequency.f[0]
-            extrapolated_f = Frequency(fstep, result.frequency.f[0]-fstep, int(round(self.frequency.f[0]/fstep)))
-            for freq in extrapolated_f.f:
+            fstep = self.frequency.f[-1]/(points-1);
+            len_interp = points - len(self);
+            extrapolated_f = Frequency(fstep, (len_interp-1) * fstep, len_interp-1)
+            for freq in reversed(extrapolated_f.f):
                 interp_sparam = interp_mag(freq) * np.exp(1j * interp_rad(freq))
                 result.s = np.insert(result.s, 0, interp_sparam, axis=0)
                 result.frequency._f = np.insert(result.frequency.f, 0, freq)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3090,6 +3090,15 @@ class Network:
             interp_rad = interp1d(f, rad, axis=0, fill_value='extrapolate')
             interp_mag = interp1d(f, mag, axis=0, fill_value='extrapolate')
             dc_sparam = interp_mag(0) * np.exp(1j * interp_rad(0))
+            
+            # Extrapolate other points and insert
+            fstep = self.frequency.f[1] - self.frequency.f[0]
+            extrapolated_f = Frequency(fstep, result.frequency.f[0]-fstep, int(round(self.frequency.f[0]/fstep)))
+            for freq in extrapolated_f.f:
+                interp_sparam = interp_mag(freq) * np.exp(1j * interp_rad(freq))
+                result.s = np.insert(result.s, 0, interp_sparam, axis=0)
+                result.frequency._f = np.insert(result.frequency.f, 0, freq)
+                result.z0 = np.insert(result.z0, 0, result.z0[0], axis=0)
         else:
             #Make numpy array if argument was list
             dc_sparam = np.array(dc_sparam)

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3091,14 +3091,15 @@ class Network:
             interp_mag = interp1d(f, mag, axis=0, fill_value='extrapolate')
             dc_sparam = interp_mag(0) * np.exp(1j * interp_rad(0))
             # Extrapolate other points and insert
-            fstep = self.frequency.f[-1]/(points-1);
-            len_interp = points - len(self);
-            extrapolated_f = Frequency(fstep, (len_interp-1) * fstep, len_interp-1)
-            for freq in reversed(extrapolated_f.f):
-                interp_sparam = interp_mag(freq) * np.exp(1j * interp_rad(freq))
-                result.s = np.insert(result.s, 0, interp_sparam, axis=0)
-                result.frequency._f = np.insert(result.frequency.f, 0, freq)
-                result.z0 = np.insert(result.z0, 0, result.z0[0], axis=0)
+            fstep = self.frequency.f[-1]/(points-1)
+            if self.frequency.f[0] >= 2*fstep:
+                len_interp = points - len(self)
+                extrapolated_f = Frequency(fstep, (len_interp-1) * fstep, len_interp-1, unit="Hz")
+                for freq in reversed(extrapolated_f.f):
+                    interp_sparam = interp_mag(freq) * np.exp(1j * interp_rad(freq))
+                    result.s = np.insert(result.s, 0, interp_sparam, axis=0)
+                    result.frequency._f = np.insert(result.frequency.f, 0, freq)
+                    result.z0 = np.insert(result.z0, 0, result.z0[0], axis=0)
         else:
             #Make numpy array if argument was list
             dc_sparam = np.array(dc_sparam)


### PR DESCRIPTION
First PR on this project, please let me know if I did anything wrong.

## The issue

[network.extrapolate_to_dc](https://github.com/scikit-rf/scikit-rf/blob/b4d423642880c2a98b0fcad6627a1c863f766453/skrf/network.py#L3027) does not work when there is a phase wrap between the extrapolated DC point and the first non-interpolated point.

### Example
Create a simple transmission line and a network starting at a high enough frequency:
```python
import skrf as rf
import matplotlib.pyplot as plt

freq = rf.Frequency(0.7, 3.0, 201, 'GHz')
Z_0 = 50  # Ohm
Z_L = 50  # Ohm
d =0.5  # m
VF = 0.67
att = 0.02 # Np/m. Equivalent to 0.1737 dB/m

alpha = att  # Np/m !
beta = freq.w/rf.c/VF
gamma = alpha + 1j*beta

coax_line = rf.media.DefinedGammaZ0(frequency=freq, z0=Z_0, gamma=gamma)
ntw = coax_line.line(d, unit='m')
```
Plotting the phase of S21 looks as expected:
```python
ntw.s21.plot_s_deg(label='original')
```
![image](https://github.com/user-attachments/assets/2f355228-6d7b-46d4-9841-b65c5c92017a)

Now we extrapolate to DC and plot that as well:
```python
extrapolated = ntw.extrapolate_to_dc(kind='linear')
extrapolated.s21.plot_s_deg(label='interpolated')
```
![image](https://github.com/user-attachments/assets/f319173c-dff6-4bf9-a209-7e5a46e8aabb)

That is of course wrong. The phase should continue to rotate linearly with decreasing frequencies, wrap around twice more and then reach the DC point.

## Why does this happen?

No DC point was given to extrapolate_to_dc, so it has to extrapolate that by itself. This is done by taking the first two S parameter points and extrapolating them to DC: https://github.com/scikit-rf/scikit-rf/blob/b4d423642880c2a98b0fcad6627a1c863f766453/skrf/network.py#L3082-L3092

This results in a valid DC point. But we need additional points between DC and the first S parameter point at 700 MHz. This is done by this line at the end of the function: https://github.com/scikit-rf/scikit-rf/blob/b4d423642880c2a98b0fcad6627a1c863f766453/skrf/network.py#L3111

And this function has no concept of phase wrapping. It will try its best to interpolate between points but even for other kinds than `linear` interpolation, it can not handle the phase wrap.

## Proposed solution

When a DC point needs to be extrapolated, also extrapolate the other points from DC to the start frequency of the non-interpolated network with the same frequency spacing. Interpolating with `interpolate_self` is still necessary (if the first frequency is not a multiple of the frequency step) but now this function has equal spacing in frequency in that frequency range as well and does not miss phase wraps anymore:
![image](https://github.com/user-attachments/assets/6887bfdb-9dd0-4f48-964e-00b6576a6642)
