### PR TITLE
Fix the issue of the 'Network.inv' due to mismatched port impedance.

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1413,6 +1413,10 @@ class Network:
             raise (TypeError('One-Port Networks don\'t have inverses'))
         out = self.copy()
         out.s = inv(self.s)
+        # flip the port impedances, nports is even guaranteed by inv() method
+        port_pairs: int = self.nports // 2
+        out.z0[:, :port_pairs] = self.z0[:, port_pairs:]
+        out.z0[:, port_pairs:] = self.z0[:, :port_pairs]
         out.deembed = True
         return out
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -997,10 +997,12 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(self.Fix.inv ** self.Meas ** self.Fix.flipped().inv,
                          self.DUT)
 
-        # Test for mismatched ports
+    def test_de_embed_port_impedance(self):
         ntw = self.ntwk1.copy()
         ntw.renormalize((25, 75))
-        rst = ntw.inv ** self.ntwk3
+        ntw_inv = ntw.inv
+        self.assertTrue(np.allclose(ntw_inv.z0, (75, 25)))
+        rst = ntw_inv ** self.ntwk3
         rst.renormalize(50)
         self.assertEqual(rst, self.ntwk2)
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -997,6 +997,13 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(self.Fix.inv ** self.Meas ** self.Fix.flipped().inv,
                          self.DUT)
 
+        # Test for mismatched ports
+        ntw = self.ntwk1.copy()
+        ntw.renormalize((25, 75))
+        rst = ntw.inv ** self.ntwk3
+        rst.renormalize(50)
+        self.assertEqual(rst, self.ntwk2)
+
     @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_one_port_db(self):
         self.ntwk1.plot_s_db(0,0)


### PR DESCRIPTION
The following shows this problem and its solution:
```bash
Python 3.13.0 (main, Oct 16 2024, 03:23:02) [Clang 18.1.8 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> import skrf as rf
>>> 
>>> # create a Mismatched Network S-Parameters
>>> rng = np.random.default_rng(1337)
>>> ntw_s = np.zeros((1, 2, 2), dtype=complex)
>>> ntw_s += rng.random((1, 2, 2)) * 2 - 1.0
>>> ntw_s += 1.0j * (rng.random((1, 2, 2)) * 2 - 1.0)
>>> 
>>> # create a Mismatched Network
>>> ntw = rf.Network(frequency=1, s=ntw_s, z0=(25, 75), name="Random Network")
>>> ntw_inv = ntw.inv
>>> ntw_inv
2-Port Network: 'Random Network',  1.0-1.0 Hz, 1 pts, z0=[25.+0.j 75.+0.j]
>>> 
>>> # Cascaded with its inverse Network, the resulting port impedance and s-parameters are incorrect
>>> rst = ntw**ntw_inv
>>> rst
2-Port Network: 'Random Network',  1.0-1.0 Hz, 1 pts, z0=[25.+0.j 75.+0.j]
>>> rst.s
array([[[ 0.96298832+0.54153582j,  0.53422415+0.17891377j],
        [ 0.53422415+0.17891377j, -0.08300245-0.18388047j]]])
>>> 
>>> # Flipped the port impedance, the resulting port impedance and s-parameters have been corrected
>>> ntw_inv.z0 = (75, 25)
>>> rst = ntw**ntw_inv
>>> rst
2-Port Network: 'Random Network',  1.0-1.0 Hz, 1 pts, z0=[25.+0.j 25.+0.j]
>>> rst.s
array([[[-1.11022302e-16-6.66133815e-16j, 1.00000000e+00+1.37885387e-16j],
        [ 1.00000000e+00+2.70230630e-16j, -5.55111512e-17-1.11022302e-16j]]])
>>> 
```