### PR TITLE
VectorFitting: New SPICE netlist topology

### DIFF
--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -2,14 +2,10 @@ import os
 import sys
 import tempfile
 import unittest
-from contextlib import suppress
 from pathlib import Path
 
 import numpy as np
 import pytest
-
-with suppress(ImportError):
-    from PySpice.Spice.Parser import SpiceParser
 
 import skrf
 

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -77,32 +77,6 @@ class VectorFittingTestCase(unittest.TestCase):
         # quality of the fit is not important in this test; it only needs to finish
         self.assertLess(vf.get_rms_error(), 0.2)
 
-    @pytest.mark.skipif(
-        "PySpice" not in sys.modules,
-        reason="test_spice_subcircuit uses PySpice parser but it is not available.")
-    def test_spice_subcircuit(self):
-        # fit ring slot example network
-        nw = skrf.data.ring_slot
-        vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_constant=True, fit_proportional=True)
-
-        # write equivalent SPICE subcircuit to tmp file
-        tmp_file = tempfile.NamedTemporaryFile(suffix='.sp', delete=False)
-        name = tmp_file.name
-        tmp_file.close()
-        vf.write_spice_subcircuit_s(name)
-
-        parser = SpiceParser(name)
-
-        # Number of elements on global level
-        assert len(parser.subcircuits[0]._statements) == 38
-        # Number of elements in RLCG subckt
-        assert len(parser.subcircuits[1]._statements) == 4
-        # Number of elements in RL subckt
-        assert len(parser.subcircuits[2]._statements) == 2
-
-        os.remove(name)
-
     def test_read_write_npz(self):
         # fit ring slot example network
         nw = skrf.data.ring_slot

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2447,7 +2447,7 @@ class VectorFitting:
 
             f.write(f'.ENDS {fitted_model_name}\n\n')
 
-            # Subcircuit for an LCRR equivalent impedance of a complex-conjugate pole-residue pair
+            # Subcircuit for an RCL equivalent impedance of a complex-conjugate pole-residue pair
             f.write('.SUBCKT rcl_active n_pos n_neg cap=1e-9 ind=100e-12 res1=1e3 res2=1e3 gt1=2e-3 gt2=2e-3\n')
             f.write('L1 n_pos 1 {ind}\n')
             f.write('R1 1 n_neg {res1}\n')
@@ -2458,7 +2458,7 @@ class VectorFitting:
             f.write('.ENDS rcl_active\n\n')
 
             # Subcircuit for an RC equivalent impedance of a real pole-residue pair
-            f.write('.SUBCKT rc n_pos n_neg res=1e3 cap=1e-9\n')
+            f.write('.SUBCKT rc_passive n_pos n_neg res=1e3 cap=1e-9\n')
             f.write('C1 n_pos n_neg {cap}\n')
             f.write('R1 n_pos n_neg {res}\n')
-            f.write('.ENDS rc\n\n')
+            f.write('.ENDS rc_passive\n\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2351,7 +2351,8 @@ class VectorFitting:
                 f.write(f'R{i + 1} s{i + 1} {ref_node} {z0_i}\n')
 
                 # total node count in the series connections for transfer networks
-                n_nodes_total = self.network.nports * (len(np.nonzero([self.constant_coeff[0], self.proportional_coeff[0]])[0]) + len(self.poles))
+                n_nodes_total = self.network.nports * (
+                        len(np.nonzero([self.constant_coeff[0], self.proportional_coeff[0]])[0]) + len(self.poles))
 
                 if n_nodes_total == 0:
                     break
@@ -2400,9 +2401,11 @@ class VectorFitting:
                     if d != 0.0:
                         # transfer to port j with correct polarity
                         if d < 0:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} {gain_vccs_b_j}\n')
+                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} '
+                                    f'{gain_vccs_b_j}\n')
                         else:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} {gain_vccs_b_j}\n')
+                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} '
+                                    f'{gain_vccs_b_j}\n')
 
                         # R = |d|
                         f.write(f'R{j + 1}_{i + 1} {node_pos} {node_neg} {np.abs(d)}\n')
@@ -2420,9 +2423,11 @@ class VectorFitting:
                     if e != 0.0:
                         # transfer to port j with correct polarity
                         if e < 0:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} {gain_vccs_b_j}\n')
+                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} '
+                                    f'{gain_vccs_b_j}\n')
                         else:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} {gain_vccs_b_j}\n')
+                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} '
+                                    f'{gain_vccs_b_j}\n')
 
                         # L = |e|
                         f.write(f'L{j + 1}_{i + 1} {node_pos} {node_neg} {np.abs(e)}\n')
@@ -2447,10 +2452,12 @@ class VectorFitting:
                             # This gets compensated by inverting the transfer voltage direction for this subcircuit
                             residue = -1 * residue
                             f.write(
-                                f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} {gain_vccs_b_j}\n')
+                                f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_neg} {node_pos} '
+                                f'{gain_vccs_b_j}\n')
                         else:
                             f.write(
-                                f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} {gain_vccs_b_j}\n')
+                                f'Gb{j + 1}_{i + 1}_{n_current} {ref_node} s{j + 1} {node_pos} {node_neg} '
+                                f'{gain_vccs_b_j}\n')
 
                         # impedance representing S_j_i_k
                         if np.imag(pole) == 0.0:

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2257,10 +2257,10 @@ class VectorFitting:
         return ax
 
     def write_spice_subcircuit_s(self, file: str, fitted_model_name: str = "s_equivalent",
-                                     create_reference_pins: bool=False) -> None:
+                                     create_reference_pins: bool = False) -> None:
         """
         Creates an equivalent N-port subcircuit based on its vector fitted S parameter responses
-        in spice simulator netlist syntax
+        in spice simulator netlist syntax (compatible with ngspice, Xyce, ...).
 
         Parameters
         ----------
@@ -2268,14 +2268,14 @@ class VectorFitting:
             Path and filename including file extension (usually .sNp) for the subcircuit file.
 
         fitted_model_name: str
-            Name of the resulting model, default "s_equivalent"
+            Name of the resulting subcircuit, default "s_equivalent"
 
         create_reference_pins: bool
             If set to True, the synthesized subcircuit will have N pin-pairs:
-            P0, P0_ref, ..., PN, PN_ref
+            p1 p1_ref p2 p2_ref ... pN pN_ref
 
             If set to False, the synthesized subcircuit will have N pins
-            P0, ..., PN
+            p1 p2 ... pN
             In this case, the reference nodes will be internally connected
             to the global ground net 0.
 
@@ -2291,7 +2291,7 @@ class VectorFitting:
 
         >>> nw_3port = skrf.Network('my3port.s3p')
         >>> vf = skrf.VectorFitting(nw_3port)
-        >>> vf.vector_fit(n_poles_real=1, n_poles_cmplx=4)
+        >>> vf.auto_fit()
         >>> vf.write_spice_subcircuit_s('/my3port_model.sp')
 
         References

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2310,13 +2310,6 @@ class VectorFitting:
 
         """
 
-        subcircuits = []
-
-        def get_new_subckt_identifier():
-            # Provides a unique subcircuit identifier (X1, X2, X3, ...)
-            subcircuits.append(f'X{len(subcircuits) + 1}')
-            return subcircuits[-1]
-
         with open(file, 'w') as f:
             # write title line
             f.write('* EQUIVALENT CIRCUIT FOR VECTOR FITTED S-MATRIX\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2447,24 +2447,18 @@ class VectorFitting:
 
             f.write(f'.ENDS {fitted_model_name}\n\n')
 
-            # Subcircuit for an LCRR equivalent admittance of a complex-conjugate pole-residue pair
-            f.write('.SUBCKT lcrr_admittance n_pos n_neg ind=100e-12 cap=1e-9 res1=1e3 res2=1e3\n')
+            # Subcircuit for an LCRR equivalent impedance of a complex-conjugate pole-residue pair
+            f.write('.SUBCKT rcl_active n_pos n_neg cap=1e-9 ind=100e-12 res1=1e3 res2=1e3 gt1=2e-3 gt2=2e-3\n')
             f.write('L1 n_pos 1 {ind}\n')
-            f.write('R1 1 2 {res1}\n')
-            f.write('C1 2 n_neg {cap}\n')
-            f.write('R2 2 n_neg {res2}\n')
-            f.write('.ENDS lcrr_admittance\n\n')
+            f.write('R1 1 n_neg {res1}\n')
+            f.write('G1 n_neg 1 1 n_neg {gt1}\n')
+            f.write('C1 n_pos n_neg {cap}\n')
+            f.write('R2 n_pos n_neg {res2}\n')
+            f.write('G2 n_neg n_pos n_pos n_neg {gt2}\n')
+            f.write('.ENDS rcl_active\n\n')
 
-            # Subcircuit for an RLCG equivalent admittance of a complex-conjugate pole-residue pair
-            f.write('.SUBCKT rcl_vccs_admittance n_pos n_neg res=1e3 cap=1e-9 ind=100e-12 gm=1e-3\n')
-            f.write('L1 n_pos 1 {ind}\n')
-            f.write('C1 1 2 {cap}\n')
-            f.write('R1 2 n_neg {res}\n')
-            f.write('G1 n_pos n_neg 1 2 {gm}\n')
-            f.write('.ENDS rcl_vccs_admittance\n\n')
-
-            # Subcircuit for an RL equivalent admittance of a real pole-residue pair
-            f.write('.SUBCKT rl_admittance n_pos n_neg res=1e3 ind=100e-12\n')
-            f.write('L1 n_pos 1 {ind}\n')
-            f.write('R1 1 n_neg {res}\n')
-            f.write('.ENDS rl_admittance\n\n')
+            # Subcircuit for an RC equivalent impedance of a real pole-residue pair
+            f.write('.SUBCKT rc n_pos n_neg res=1e3 cap=1e-9\n')
+            f.write('C1 n_pos n_neg {cap}\n')
+            f.write('R1 n_pos n_neg {res}\n')
+            f.write('.ENDS rc\n\n')


### PR DESCRIPTION
A different circuit topology for the equivalent netlists of vector-fitted scattering responses enables massive improvements in the simulation runtime. This is at least true for circuit simulators using modified nodal analysis, such as ngspice and Xyce. See discussion https://github.com/scikit-rf/scikit-rf/discussions/1225.

I tested three different pole configurations with two different networks and compared the simulation time in _ngspice_ with the current admittance-based topology (master branch) and with the new impedance-based topology (this PR).

Both approaches provide accurate results, at least for SP simulations in ngspice, but differences in runtime are huge!

Example: `scikit-rf/doc/source/examples/vectorfitting/190ghz_tx_measured.S2P`
- Vector fit with model order 15
- Simulation time with admittance-based topology (master branch): **0.051 s**
- Simulation time with impedance-based topology (this PR): **0.028 s**

Example: `4port.s4p` (reduced fit)
- Vector fit with model order 105
- Simulation time with admittance-based topology (master branch): **257.759 s**
- Simulation time with impedance-based topology (this PR): **0.179 s**

Example: `4port.s4p` (full fit)
- Vector fit with model order 317
- Simulation time with admittance-based topology (master branch): **>> 15 minutes** (cancelled because of impatience)
- Simulation time with impedance-based topology (this PR): **0.819 s**