### PR TITLE
New features in vectorFitting: Weighting, Multi-SISO and MIMO fitting

### DIFF
--- a/doc/source/examples/vectorfitting/vectorfitting_ex1_ringslot.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex1_ringslot.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)"
+    "vf.vector_fit(n_poles_init=3, poles_init_type='real')"
    ]
   },
   {
@@ -145,8 +145,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -159,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/vectorfitting/vectorfitting_ex2_190ghz_active.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex2_190ghz_active.ipynb
@@ -67,17 +67,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f'model order = {vf.get_model_order(vf.poles)}')\n",
-    "print(f'n_poles_real = {np.sum(vf.poles.imag == 0.0)}')\n",
-    "print(f'n_poles_complex = {np.sum(vf.poles.imag > 0.0)}')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -121,12 +110,19 @@
     "freqs = np.linspace(0, 500e9, 501) # plot model response from dc to 500 GHz\n",
     "vf.plot_s_db(freqs=freqs)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -139,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.7"
   },
   "nbsphinx": {
    "timeout": 360

--- a/doc/source/examples/vectorfitting/vectorfitting_ex3_Agilent_E5071B.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex3_Agilent_E5071B.ipynb
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After trying different numbers of real and complex-conjugate poles, the following setup was found to result in a very good fit. The initial model order is $1 + 2 * 26 = 53$, which will remain unchanged during the fitting process. Other setups were also found to work well for this network (e.g. 0-2 real poles and 25-26 cc poles):"
+    "After trying different numbers and types of poles, the following setup was found to result in a very good fit. The initial model order is $2 * 27 = 54$, which will remain unchanged during the fitting process"
    ]
   },
   {
@@ -94,16 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=1, n_poles_cmplx=26)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f'model order = {vf.get_model_order(vf.poles)}')"
+    "vf.vector_fit(n_poles_init=27, poles_init_type='complex')"
    ]
   },
   {
@@ -126,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The fitted model parameters are now stored in the class attributes `poles`, `residues`, `proportional_coeff` and `constant_coeff` for further use. To verify the result, the fitted model responses can be compared to the original network responses. As the model will return a response at any given frequency, it makes sense to also check its response outside the frequency range of the original samples. In this case, the original network was measured from 0.5 GHz to 4.5 GHz, so we can plot the fit from dc to 10 GHz:"
+    "The fitted model parameters are now stored in the class attributes `poles`, `residues`, `proportional` and `constant` for further use. To verify the result, the fitted model responses can be compared to the original network responses. As the model will return a response at any given frequency, it makes sense to also check its response outside the frequency range of the original samples. In this case, the original network was measured from 0.5 GHz to 4.5 GHz, so we can plot the fit from dc to 10 GHz:"
    ]
   },
   {
@@ -205,17 +196,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'model order = {vf.get_model_order(vf.poles)}')\n",
-    "print(f'n_poles_real = {np.sum(vf.poles.imag == 0.0)}')\n",
-    "print(f'n_poles_complex = {np.sum(vf.poles.imag > 0.0)}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "print(f'rms error = {vf.get_rms_error()}')"
    ]
   },
@@ -235,12 +215,19 @@
     "fig.tight_layout()\n",
     "mplt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -253,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.7"
   },
   "nbsphinx": {
    "timeout": 240

--- a/doc/source/examples/vectorfitting/vectorfitting_ex4_passivity.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex4_passivity.ipynb
@@ -22,7 +22,7 @@
     "# load and fit the ring slot network with 3 poles\n",
     "nw = skrf.data.ring_slot\n",
     "vf = skrf.VectorFitting(nw)\n",
-    "vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)\n",
+    "vf.vector_fit(n_poles_init=3, poles_init_type='real')\n",
     "\n",
     "# plot fitting results\n",
     "freqs = np.linspace(0, 200e9, 201)\n",
@@ -230,8 +230,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -244,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/vectorfitting/vectorfitting_ex5_weighting.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex5_weighting.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ex5: Weighting\n",
+    "This example demonstrates how weighting can be used to balance the fit accuracy between large and small magnitudes of the response.\n",
+    "\n",
+    "Because the vector fitting algorithm uses a least squares fit, large values in the responses contribute more to the least squares error than small values, thus giving them by default more weight.\n",
+    "\n",
+    "But sometimes we are interested to accurately fit very small magnitudes of a response very accurately, for example when analyzing the cross-talk or isolation between certain ports of a network.\n",
+    "\n",
+    "In this case, we can weight every sample by multiplying it with its inverse magnitude in the least squares fit and so we will get the same relative accuracy for large and small values. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as mplt\n",
+    "import numpy as np\n",
+    "\n",
+    "import skrf\n",
+    "\n",
+    "nw = skrf.network.Network('./190ghz_tx_measured.S2P')\n",
+    "vf = skrf.VectorFitting(nw)\n",
+    "vf.auto_fit(verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then plot the fitted responsse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freqs = np.linspace(np.min(vf.network.f), np.max(vf.network.f), 201)\n",
+    "n_ports=vf._get_n_ports()\n",
+    "fig, ax = mplt.subplots(n_ports, n_ports)\n",
+    "fig.set_size_inches(12, 8)\n",
+    "for i in range(n_ports):\n",
+    "    for j in range(n_ports):\n",
+    "        vf.plot_s_db(i, j, freqs=freqs, ax=ax[i][j])\n",
+    "fig.tight_layout()\n",
+    "mplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can already see that the response i=0, j=1 shows a deviation to the data of around 10 dB at 1.6 GHz and the deep notch in the data that goes down to -90 dB is actually only a notch down to -65 dB, so we miss the notch by 25 dB!\n",
+    "\n",
+    "We can also see that the relative error for response 0, 1 is the heighest.\n",
+    "\n",
+    "Now we run a new fit with inverse_magnited weighting to improve this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vf.auto_fit(weighting='inverse_magnitude', verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can already see that the total relative error decreased a lot compared to the non-weigthed fit and also the relative error for response 0, 1 is now about half.\n",
+    "If we now plot the responses, we can see the difference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freqs = np.linspace(np.min(vf.network.f), np.max(vf.network.f), 201)\n",
+    "n_ports=vf._get_n_ports()\n",
+    "fig, ax = mplt.subplots(n_ports, n_ports)\n",
+    "fig.set_size_inches(12, 8)\n",
+    "for i in range(n_ports):\n",
+    "    for j in range(n_ports):\n",
+    "        vf.plot_s_db(i, j, freqs=freqs, ax=ax[i][j])\n",
+    "fig.tight_layout()\n",
+    "mplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can observe from the plot that the strong deviations in response 0, 1 around 1.6 GHz is now gone completely and the -90 dB notch is exactly represented by the model.\n",
+    "\n",
+    "We can also observe in the response 1,1 that the fit deviates a bit more than in the non-weigthed fit from the data around 1.4 GHz. This is normal and comes because we gave more weight to the small values. The least squares fit will sacrifice a bit of the accuracy in the large magnitudes in favor of the accuracy in the small magnitudes. \n",
+    "\n",
+    "This effect of decreased accuracy in large magnitudes in favor of better accuracy for lower magnitudes is actually a trade off, that can be adjusted with a parameter called weighting_accuracy_db. This parameter limits the magnitude weighting to a certain level, for example -40 dB. Every magnitude below this level is not weighted by more than the limit. \n",
+    "\n",
+    "This is very useful because, for example, we might not actually be interested in fitting the -90 dB notch exactly, but still we might be interested in fitting very exact down to about -40 dB. If we specify this as a parameter, we will get good accuracy down to -40 dB without sacrificing more than neccesary of the accuracy for the large values!\n",
+    "\n",
+    "Let's try this and see what we can get:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vf.auto_fit(weighting='inverse_magnitude', weighting_accuracy_db=-40, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now the relative error of the response 0, 1 went up again, which is expected, but let's see how it looks in the plots:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freqs = np.linspace(np.min(vf.network.f), np.max(vf.network.f), 201)\n",
+    "n_ports=vf._get_n_ports()\n",
+    "fig, ax = mplt.subplots(n_ports, n_ports)\n",
+    "fig.set_size_inches(12, 8)\n",
+    "for i in range(n_ports):\n",
+    "    for j in range(n_ports):\n",
+    "        vf.plot_s_db(i, j, freqs=freqs, ax=ax[i][j])\n",
+    "fig.tight_layout()\n",
+    "mplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now see that we could maintain the good fit around 1.6 GHz in the -55 dB range, but we lost (as expected) the perfect match of the -90 dB notch. But the good thing is that we also got back our good fit for the response 1, 1!\n",
+    "\n",
+    "Thus, the specification of the weighting_accuracy_db parameter is very important and it should not be set much lower than necessary to achieve the desired accuracy down to a certain magnitude.\n",
+    "\n",
+    "Setting weighted_accuracy_db=0 is thus equivalent to non-weighted vector fitting.\n",
+    "\n",
+    "It is also possible to set weighting='uniform', which will weight all samples with 1, thus, not weighting them at all. This is also equivalent to the non-weighted vector fitting. In the future, other weighting schemes can easily be implemented if desired.\n",
+    "\n",
+    "Moreover, the weights can directly be providid as an argument and thus, arbitrary user defined weights can be used. Details on this can be found in the documentation of the arguments of auto_fit()."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/source/examples/vectorfitting/vectorfitting_ex6_shared_poles.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_ex6_shared_poles.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ex5: Pole sharing\n",
+    "In vanilla vector fitting, all responses share a common set of poles. In the literature, this case is called MIMO fitting.\n",
+    "\n",
+    "There are applications in which this can lead to problems and it is desirable to use a separate pole set for each response. In the literature, this is called Multi-SISO fitting.\n",
+    "\n",
+    "It is also possible to go anywhere between those two extreme cases, for example by using a common set of poles for every input j, for example: S1j, S2j, S3j, ... will share one set of poles for every value of the input j. We thus have one pole set per input, which is used for the transfer of this input j to all outputs j=1, 2, 3, ... This is why in the literature this approach is called Multi-SIMO fitting.\n",
+    "\n",
+    "In general, arbitrary combinations of inputs and outputs can be grouped to use a separate set of poles per group.\n",
+    "\n",
+    "Right now in vectorFitting, MIMO and multi-SISO is implemented and multi-SIMO is in the work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following example shows how to do a MIMO fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as mplt\n",
+    "import numpy as np\n",
+    "\n",
+    "import skrf\n",
+    "\n",
+    "nw = skrf.network.Network('./190ghz_tx_measured.S2P')\n",
+    "vf = skrf.VectorFitting(nw)\n",
+    "vf.vector_fit(n_poles_init=16, poles_init_type = 'real', pole_sharing='MIMO', verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then plot the fitted responses:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freqs = np.linspace(np.min(vf.network.f), np.max(vf.network.f), 201)\n",
+    "n_ports=vf._get_n_ports()\n",
+    "fig, ax = mplt.subplots(n_ports, n_ports)\n",
+    "fig.set_size_inches(12, 8)\n",
+    "for i in range(n_ports):\n",
+    "    for j in range(n_ports):\n",
+    "        vf.plot_s_db(i, j, freqs=freqs, ax=ax[i][j])\n",
+    "fig.tight_layout()\n",
+    "mplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we run the fit as a Multi-SISO fit with the same overall model order (16), thus every response gets a model order of 4:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vf.vector_fit(n_poles_init=4, poles_init_type = 'real', pole_sharing='Multi-SISO', verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As can be observed from the model summary, both the total absolute and relative errors are worse than in the MIMO fit with the same overall model order. Thus, it is not beneficial to use Multi-SISO for this example data because there are probably shared poles in the system that we are now treating as separate, which is not optimal.\n",
+    "\n",
+    "Note that this example data is just used to demonstrate the process. If Multi-SISO fitting is advantageous or not depends on your data.\n",
+    "\n",
+    "We can now plot the responses:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freqs = np.linspace(np.min(vf.network.f), np.max(vf.network.f), 201)\n",
+    "n_ports=vf._get_n_ports()\n",
+    "fig, ax = mplt.subplots(n_ports, n_ports)\n",
+    "fig.set_size_inches(12, 8)\n",
+    "for i in range(n_ports):\n",
+    "    for j in range(n_ports):\n",
+    "        vf.plot_s_db(i, j, freqs=freqs, ax=ax[i][j])\n",
+    "fig.tight_layout()\n",
+    "mplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Multi-SIMO is not yet implemented in vectorFitting. Once it is implemented, this example will be extended to show how it works."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/source/examples/vectorfitting/vectorfitting_problems.ipynb
+++ b/doc/source/examples/vectorfitting/vectorfitting_problems.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=3, n_poles_cmplx=1)"
+    "vf.vector_fit(n_poles_init=5, poles_init_type='real')"
    ]
   },
   {
@@ -112,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ten real poles and ten complex conjugate pairs are too much for this simple network. The unsued poles get shifted toward higher frequencies outside the measured band and still spook around during the relocation process. Due to these spurious pole, the relocation process cannot converge properly and gets stopped after reaching the maxmimum number of iterations (default is 100). Interstingly, the residue settles rather quickly within the first 20 iterations, as shown in the convergence plot.\n",
+    "Ten real poles and ten complex conjugate pairs are too much for this simple network. The unsued poles get shifted toward higher frequencies outside the measured band and still spook around during the relocation process. Due to these spurious pole, the relocation process cannot converge properly and gets stopped after reaching the maxmimum number of iterations (default is 200). Interstingly, the residue settles rather quickly within the first 20 iterations, as shown in the convergence plot.\n",
     "Still, the fitting result within the measured frequency band is very good, but the spurious out-of-band poles are clearly visible."
    ]
   },
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=10, n_poles_cmplx=10)"
+    "vf.vector_fit(n_poles_init=20, poles_init_type='complex')"
    ]
   },
   {
@@ -163,31 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "During the pole relocation process (first step in the fitting process), the starting poles are sucessively moved to frequencies where they can best match all target responses. Additionally, the type of poles can change from real to complex-conjugate: two real poles can become one complex-conjugate pole (and vise versa). As a result, there are multiple combinations of starting poles which can produce the same final set of poles. However, certain setups will converge faster than others, which also depends on the initial pole spacing. In extreme cases, the algorithm can even be \"undecided\" if two real poles behave exactly like one complex-conjugate pole and it gets \"stuck\" jumping back and forth without converging to a final solution.\n",
-    "\n",
-    "Equivalent setups for a fitting attempt with `n_poles_real=3, n_poles_cmplx=4` (i.e. 3+4):\n",
-    "\n",
-    "- 1+5\n",
-    "- **3+4**\n",
-    "- 5+3\n",
-    "- 7+2\n",
-    "- 9+1\n",
-    "- 11+0\n",
-    "\n",
-    "Equivalent setups for another fitting attempt with `n_poles_real=4, n_poles_cmplx=4` (i.e. 4+4):\n",
-    "\n",
-    "- 0+6\n",
-    "- 2+5\n",
-    "- **4+4**\n",
-    "- 6+3\n",
-    "- 8+2\n",
-    "- 10+1\n",
-    "- 12+0\n",
-    "\n",
-    "Examples for problematic setups that do not converge properly due to an oscillation between two (equally good) solutions:\n",
-    "\n",
-    "- 0+5 <--> 2+4 <--> ...\n",
-    "- 0+7 <--> 2+5 <--> ..."
+    "During the pole relocation process (first step in the fitting process), the starting poles are sucessively moved to frequencies where they can best match all target responses. Additionally, the type of poles can change from real to complex-conjugate: two real poles can become one complex-conjugate pole (and vise versa). As a result, there are multiple combinations of starting poles which can produce the same final set of poles. However, certain setups will converge faster than others, which also depends on the initial pole spacing. In extreme cases, the algorithm can even be \"undecided\" if two real poles behave exactly like one complex-conjugate pole and it gets \"stuck\" jumping back and forth without converging to a final solution."
    ]
   },
   {
@@ -196,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vf.vector_fit(n_poles_real=0, n_poles_cmplx=5)\n",
+    "vf.vector_fit(n_poles_init=5, poles_init_type='complex')\n",
     "vf.plot_convergence()"
    ]
   },
@@ -231,12 +207,19 @@
     "fig.tight_layout()\n",
     "mplt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -249,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.7"
   },
   "nbsphinx": {
    "timeout": 360

--- a/doc/source/tutorials/VectorFitting.ipynb
+++ b/doc/source/tutorials/VectorFitting.ipynb
@@ -192,8 +192,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -206,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -21,7 +21,7 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=2, n_poles_cmplx=0, fit_proportional=True, fit_constant=True)
+        vf.vector_fit(n_poles_init=2, poles_init_type='real', fit_proportional=True, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -29,7 +29,7 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, init_pole_spacing='log')
+        vf.vector_fit(n_poles_init=4, poles_init_type='real', poles_init_spacing='log')
         self.assertLess(vf.get_rms_error(), 0.01)
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -37,7 +37,7 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit without proportional term
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_proportional=False, fit_constant=False)
+        vf.vector_fit(n_poles_init=4, poles_init_type='real', fit_proportional=False, fit_constant=False)
         self.assertLess(vf.get_rms_error(), 0.01)
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -45,8 +45,8 @@ class VectorFittingTestCase(unittest.TestCase):
         # perform the fit with custom initial poles
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.poles = 2 * np.pi * np.array([-100e9, -10e9 + 100e9j])
-        vf.vector_fit(init_pole_spacing='custom')
+        poles_init = 2 * np.pi * np.array([-100e9, -10e9 + 100e9j])
+        vf.vector_fit(poles=poles_init)
         self.assertLess(vf.get_rms_error(), 0.01)
 
     def test_190ghz_measured(self):
@@ -54,26 +54,15 @@ class VectorFittingTestCase(unittest.TestCase):
         s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
         nw = skrf.network.Network(s2p_file)
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=4, fit_proportional=False, fit_constant=True)
+        vf.vector_fit(n_poles_init=8, poles_init_type='complex', fit_proportional=False, fit_constant=True)
         self.assertLess(vf.get_rms_error(), 0.02)
-
-    def test_no_convergence(self):
-        s2p_file = Path(__file__).parent.parent.parent / 'doc/source/examples/vectorfitting/190ghz_tx_measured.S2P'
-        # perform a bad fit that does not converge and check if a RuntimeWarning is given
-        nw = skrf.network.Network(s2p_file)
-        vf = skrf.vectorFitting.VectorFitting(nw)
-
-        with pytest.warns(RuntimeWarning) as record:
-            vf.vector_fit(n_poles_real=0, n_poles_cmplx=5, fit_proportional=False, fit_constant=True)
-
-        assert len(record) == 1
 
     def test_dc(self):
         # perform the fit on data including a dc sample (0 Hz)
         s4p_file = Path(__file__).parent / 'cst_example_4ports.s4p'
         nw = skrf.Network(s4p_file)
         vf = skrf.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
+        vf.vector_fit(n_poles_init=3, poles_init_type='real')
         # quality of the fit is not important in this test; it only needs to finish
         self.assertLess(vf.get_rms_error(), 0.2)
 
@@ -84,7 +73,7 @@ class VectorFittingTestCase(unittest.TestCase):
         # fit ring slot example network
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
-        vf.vector_fit(n_poles_real=4, n_poles_cmplx=0, fit_constant=True, fit_proportional=True)
+        vf.vector_fit(n_poles_init=4, poles_init_type='real', fit_constant=True, fit_proportional=True)
 
         # write equivalent SPICE subcircuit to tmp file
         tmp_file = tempfile.NamedTemporaryFile(suffix='.sp', delete=False)
@@ -108,13 +97,10 @@ class VectorFittingTestCase(unittest.TestCase):
         nw = skrf.data.ring_slot
         vf = skrf.vectorFitting.VectorFitting(nw)
 
-        with pytest.warns(UserWarning) as record:
-            vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
-
-        assert len(record) == 1
+        vf.vector_fit(n_poles_init=3, poles_init_type='real')
 
         # export (write) fitted parameters to .npz file in tmp directory
-        with  tempfile.TemporaryDirectory() as name:
+        with tempfile.TemporaryDirectory() as name:
             vf.write_npz(name)
 
             # create a new vector fitting instance and import (read) those fitted parameters
@@ -124,8 +110,8 @@ class VectorFittingTestCase(unittest.TestCase):
         # compare both sets of parameters
         self.assertTrue(np.allclose(vf.poles, vf2.poles))
         self.assertTrue(np.allclose(vf.residues, vf2.residues))
-        self.assertTrue(np.allclose(vf.proportional_coeff, vf2.proportional_coeff))
-        self.assertTrue(np.allclose(vf.constant_coeff, vf2.constant_coeff))
+        self.assertTrue(np.allclose(vf.proportional, vf2.proportional))
+        self.assertTrue(np.allclose(vf.constant, vf2.constant))
 
     @pytest.mark.skipif("matplotlib" in sys.modules, reason="Raise Error only if matplotlib is not installed.")
     def test_matplotlib_missing(self):
@@ -139,8 +125,8 @@ class VectorFittingTestCase(unittest.TestCase):
         # non-passive example parameters from Gustavsen's passivity assessment paper:
         vf.poles = np.array([-1, -5 + 6j])
         vf.residues = np.array([[0.3, 4 + 5j], [0.1, 2 + 3j], [0.1, 2 + 3j], [0.4, 3 + 4j]])
-        vf.constant_coeff = np.array([0.2, 0.1, 0.1, 0.3])
-        vf.proportional_coeff = np.array([0.0, 0.0, 0.0, 0.0])
+        vf.constant = np.array([0.2, 0.1, 0.1, 0.3])
+        vf.proportional = np.array([0.0, 0.0, 0.0, 0.0])
 
         # test if model is not passive
         violation_bands = vf.passivity_test()
@@ -157,13 +143,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf = skrf.VectorFitting(skrf.data.ring_slot)
         vf.auto_fit()
 
-        assert vf.get_model_order(vf.poles) == 6
-        assert np.sum(vf.poles.imag == 0.0) == 0
-        assert np.sum(vf.poles.imag > 0.0) == 3
-
-        assert np.allclose(vf.get_rms_error(), 1.2748979815157275e-06)
-
-
+        assert vf.get_rms_error() < 1e-3
 
 suite = unittest.TestLoader().loadTestsFromTestCase(VectorFittingTestCase)
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -7,7 +7,8 @@ from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from scipy.integrate import trapezoid
+from scipy import integrate
+from scipy.signal import find_peaks
 
 from .util import Axes, axes_kwarg
 
@@ -74,33 +75,25 @@ class VectorFitting:
         self.residues = None
         """ Instance variable holding the list of fitted residues. Will be initialized by :func:`vector_fit`. """
 
-        self.proportional_coeff = None
+        self.proportional = None
         """ Instance variable holding the list of fitted proportional coefficients. Will be initialized by
         :func:`vector_fit`. """
 
-        self.constant_coeff = None
+        self.constant = None
         """ Instance variable holding the list of fitted constants. Will be initialized by :func:`vector_fit`. """
-
-        self.max_iterations = 100
-        """ Instance variable specifying the maximum number of iterations for the fitting process and for the passivity
-        enforcement. To be changed by the user before calling :func:`vector_fit` and/or :func:`passivity_enforce`. """
-
-        self.max_tol = 1e-6
-        """ Instance variable specifying the convergence criterion in terms of relative tolerance. To be changed by the
-         user before calling :func:`vector_fit`. """
 
         self.wall_clock_time = 0
         """ Instance variable holding the wall-clock time (in seconds) consumed by the most recent fitting process with
         :func:`vector_fit`. Subsequent calls of :func:`vector_fit` will overwrite this value. """
 
-        self.d_res_history = []
-        self.delta_max_history = []
+        self.d_tilde_history = []
+        self.delta_rel_max_singular_value_A_dense_history = []
         self.history_max_sigma = []
-        self.history_cond_A = []
-        self.history_rank_deficiency = []
+        self.history_cond_A_dense = []
+        self.history_rank_deficiency_A_dense = []
 
     @staticmethod
-    def get_spurious(poles: np.ndarray, residues: np.ndarray, n_freqs: int = 101, gamma: float = 0.03) -> np.ndarray:
+    def get_spurious(poles: np.ndarray, residues: np.ndarray, spurious_pole_threshold: float = 0.03) -> np.ndarray:
         """
         Classifies fitted pole-residue pairs as spurious or not spurious. The implementation is based on the evaluation
         of band-limited energy norms (p=2) of the resonance curves of individual pole-residue pairs, as proposed in
@@ -114,11 +107,7 @@ class VectorFitting:
         residues : ndarray, shape (M, N)
             Array of fitted residues
 
-        n_freqs : int, optional
-            Number of frequencies for the evaluation. The frequency range is chosen automatically and the default
-            101 frequencies should be appropriate in most cases.
-
-        gamma : float, optional
+        spurious_pole_threshold : float, optional
             Sensitivity threshold for the classification. Typical values range from 0.01 to 0.05.
 
         Returns
@@ -133,15 +122,45 @@ class VectorFitting:
             Compatibility, vol. 48, no. 1, pp. 104-120, Feb. 2006, DOI: https://doi.org/10.1109/TEMC.2006.870814
         """
 
-        omega_eval = np.linspace(np.min(poles.imag) / 3, np.max(poles.imag) * 3, n_freqs)
-        h = (residues[:, None, :] / (1j * omega_eval[:, None] - poles)
-             + np.conj(residues[:, None, :]) / (1j * omega_eval[:, None] - np.conj(poles)))
-        norm2 = np.sqrt(trapezoid(h.real ** 2 + h.imag ** 2, omega_eval, axis=1))
-        spurious = np.all(norm2 / np.mean(norm2) < gamma, axis=0)
+        omega_poles_min=np.min(poles.imag)
+        omega_poles_max=np.max(poles.imag)
+
+        # Only complex poles are considered
+        idx_poles_complex = np.nonzero(poles.imag != 0)[0]
+
+        # Alle residues are considered
+        n_responses=np.size(residues, axis=0)
+
+        # Initialize to False for every pole
+        spurious=np.repeat(False, len(poles))
+
+        # Define function for integration
+        def H(s, r, p):
+            return np.abs(r / (1j * s - p) + np.conj(r) / (1j * s - np.conj(p)))**2
+
+        # Collects all norms
+        norm2 = np.empty((n_responses, len(idx_poles_complex)))
+
+        # Run for debug plotting
+        # import matplotlib.pyplot as plt
+        # omega_eval = np.linspace(omega_poles_min / 3, omega_poles_max * 3, 101)
+
+        for i in range(len(idx_poles_complex)):
+            for j in range(n_responses):
+                y, err = integrate.quad(H, omega_poles_min / 3, omega_poles_max*3, args=(residues[j, i], poles[i]))
+                norm2[j, i] = np.sqrt(y)
+
+                # Plot what has been integrated for debug
+                # fig, ax = plt.subplots()
+                # ax.grid()
+                # ax.plot(omega_eval, [f(s,residues[j, i], poles[i]) for s in omega_eval], linewidth=2.0)
+                # plt.show()
+
+        spurious[idx_poles_complex] = np.all(norm2 / np.mean(norm2) < spurious_pole_threshold, axis=0)
+
         return spurious
 
-    @staticmethod
-    def get_model_order(poles: np.ndarray) -> int:
+    def get_model_order(self, poles=None) -> int:
         """
         Returns the model order calculated with :math:`N_{real} + 2 N_{complex}` for a given set of poles.
 
@@ -154,29 +173,144 @@ class VectorFitting:
         -------
         order: int
         """
+
+        # Use internal poles if not provided
+        if poles is None:
+            poles = self.poles
+
         # poles.imag != 0 is True(1) for complex poles, False (0) for real poles.
         # Adding one to each element gives 2 columns for complex and 1 column for real poles.
-        return np.sum((poles.imag != 0) + 1)
+        if isinstance(poles, list):
+            model_order=0
+            for _poles in poles:
+                model_order += np.sum((_poles.imag != 0) + 1)
+        else:
+            model_order=np.sum((poles.imag != 0) + 1)
 
-    def vector_fit(self, n_poles_real: int = 2, n_poles_cmplx: int = 2, init_pole_spacing: str = 'lin',
-                   parameter_type: str = 's', fit_constant: bool = True, fit_proportional: bool = False) -> None:
+        return model_order
+
+    def vector_fit(self,
+                 # Initial poles
+                 poles = None,
+                 n_poles_init: int = None, poles_init_type: str = 'complex', poles_init_spacing: str = 'lin',
+
+                 # Weighting and fit options
+                 weights = None,
+                 weighting: str = 'uniform',
+                 weighting_accuracy_db: float = -60.0,
+
+                 # Fit constant and/or proportional term
+                 fit_constant: bool = True,
+                 fit_proportional: bool = False,
+
+                 # Share poles between responses
+                 pole_sharing: str = 'MIMO',
+
+                 # Parameters for the vector fitting algorithm
+                 max_iterations: int = 200,
+                 stagnation_threshold: float = 1e-6,
+                 abstol: float = 1e-3,
+
+                 # Memory saver
+                 memory_saver: bool = False,
+
+                 # Parametertype
+                 parameter_type: str = 's',
+
+                 # Verbose
+                 verbose = False,
+                 ) -> None:
         """
         Main work routine performing the vector fit. The results will be stored in the class variables
-        :attr:`poles`, :attr:`residues`, :attr:`proportional_coeff` and :attr:`constant_coeff`.
+        :attr:`poles`, :attr:`residues`, :attr:`proportional` and :attr:`constant`.
 
         Parameters
         ----------
-        n_poles_real : int, optional
-            Number of initial real poles. See notes.
+        poles: numpy array of initial poles (if shared_poles==True) or list of numpy arrays of initial poles (if
+        shared_poles==False), optional.
 
-        n_poles_cmplx : int, optional
-            Number of initial complex conjugate poles. See notes.
+        n_poles_init: int, optional
+            Number of poles in the initial model.
 
-        init_pole_spacing : str, optional
+        poles_init_type: str, optional
+            Type of poles in the initial model. Can be 'complex' or 'real'.
+
+        poles_init_spacing: str, optional
+            Spacing of the initial poles in the frequency range
+
             Type of initial pole spacing across the frequency interval of the S-matrix. Either *linear* (`'lin'`),
             *logarithmic* (`'log'`), or `custom`. In case of `custom`, the initial poles must be stored in :attr:`poles`
             as a NumPy array before calling this method. They will be overwritten by the final poles. The
             initialization parameters `n_poles_real` and `n_poles_cmplx` will be ignored in case of `'custom'`.
+
+        weights: numpy ndarray of size n_responses, n_freqs, optional
+            If weights are provided, these weights are used. The weights must be in the order
+            The rows must be in this order: W11, W12, W13,...W21, W22,... where Wij is the weight
+            vector used to calculate Sij * Wij.
+
+            Alternatively to providing the weights yourself, you can set thei weighting parameter
+            (and accompanying weighting_accuracy_db parameter) to have the weights created from the data.
+
+        weighting: str, optional
+            Weighting to be used for the frequency responses. The default is uniform weigthing.
+
+            'uniform': Uniform weighting: Every frequency sample has the same weight. Favors absolute accuracy.
+            Advantages: Ensures that no frequency range is prioritized over another.
+            Disadvantages: May lead to poor accuracy in regions where the frequency response magnitude is much smaller.
+
+            'inverse_magnitude': Inverse magnitude weighting: Weight is inversely proportional to the magnitude of the
+            frequency response. Weight=1/abs(f(s)). Favors relative accuracy. Advantages: Improves the relative accuracy
+            in low-magnitude regions, ensuring that small values in the response are not overshadowed by larger ones.
+            Disadvantages: May overly emphasize small-magnitude regions, leading to less accuracy in high-magnitude
+            regions or increased numerical sensitivity. Can amplify noise if the response magnitude is very small.
+
+        weighting_accuracy_db: float, optional
+            In inverse magnitude weighting, specifies a limit in dB (dB20), down to which the magnitudes are weighted.
+
+            The possible range is -inf to 0 dB. If set to 0 dB, the minimum weight is 1, which is effectively the
+            same as uniform weighting (all weights 1.0).
+
+            Example: If you set it to -20 dB, all values are weighted according to their inverse magnitude 1/abs(value),
+            but with a limit of 0.1: All values less than 0.1 are weighted with 1/0.1 but no less than that.
+
+            In summary, with this parameter the accuracy tradeoff between large and small magnitudes can be adjusted.
+
+            For example, if you want the same accuracy down to -80 dB as for larger values around 0 dB, you can set
+            weighting_accuracy_db=-80. This will fit all values down to -80 dB with the same relative accuracy as those
+            around 0 dB. Important note: It is inevitable that this will lead to a higher absolute RMS error of the
+            entire fit. This is because the fit accuracy for larger values will now be traded off against the fit
+            accuracy for small values.
+
+            For this reason it is important not to set weighting_accuracy_db lower than you actually need, because
+            otherwise you will sacrifice accuracy on the larger values for extra accuracy on very small values
+            that you may not even be interested in. Note that setting it to, for example, -40 dB, also the -80 dB
+            range values will benefit from more accuracy, but only to a certain extent limited by the -40 dB
+            weighting_accuracy_db.
+
+            The default was chosen to -60 dB because it may fit most practical applications, putting weight on values
+            down to -60 dB but also not sacrificing too much accuracy in the 0 dB range.
+
+        fit_constant: bool, optional
+            Decide whether the constant term d is fitted or not.
+
+        fit_proportional: bool, optional
+            Decide whether the proportional term e is fitted or not.
+
+        pole_sharing: bool, optional
+            Decide whether to share one common pole set for all responses or
+            use separate pole sets for each response.
+
+        max_iterations: int, optional
+            Maximum number of iterations for the fitting process.
+
+        abstol: float, optional
+            Absolute error threshold. The algorithm stops iterating once the absolute error of the fit is less than
+            abstol. Because a residue fit and a delta calculation needs to be done, this check is only done every
+            25 iterations.
+
+        stagnation_threshold: float, optional
+            The algorithm stops iterating if the relative change of the maximum absolute singular value of the system
+            matrix from one iteration to the next is less than stagnation_threshold.
 
         parameter_type : str, optional
             Representation type of the frequency responses to be fitted. Either *scattering* (`'s'` or `'S'`),
@@ -184,11 +318,9 @@ class VectorFitting:
             original S parameters. Otherwise, scikit-rf will convert the responses from S to Z or Y, which might work
             for the fit but can cause other issues.
 
-        fit_constant : bool, optional
-            Include a constant term **d** in the fit.
-
-        fit_proportional : bool, optional
-            Include a proportional term **e** in the fit.
+        memory_saver: bool, optional
+            Enables the memory saver. If enabled, the runtime might be longer but the memory usage is reduced.
+            Use it for very large data sets if memory is the limiting factor.
 
         Returns
         -------
@@ -208,221 +340,290 @@ class VectorFitting:
         --------
         auto_fit : Automatic vector fitting routine with pole adding and skimming.
         """
-
+        # Start timer to track run time
         timer_start = timer()
+        pole_sharing = pole_sharing.lower()
 
-        # use normalized frequencies during the iterations (seems to be more stable during least-squares fit)
-        norm = np.average(self.network.f)
-        # norm = np.exp(np.mean(np.log(self.network.f)))
-        freqs_norm = np.array(self.network.f) / norm
+        # Get omega
+        omega = self._get_omega()
 
-        # get initial poles
-        poles = self._init_poles(freqs_norm, n_poles_real, n_poles_cmplx, init_pole_spacing)
+        # Get responses
+        responses = self._get_responses(parameter_type)
 
-        # check and normalize custom poles
-        if poles is None:
-            if self.poles is not None and len(self.poles) > 0:
-                poles = self.poles / norm
-            else:
-                raise ValueError('Initial poles must be provided in `self.poles` when calling with '
-                                 '`init_pole_spacing == \'custom\'`.')
+        # Get weights
+        if weights is None:
+            weights=self._get_weights(weighting, weighting_accuracy_db, responses)
 
-        # save initial poles (un-normalize first)
-        initial_poles = poles * norm
-        max_singular = 1
+        # Check if poles are shared between responses
+        if pole_sharing == 'mimo':
+            # Poles are shared between all responses
 
-        logger.info('### Starting pole relocation process.\n')
+            # Get initial poles
+            if poles is None:
+                poles = self._get_initial_poles(omega, n_poles_init, poles_init_type,
+                                                poles_init_spacing, responses)
 
-        # select network representation type
-        if parameter_type.lower() == 's':
-            nw_responses = self.network.s
-        elif parameter_type.lower() == 'z':
-            nw_responses = self.network.z
-        elif parameter_type.lower() == 'y':
-            nw_responses = self.network.y
-        else:
-            warnings.warn('Invalid choice of matrix parameter type (S, Z, or Y); proceeding with scattering '
-                          'representation.', UserWarning, stacklevel=2)
-            nw_responses = self.network.s
+            # Call _vector_fit
+            poles, residues, constant, proportional=self._vector_fit(
+                poles, omega, responses, weights, fit_constant, fit_proportional, memory_saver,
+                max_iterations, stagnation_threshold, abstol)
 
-        # stack frequency responses as a single vector
-        # stacking order (row-major):
-        # s11, s12, s13, ..., s21, s22, s23, ...
-        freq_responses = []
-        for i in range(self.network.nports):
-            for j in range(self.network.nports):
-                freq_responses.append(nw_responses[:, i, j])
-        freq_responses = np.array(freq_responses)
+            # Save results
+            self._save_results(poles, residues, constant, proportional)
 
-        # responses will be weighted according to their norm;
-        # alternative: equal weights with weight_response = 1.0
-        # or anti-proportional weights with weight_response = 1 / np.linalg.norm(freq_response)
-        weights_responses = np.linalg.norm(freq_responses, axis=1)
-        #weights_responses = np.ones(self.network.nports ** 2)
-        #weights_responses = 10 / np.exp(np.mean(np.log(np.abs(freq_responses)), axis=1))
+        elif pole_sharing == 'multi-siso':
+            # Each response gets its own set of poles
+            n_responses=np.size(responses, axis=0)
+            poles_list = [None]*n_responses
+            residues_list = [None]*n_responses
+            const_list = [None]*n_responses
+            prop_list = [None]*n_responses
 
-        # ITERATIVE FITTING OF POLES to the provided frequency responses
-        # initial set of poles will be replaced with new poles after every iteration
-        iterations = self.max_iterations
-        self.d_res_history = []
-        self.delta_max_history = []
-        self.history_cond_A = []
-        self.history_rank_deficiency = []
-        converged = False
+            # Save initial poles if we have them
+            initial_poles=poles
 
-        # POLE RELOCATION LOOP
-        while iterations > 0:
-            logger.info(f'Iteration {self.max_iterations - iterations + 1}')
+            for i in range(n_responses):
+                logger.info(f'Starting vector fit for response {i+1} of {n_responses}\n')
 
-            poles, d_res, cond, rank_deficiency, residuals, singular_vals = self._pole_relocation(
-                poles, freqs_norm, freq_responses, weights_responses, fit_constant, fit_proportional)
-
-            logger.info(f'Condition number of coefficient matrix is {int(cond)}')
-            self.history_cond_A.append(cond)
-
-            self.history_rank_deficiency.append(rank_deficiency)
-            logger.info(f'Rank deficiency is {rank_deficiency}.')
-
-            self.d_res_history.append(d_res)
-            logger.info(f'd_res = {d_res}')
-
-            # calculate relative changes in the singular values; stop iteration loop once poles have converged
-            new_max_singular = np.amax(singular_vals)
-            delta_max = np.abs(1 - new_max_singular / max_singular)
-            self.delta_max_history.append(delta_max)
-            logger.info(f'Max. relative change in residues = {delta_max}\n')
-            max_singular = new_max_singular
-
-            stop = False
-            if delta_max < self.max_tol:
-                if converged:
-                    # is really converged, finish
-                    logger.info(f'Pole relocation process converged after {self.max_iterations - iterations + 1} '
-                                  'iterations.')
-                    stop = True
+                if initial_poles is None:
+                    # Get initial poles
+                    poles = self._get_initial_poles(omega, n_poles_init, poles_init_type,
+                                                    poles_init_spacing, responses)
                 else:
-                    # might be converged, but do one last run to be sure
-                    converged = True
-            else:
-                if converged:
-                    # is not really converged, continue
-                    converged = False
+                    # Set initial poles to user-provided poles
+                    poles = initial_poles[i]
 
-            iterations -= 1
+                # Call _auto_fit
+                poles_list[i], residues_list[i], const_list[i], prop_list[i]=self._vector_fit(
+                    poles, omega, responses[i, None], weights[i, None], fit_constant, fit_proportional, memory_saver,
+                    max_iterations, stagnation_threshold, abstol)
 
-            if iterations == 0:
-                # loop ran into iterations limit; trying to assess the issue
-                max_cond = np.amax(self.history_cond_A)
-                max_deficiency = np.amax(self.history_rank_deficiency)
-                if max_cond > 1e10:
-                    hint_illcond = ('\nHint: the linear system was ill-conditioned (max. condition number was '
-                                    f'{max_cond}).')
-                else:
-                    hint_illcond = ''
-                if max_deficiency < 0:
-                    hint_rank = ('\nHint: the coefficient matrix was rank-deficient (max. rank deficiency was '
-                                 f'{max_deficiency}).')
-                else:
-                    hint_rank = ''
-                if converged and stop is False:
-                    warnings.warn('Vector Fitting: The pole relocation process barely converged to tolerance. '
-                                  f'It took the max. number of iterations (N_max = {self.max_iterations}). '
-                                  'The results might not have converged properly.'
-                                  + hint_illcond + hint_rank, RuntimeWarning, stacklevel=2)
-                else:
-                    warnings.warn('Vector Fitting: The pole relocation process stopped after reaching the '
-                                  f'maximum number of iterations (N_max = {self.max_iterations}). '
-                                  'The results did not converge properly.'
-                                  + hint_illcond + hint_rank, RuntimeWarning, stacklevel=2)
+                logger.info(f'Finished vector fit for response {i+1} of {n_responses}\n')
 
-            if stop:
-                iterations = 0
+            # Save results
+            self._save_results(poles_list, residues_list, const_list, prop_list)
 
-        # ITERATIONS DONE
-        logger.info('Initial poles before relocation:')
-        logger.info(initial_poles)
-
-        logger.info('Final poles:')
-        logger.info(poles * norm)
-
-        logger.info('\n### Starting residues calculation process.\n')
-
-        # finally, solve for the residues with the previously calculated poles
-        residues, constant_coeff, proportional_coeff, residuals, rank, singular_vals = self._fit_residues(
-            poles, freqs_norm, freq_responses, fit_constant, fit_proportional)
-
-        # save poles, residues, d, e in actual frequencies (un-normalized)
-        self.poles = poles * norm
-        self.residues = np.array(residues) * norm
-        self.constant_coeff = np.array(constant_coeff)
-        self.proportional_coeff = np.array(proportional_coeff) / norm
+        # Print model summary
+        self.print_model_summary(verbose)
 
         timer_stop = timer()
         self.wall_clock_time = timer_stop - timer_start
 
-        logger.info(f'\n### Vector fitting finished in {self.wall_clock_time} seconds.\n')
+    def _vector_fit(self, poles, omega, responses, weights, fit_constant, fit_proportional,
+                    memory_saver, max_iterations, stagnation_threshold, abstol):
+        # This implements the core algorithm of vector fitting.
+        # _vector_fit is called by vector_fit. For a description of the arguments see vector_fit.
 
-        # raise a warning if the fitted Network is passive but the fit is not (only without proportional_coeff):
-        if self.network.is_passive() and not fit_proportional:
-            if not self.is_passive():
-                warnings.warn('The fitted network is passive, but the vector fit is not passive. Consider running '
-                              '`passivity_enforce()` to enforce passivity before using this model.',
-                              UserWarning, stacklevel=2)
+        # Clear history. History variables are used to track convergence while fitting
+        self._clear_history()
 
-    def auto_fit(self, n_poles_init_real: int = 3, n_poles_init_cmplx: int = 3, n_poles_add: int = 3,
-                 model_order_max: int = 100, iters_start: int = 3, iters_inter: int = 3, iters_final: int = 5,
-                 target_error: float = 1e-2, alpha: float = 0.03, gamma: float = 0.03, nu_samples: float = 1.0,
-                 parameter_type: str = 's') -> (np.ndarray, np.ndarray):
+        # Initialize iteration counter, converged flag and max singular used in relocation loop
+        iteration = 0
+
+        # Pole relocation loop
+        while True:
+            logger.info(f'Iteration {iteration}')
+
+            # Relocate poles
+            poles, d_tilde = self._relocate_poles(poles, omega, responses, weights, fit_constant,
+                                                  fit_proportional, memory_saver)
+
+            # Check relative change of maximum singular value in A_dense stopping condition
+            dRelMaxSv=self.delta_rel_max_singular_value_A_dense_history[-1]
+            if dRelMaxSv < stagnation_threshold:
+                logger.info(f'Stopping pole relocation because dRelMaxSv = {dRelMaxSv:.4e} < '
+                            f'stagnation_threshold = {stagnation_threshold:.4e}')
+                break
+
+            # Check absolute error stopping condition only every 25 iterations
+            if np.mod(iteration, 25) == 0:
+                # Fit residues with the previously calculated poles
+                residues, constant, proportional = self._fit_residues(poles, omega, responses,
+                                                                      weights, fit_constant, fit_proportional)
+                # Calculate error_max
+                error_max = np.max(self._get_delta(poles, residues, constant, proportional, omega, responses, weights))
+
+                logger.info(f'ErrorMax = {error_max:.4e}')
+
+                # Check stopping condition
+                if error_max < abstol:
+                    logger.info(f'Stopping pole relocation because error_max = {error_max:.4e} < abstol = {abstol:.4e}')
+                    break
+
+            # Check maximum iterations stopping condition
+            if iteration == max_iterations:
+                logger.info(f'Stopping pole relocation because iteration = {iteration} '
+                            f'== max_iterations = {max_iterations}')
+
+                # Print convergence hint for cond(A_dense)
+                max_cond = np.amax(self.history_cond_A_dense)
+                if max_cond > 1e10:
+                    warnings.warn = ('Hint: the linear system was ill-conditioned (max. condition number was '
+                                    f'{max_cond:.4e}).')
+
+                # Print convergence hint for rank(A_dense)
+                max_deficiency = np.amax(self.history_rank_deficiency_A_dense)
+                if max_deficiency < 0:
+                   warnings.warn  = ('Hint: the coefficient matrix was rank-deficient (max. rank deficiency was '
+                                 f'{max_deficiency}).')
+
+                break
+
+            # Increment iteration counter
+            iteration += 1
+
+        # Fit residues with the previously calculated poles
+        residues, constant, proportional = self._fit_residues(poles, omega, responses,
+                                                              weights, fit_constant, fit_proportional)
+
+        return poles, residues, constant, proportional
+
+    def auto_fit(self,
+                 # Initial poles
+                 poles=None,
+                 n_poles_init: int = None, poles_init_type: str = 'complex', poles_init_spacing: str = 'lin',
+
+                 # Weighting
+                 weights = None,
+                 weighting: str = 'uniform',
+                 weighting_accuracy_db: float = -60.0,
+
+                 # Fit constant and/or proportional term
+                 fit_constant: bool = True,
+                 fit_proportional: bool = False,
+
+                 # Share poles between responses
+                 pole_sharing: str = 'MIMO',
+
+                 # Parameters for adding and skimming algorithm
+                 n_poles_add_max: int = None, model_order_max: int = 1000,
+                 # Note: n_iterations < 5 can lead to oscillation of the VF-AS algorithm with slow converge
+                 n_iterations_pre: int = 5, n_iterations: int = 5, n_iterations_post: int = 5,
+                 abstol: float = 1e-3, error_stagnation_threshold: float = 0.03, spurious_pole_threshold: float = 0.03,
+
+                 # Memory saver
+                 memory_saver: bool = False,
+
+                 # Parameter type
+                 parameter_type: str = 's',
+
+                 # Verbose
+                 verbose=False,
+                 ) -> (np.ndarray, np.ndarray):
         """
         Automatic fitting routine implementing the "vector fitting with adding and skimming" algorithm as proposed in
         [#Grivet-Talocia]_. This algorithm is able to provide high quality macromodels with automatic model order
         optimization, while improving both the rate of convergence and the fit quality in case of noisy data.
         The resulting model parameters will be stored in the class variables :attr:`poles`, :attr:`residues`,
-        :attr:`proportional_coeff` and :attr:`constant_coeff`.
+        :attr:`proportional` and :attr:`constant`.
 
         Parameters
         ----------
-        n_poles_init_real: int, optional
-            Number of real poles in the initial model.
+        poles: numpy array of initial poles (if shared_poles==True) or list of numpy arrays of initial poles (if
+        shared_poles==False), optional.
 
-        n_poles_init_cmplx: int, optional
-            Number of complex conjugate poles in the initial model.
+        n_poles_init: int, optional
+            Number of poles in the initial model.
+            If not specified, the number of initial poles will be estimated from the data
 
-        n_poles_add: int, optional
-            Number of new poles allowed to be added in each refinement iteration, if possible. This controls how fast
-            the model order is allowed to grow. Unnecessary poles will have to be skimmed and removed later. This
-            parameter has a strong effect on the convergence.
+        poles_init_type: str, optional
+            Type of poles in the initial model. Can be 'complex' or 'real'. Only used if n_poles_init is specified.
+            Otherwise the type of initial poles is estimated from the data.
+
+        poles_init_spacing: str, optional
+            Spacing of the initial poles in the frequency range. Only used if n_poles_init is specified.
+            Otherwise the poles will be estimated from the data.
+
+        n_poles_add_max: int, optional
+            Maximum number of new poles allowed to be added in each iteration. Controls how fast
+            the model order is allowed to grow. If not specified, a reasonable value will be estimated from the data.
 
         model_order_max: int, optional
-            Maximum model order as calculated with :math:`N_{real} + 2 N_{complex}`. This parameter provides a stopping
-            criterion in case the refinement process is not converging.
+            Maximum model order to be used by the fit.
 
-        iters_start: int, optional
-            Number of initial iterations for pole relocations as in regular vector fitting.
+        n_iterations_pre: int, optional
+            Number of initial iterations for pole relocation as in regular vector fitting.
 
-        iters_inter: int, optional
-            Number of intermediate iterations for pole relocations during each iteration of the refinement process.
+        n_iterations: int, optional
+            Number of intermediate iterations for pole relocation during each iteration of the adding and skimming loop.
 
-        iters_final: int, optional
-            Number of final iterations for pole relocations after the refinement process.
+        n_iterations_post: int, optional
+            Number of final iterations for pole relocation after the adding and skimming loop terminated.
 
-        target_error: float, optional
-            Target for the model error to be reached during the refinement process. The actual achievable error is
-            bound by the noise in the data. If specified with a number greater than the noise floor, this parameter
-            provides another stopping criterion for the refinement process. It therefore affects both the convergence,
-            the final error, and the final model order (number of poles used in the model).
+        weights: numpy ndarray of size n_responses, n_freqs, optional
+            If weights are provided, these weights are used. The weights must be in the order
+            The rows must be in this order: W11, W12, W13,...W21, W22,... where Wij is the weight
+            vector used to calculate Sij * Wij.
 
-        alpha: float, optional
-            Threshold for the error decay to stop the refinement loop in case of error stagnation. This parameter
-            provides another stopping criterion for cases where the model already has enough poles but the target error
-            still cannot be reached because of excess noise (target error too small for noise level in the data).
+            Alternatively to providing the weights yourself, you can set thei weighting parameter
+            (and accompanying weighting_accuracy_db parameter) to have the weights created from the data.
 
-        gamma: float, optional
-            Threshold for the detection of spurious poles.
+        weighting: str, optional
+            Weighting to be used for the frequency responses. The default is uniform weigthing.
 
-        nu_samples: float, optional
-            Required and enforced (relative) spacing in termins of frequency samples between existing poles and
-            relocated or added poles. The number can be a float, it does not have to be an integer.
+            'uniform': Uniform weighting: Every frequency sample has the same weight. Favors absolute accuracy.
+            Advantages: Ensures that no frequency range is prioritized over another.
+            Disadvantages: May lead to poor accuracy in regions where the frequency response magnitude is much smaller.
+
+            'inverse_magnitude': Inverse magnitude weighting: Weight is inversely proportional to the magnitude of the
+            frequency response. Weight=1/abs(f(s)). Favors relative accuracy. Advantages: Improves the relative accuracy
+            in low-magnitude regions, ensuring that small values in the response are not overshadowed by larger ones.
+            Disadvantages: May overly emphasize small-magnitude regions, leading to less accuracy in high-magnitude
+            regions or increased numerical sensitivity. Can amplify noise if the response magnitude is very small.
+
+        weighting_accuracy_db: float, optional
+            In inverse magnitude weighting, specifies a limit in dB (dB20), down to which the magnitudes are weighted.
+
+            The possible range is -inf to 0 dB. If set to 0 dB, the minimum weight is 1, which is effectively the
+            same as uniform weighting (all weights 1.0).
+
+            Example: If you set it to -20 dB, all values are weighted according to their inverse magnitude 1/abs(value),
+            but with a limit of 0.1: All values less than 0.1 are weighted with 1/0.1 but no less than that.
+
+            In summary, with this parameter the accuracy tradeoff between large and small magnitudes can be adjusted.
+
+            For example, if you want the same accuracy down to -80 dB as for larger values around 0 dB, you can set
+            weighting_accuracy_db=-80. This will fit all values down to -80 dB with the same relative accuracy as those
+            around 0 dB. Important note: It is inevitable that this will lead to a higher absolute RMS error of the
+            entire fit. This is because the fit accuracy for larger values will now be traded off against the fit
+            accuracy for small values.
+
+            For this reason it is important not to set weighting_accuracy_db lower than you actually need, because
+            otherwise you will sacrifice accuracy on the larger values for extra accuracy on very small values
+            that you may not even be interested in. Note that setting it to, for example, -40 dB, also the -80 dB
+            range values will benefit from more accuracy, but only to a certain extent limited by the -40 dB
+            weighting_accuracy_db.
+
+            The default was chosen to -60 dB because it may fit most practical applications, putting weight on values
+            down to -60 dB but also not sacrificing too much accuracy in the 0 dB range.
+
+        fit_constart: bool, optional
+            Decide whether the constant term d is fitted or not.
+
+        fit_proportional: bool, optional
+            Decide whether the proportional term e is fitted or not.
+
+        pole_sharing: bool, optional
+            Decide whether to share one common pole set for all responses or
+            use separate pole sets for each response.
+
+        memory_saver: bool, optional
+            Enables the memory saver. If enabled, the runtime might be longer but the memory usage is reduced.
+            Use it for very large data sets if memory is the limiting factor.
+
+        abstol: float, optional
+            Absolute error threshold. The algorithm stops iterating once the absolute error of the fit is less than
+            abstol.
+
+        error_stagnation_threshold: float, optional
+            Error stagnation treshold. The algorithm stops iterating if the decay of the error with respect to an
+            average of the decay of the error over the last 3 iterations is less than
+            error_stagnation_threshold * current error.
+
+        spurious_pole_threshold: float, optional
+            Threshold for the detection of spurious poles. A pole is skimmed if at least one of the integrals of the
+            energy norm (l2 norm) of the corresponding pole-residue pairs contributes less than
+            spurious_pole_threshold * mean_of_the_energy_norms_of_all_poles.
 
         parameter_type: str, optional
             Representation type of the frequency responses to be fitted. Either *scattering* (`'s'` or `'S'`),
@@ -446,602 +647,1263 @@ class VectorFitting:
             Compatibility, vol. 48, no. 1, pp. 104-120, Feb. 2006, DOI: https://doi.org/10.1109/TEMC.2006.870814
         """
 
-        self.d_res_history = []
-        self.delta_max_history = []
-        self.history_cond_A = []
-        self.history_rank_deficiency = []
-        max_singular = 1
-        error_peak_history = []
-        model_order_history = []
-
         timer_start = timer()
+        pole_sharing = pole_sharing.lower()
 
-        # use normalized frequencies during the iterations (seems to be more stable during least-squares fit)
-        norm = np.average(self.network.f)
-        # norm = np.exp(np.mean(np.log(self.network.f)))
-        freqs_norm = np.array(self.network.f) / norm
-        omega_norm = 2 * np.pi * freqs_norm
-        nu = (omega_norm[1] - omega_norm[0]) * nu_samples
+        # Get omega
+        omega = self._get_omega()
 
-        # get initial poles
-        poles = self._init_poles(freqs_norm, n_poles_init_real, n_poles_init_cmplx, 'lin')
+        # Get responses
+        responses = self._get_responses(parameter_type)
 
-        logger.info('### Starting pole relocation process.\n')
+        # Get weights
+        if weights is None:
+            weights=self._get_weights(weighting, weighting_accuracy_db, responses)
 
-        # select network representation type
-        if parameter_type.lower() == 's':
-            nw_responses = self.network.s
-            fit_constant = True
-            fit_proportional = False
-        elif parameter_type.lower() == 'z':
-            nw_responses = self.network.z
-            fit_constant = True
-            fit_proportional = True
-        elif parameter_type.lower() == 'y':
-            nw_responses = self.network.y
-            fit_constant = True
-            fit_proportional = True
-        else:
-            warnings.warn('Invalid choice of matrix parameter type (S, Z, or Y); proceeding with scattering '
-                          'representation.', UserWarning, stacklevel=2)
-            nw_responses = self.network.s
-            fit_constant = True
-            fit_proportional = False
+        # Check if poles are shared between responses
+        if pole_sharing == 'mimo':
+            # Poles are shared between all responses
 
-        # stack frequency responses as a single vector
-        # stacking order (row-major):
-        # s11, s12, s13, ..., s21, s22, s23, ...
-        freq_responses = []
-        for i in range(self.network.nports):
-            for j in range(self.network.nports):
-                freq_responses.append(nw_responses[:, i, j])
-        freq_responses = np.array(freq_responses)
+            # Get initial poles
+            if poles is None:
+                poles = self._get_initial_poles(omega, n_poles_init, poles_init_type,
+                                                poles_init_spacing, responses)
 
-        # responses will be weighted according to their norm;
-        # alternative: equal weights with weight_response = 1.0
-        # or anti-proportional weights with weight_response = 1 / np.linalg.norm(freq_response)
-        weights_responses = np.linalg.norm(freq_responses, axis=1)
-        # weights_responses = np.ones(self.network.nports ** 2)
-        # weights_responses = 10 / np.exp(np.mean(np.log(np.abs(freq_responses)), axis=1))
+            # Set n_poles_add_max if it is not provided
+            if n_poles_add_max is None:
+                n_poles_add_max=max(2, int(len(poles)/2))
 
-        # INITIAL POLE RELOCATION FOR i_start ITERATIONS
-        for _ in range(iters_start):
-            poles, d_res, cond, rank_deficiency, residuals, singular_vals = self._pole_relocation(
-                poles, freqs_norm, freq_responses, weights_responses, fit_constant, fit_proportional)
+            # Call _auto_fit
+            poles, residues, constant, proportional=self._auto_fit(
+                poles, omega, responses, weights, fit_constant, fit_proportional, memory_saver,
+                n_iterations_pre, n_iterations, n_iterations_post,
+                error_stagnation_threshold, spurious_pole_threshold, abstol, model_order_max, n_poles_add_max)
 
-            self.d_res_history.append(d_res)
+            # Save results
+            self._save_results(poles, residues, constant, proportional)
 
-            logger.info(f'Condition number of coefficient matrix is {int(cond)}')
-            self.history_cond_A.append(cond)
+        elif pole_sharing == 'multi-siso':
+            # Each response gets its own set of poles
+            n_responses=np.size(responses, axis=0)
+            poles_list = [None]*n_responses
+            residues_list = [None]*n_responses
+            const_list = [None]*n_responses
+            prop_list = [None]*n_responses
 
-            self.history_rank_deficiency.append(rank_deficiency)
-            logger.info(f'Rank deficiency is {rank_deficiency}.')
+            # Save initial poles if we have them
+            initial_poles=poles
 
-            new_max_singular = np.amax(singular_vals)
-            delta_max = np.abs(1 - new_max_singular / max_singular)
-            self.delta_max_history.append(delta_max)
-            logger.info(f'Max. relative change in residues = {delta_max}\n')
-            max_singular = new_max_singular
+            for i in range(n_responses):
+                logger.info(f'Starting auto_fit for response {i+1} of {n_responses}')
 
-        # RESIDUE FITTING FOR ERROR COMPUTATION
-        residues, constant_coeff, proportional_coeff, residuals, rank, singular_vals = self._fit_residues(
-            poles, freqs_norm, freq_responses, fit_constant, fit_proportional)
-        delta = self._get_delta(poles, residues, constant_coeff, proportional_coeff, freqs_norm, freq_responses,
-                                weights_responses)
-        error_peak = np.max(delta)
-        error_peak_history.append(error_peak)
+                if initial_poles is None:
+                    # Get initial poles
+                    poles = self._get_initial_poles(omega, n_poles_init, poles_init_type,
+                                                    poles_init_spacing, responses)
+                else:
+                    # Set initial poles to user-provided poles
+                    poles = initial_poles[i]
 
-        model_order = self.get_model_order(poles)
-        model_order_history.append(model_order)
+                # Set n_poles_add_max if it is not provided
+                if n_poles_add_max is None:
+                    n_poles_add_max=max(2, int(len(poles)/2))
 
-        delta_eps = 10 * alpha
+                # Call _auto_fit
+                poles_list[i], residues_list[i], const_list[i], prop_list[i]=self._auto_fit(
+                    poles, omega, responses[i, None], weights[i, None], fit_constant, fit_proportional, memory_saver,
+                    n_iterations_pre, n_iterations, n_iterations_post,
+                    error_stagnation_threshold, spurious_pole_threshold, abstol, model_order_max, n_poles_add_max)
 
-        # POLE SKIMMING AND ADDING LOOP
-        while error_peak > target_error and model_order < model_order_max and delta_eps > alpha:
+                logger.info(f'Finished auto_fit for response {i+1} of {n_responses}\n')
 
-            # SKIMMING OF SPURIOUS POLES
-            spurious = self.get_spurious(poles, residues, gamma=gamma)
-            n_skim = np.sum(spurious)
-            poles = poles[~spurious]
+            # Save results
+            self._save_results(poles_list, residues_list, const_list, prop_list)
 
-            # REPLACING SPURIOUS POLE AND ADDING NEW POLES
-            idx_freqs_start, idx_freqs_stop, idx_freqs_max, delta_mean_bands = self._find_error_bands(freqs_norm, delta)
-
-            n_bands = len(idx_freqs_max)
-            if n_bands < n_skim:
-                n_add = n_bands
-            elif n_bands < n_skim + n_poles_add:
-                n_add = n_bands
-            else:
-                n_add = n_skim + n_poles_add
-
-            for i in range(n_add):
-                omega_add = omega_norm[idx_freqs_max[i]]
-                pole_add = (-0.01 + 1j) * omega_add
-
-                # compute distance to neighbouring poles
-                abs_poles_existing = np.abs(poles) - pole_add.imag  # (equation 16)
-                #abs_poles_existing = np.abs(poles - pole_add)   # (equation 17)
-
-                # avoid forbidden bands (too close to neighbour)
-                if np.min(abs_poles_existing) < nu or pole_add.imag < nu:
-                    # decide shift direction (towards higher or lower frequencies)
-                    if idx_freqs_max[i] > 0:
-                        delta_below = delta[idx_freqs_max[i] - 1]
-                    else:
-                        delta_below = 0
-                    if idx_freqs_max[i] < len(omega_norm) - 1:
-                        delta_above = delta[idx_freqs_max[i] + 1]
-                    else:
-                        delta_above = 0
-
-                    if delta_above > delta_below:
-                        # shift to higher frequencies
-                        pole_add += 1j * nu
-                    else:
-                        # shift to lower frequencies
-                        pole_add -= 1j * nu
-
-                poles = np.append(poles, [pole_add])
-
-            # INTERMEDIATE POLE RELOCATION FOR i_inter ITERATIONS
-            for _ in range(iters_inter):
-                poles, d_res, cond, rank_deficiency, residuals, singular_vals = self._pole_relocation(
-                    poles, freqs_norm, freq_responses, weights_responses, fit_constant, fit_proportional)
-
-                self.d_res_history.append(d_res)
-
-                logger.info(f'Condition number of coefficient matrix is {int(cond)}')
-                self.history_cond_A.append(cond)
-
-                self.history_rank_deficiency.append(rank_deficiency)
-                logger.info(f'Rank deficiency is {rank_deficiency}.')
-
-                new_max_singular = np.amax(singular_vals)
-                delta_max = np.abs(1 - new_max_singular / max_singular)
-                self.delta_max_history.append(delta_max)
-                logger.info(f'Max. relative change in residues = {delta_max}\n')
-                max_singular = new_max_singular
-
-            # RESIDUE FITTING FOR ERROR COMPUTATION
-            residues, constant_coeff, proportional_coeff, residuals, rank, singular_vals = self._fit_residues(
-                poles, freqs_norm, freq_responses, fit_constant, fit_proportional)
-            delta = self._get_delta(poles, residues, constant_coeff, proportional_coeff, freqs_norm, freq_responses,
-                                    weights_responses)
-            error_peak_history.append(np.max(delta))
-
-            m = 3
-            if len(error_peak_history) > m:
-                delta_eps = np.mean(np.abs(np.diff(error_peak_history[-1-m:-1])))
-            else:
-                delta_eps = 1
-
-            model_order = self.get_model_order(poles)
-            model_order_history.append(model_order)
-
-        # SKIMMING OF SPURIOUS POLES
-        spurious = self.get_spurious(poles, residues, gamma=gamma)
-        poles = poles[~spurious]
-
-        # FINAL POLE RELOCATION FOR i_final ITERATIONS
-        for _ in range(iters_final):
-            poles, d_res, cond, rank_deficiency, residuals, singular_vals = self._pole_relocation(
-                poles, freqs_norm, freq_responses, weights_responses, fit_constant, fit_proportional)
-
-            self.d_res_history.append(d_res)
-
-            logger.info(f'Condition number of coefficient matrix is {int(cond)}')
-            self.history_cond_A.append(cond)
-
-            self.history_rank_deficiency.append(rank_deficiency)
-            logger.info(f'Rank deficiency is {rank_deficiency}.')
-
-            new_max_singular = np.amax(singular_vals)
-            delta_max = np.abs(1 - new_max_singular / max_singular)
-            self.delta_max_history.append(delta_max)
-            logger.info(f'Max. relative change in residues = {delta_max}\n')
-            max_singular = new_max_singular
-
-        # FINAL RESIDUE FITTING
-        residues, constant_coeff, proportional_coeff, residuals, rank, singular_vals = self._fit_residues(
-            poles, freqs_norm, freq_responses, fit_constant, fit_proportional)
-
-        # save poles, residues, d, e in actual frequencies (un-normalized)
-        self.poles = poles * norm
-        self.residues = np.array(residues) * norm
-        self.constant_coeff = np.array(constant_coeff)
-        self.proportional_coeff = np.array(proportional_coeff) / norm
+        # Print model summary
+        self.print_model_summary(verbose)
 
         timer_stop = timer()
         self.wall_clock_time = timer_stop - timer_start
 
+    def _auto_fit(self,
+                  poles, omega, responses, weights, fit_constant, fit_proportional, memory_saver,
+                  n_iterations_pre, n_iterations, n_iterations_post,
+                  error_stagnation_threshold, spurious_pole_threshold, abstol, model_order_max, n_poles_add_max
+                  ):
+        # This implements the core algorithm of vector fitting with adding and skimming.
+        # _auto_fit is called by auto_fit. For a description of the arguments see auto_fit.
+
+        # Clear history. History variables are used to track convergence while fitting
+        self._clear_history()
+
+        # Initial pole relocation
+        logger.info('Initial pole relocation')
+        for _ in range(n_iterations_pre):
+            poles, d_tilde = self._relocate_poles(poles, omega, responses, weights,
+                                                  fit_constant, fit_proportional, memory_saver)
+
+        # Fit residues
+        residues, constant, proportional = self._fit_residues(poles, omega, responses,
+                                                              weights, fit_constant, fit_proportional)
+
+        # Calculate delta
+        delta = self._get_delta(poles, residues, constant, proportional, omega, responses, weights)
+
+        # Initialize stopping condition variables of skim-and-add loop
+        error_max = np.max(delta)
+        model_order = self.get_model_order(poles)
+        delta_eps_avg_m = 3 # Average the last m iterations of delta eps
+        error_max_history = []
+        iteration=0
+
+        # Minimum spacing of added poles to existing poles
+        delta_omega_min = (omega[1] - omega[0])*1.0
+
+        # Pole skimming and adding loop
+        while True:
+            logger.info(f'AS-Loop Iteration = {iteration} AbsError = {error_max:.4e}, ModelOrder = {model_order}')
+
+            if error_max <= abstol:
+                logger.info(f'Stopping AS-Loop because AbsError = {error_max:.4e} < AbsTol = {abstol:.4e}')
+                break
+
+            # Get spurious poles and skim
+            spurious = self.get_spurious(poles, residues, spurious_pole_threshold)
+            poles = poles[~spurious]
+
+            # Get pole candidates
+            pole_candidates = self._get_pole_candidates(delta, omega)
+
+            # Calculate how many of the pole candidates we will add
+            n_pole_candidates = len(pole_candidates)
+            n_poles_skimmed = np.sum(spurious)
+            n_poles_add=min(n_pole_candidates, n_poles_skimmed+n_poles_add_max)
+
+            logger.info(f'n_poles_skimmed = {n_poles_skimmed} '
+                        f'n_pole_candidates = {n_pole_candidates} n_poles_add = {n_poles_add}')
+
+            # Merge pole_candidates into poles keeping a minimum distance delta_omega_min to existing poles.
+            # If they collide, the candidates will be moved to the best possible available spot.
+            poles = self._add_poles(poles, pole_candidates[:n_poles_add], delta_omega_min)
+
+            # Intermediate pole relocation
+            logger.info('Intermediate pole relocation')
+            for _ in range(n_iterations):
+                poles, d_tilde, = self._relocate_poles(poles, omega, responses, weights,
+                                                       fit_constant, fit_proportional, memory_saver)
+
+            # Fit residues
+            residues, constant, proportional = self._fit_residues(poles, omega, responses,
+                                                                  weights, fit_constant, fit_proportional)
+
+            # Calculate delta
+            delta = self._get_delta(poles, residues, constant, proportional, omega, responses, weights)
+
+            # Update stopping condition variables
+            error_max=np.max(delta)
+            error_max_history.append(error_max)
+            if len(error_max_history) >= delta_eps_avg_m:
+                # Calculate delta_error using the last delta_eps_avg_m values
+                delta_error=np.diff(error_max_history[-delta_eps_avg_m:])
+                # Set all delta error that are positive to 0. This means that
+                # if the error gets larger, we have 0 improvement.
+                delta_error=np.clip(delta_error, -np.inf, 0)
+                # It can happen that all elements have been clipped, put at least one element in
+                if len(delta_error) == 0:
+                    delta_error=np.array([0])
+                # Calculate the mean of the absolute values
+                delta_eps = np.mean(np.abs(delta_error))
+                delta_eps_min = error_stagnation_threshold * error_max
+                # Check delta_eps stopping condition
+                if delta_eps < delta_eps_min:
+                    logger.info(f'Stopping AS-Loop because DeltaEps = {delta_eps:.4e} < '
+                                f'DeltaEpsMin = {delta_eps_min:.4e}')
+                    break
+            model_order = self.get_model_order(poles)
+
+            # Check stopping condition of model order
+            if model_order >= model_order_max:
+                logger.info(f'Stopping AS-Loop because ModelOrder = {model_order} >= '
+                            f'ModelOrderMax = {model_order_max}')
+                break
+
+            iteration += 1
+
+        # Final skimming of spurious poles
+        logger.info('Final pole relocation')
+        spurious = self.get_spurious(poles, residues, spurious_pole_threshold=spurious_pole_threshold)
+        poles = poles[~spurious]
+
+        # Final pole relocation
+        for _ in range(n_iterations_post):
+            poles, d_tilde = self._relocate_poles(poles, omega, responses, weights,
+                                                  fit_constant, fit_proportional, memory_saver)
+
+        # Final residue fitting
+        residues, constant, proportional = self._fit_residues(poles, omega, responses,
+                                                              weights, fit_constant, fit_proportional)
+
+        return poles, residues, constant, proportional
+
     @staticmethod
-    def _init_poles(freqs: list, n_poles_real: int, n_poles_cmplx: int, init_pole_spacing: str):
-        # create initial poles and space them across the frequencies in the provided Touchstone file
+    def _get_initial_poles(omega: list, n_poles: int, pole_type: str, pole_spacing: str, responses):
+        # Create initial poles and space them across the frequencies
+        #
+        # According to Gustavsen they thould generally
+        # be complex conjugate pole pairs with linear spacing. Real poles
+        # only work for very smooth responses.
+        #
+        # Note: According to the VF-AS paper, placing multiple poles at the same
+        # frequency will lead to a seriously ill conditioned least squares system.
 
-        fmin = np.amin(freqs)
-        fmax = np.amax(freqs)
+        poles=[]
 
-        # poles cannot be at f=0; hence, f_min for starting pole must be greater than 0
-        if fmin == 0.0:
-            # random choice: use 1/1000 of first non-zero frequency
-            fmin = freqs[1] / 1000
+        if n_poles is None:
+            # Estimate the initial poles from the responses
 
-        init_pole_spacing = init_pole_spacing.lower()
-        if init_pole_spacing == 'log':
-            pole_freqs_real = np.geomspace(fmin, fmax, n_poles_real)
-            pole_freqs_cmplx = np.geomspace(fmin, fmax, n_poles_cmplx)
-        elif init_pole_spacing == 'lin':
-            pole_freqs_real = np.linspace(fmin, fmax, n_poles_real)
-            pole_freqs_cmplx = np.linspace(fmin, fmax, n_poles_cmplx)
-        elif init_pole_spacing == 'custom':
-            pole_freqs_real = None
-            pole_freqs_cmplx = None
+            # Calculate absolute value of responses
+            responses_abs=np.abs(responses)
+
+            # Mean over all responses
+            responses_abs=np.mean(responses_abs, axis=0)
+
+            # Subtract the mean response. This is not important to find the peaks but it increases
+            # numerical accuracy.
+            responses_abs=responses_abs-np.mean(responses_abs)
+
+            # Find peaks. The prominence is adjusted according to the selected abstol to avoid
+            # placing way too many poles for deviations in the responses that are less than abstol.
+            idx_peaks, _ = find_peaks(responses_abs,
+                                      prominence=0.05*(np.max(responses_abs)-np.min(responses_abs)))
+
+            # Plot for debug
+            # import matplotlib.pyplot as plt
+            # plt.plot(responses_abs)
+            # plt.plot(idx_peaks, responses_abs[idx_peaks], "x")
+            # plt.plot(np.zeros_like(responses_abs), "--", color="gray")
+            # plt.show()
+
+            poles = omega[idx_peaks]
+
+            # Check if the peak finder failed. This can happen if the response is completely
+            # smooth and no maximum exists.
+            if len(poles) == 0:
+                # In the case of smooth responses, according to Gustavsen, it is better to
+                # use real poles instead. The real poles will be created below.
+                pole_type='real'
+
+                # Create two real poles
+                n_poles = 2
+                logger.info(f'Automatic initial pole estimation created {n_poles} {pole_type} poles')
+            else:
+                logger.info(f'Automatic initial pole estimation created {len(poles)} {pole_type} poles')
+
+        if len(poles) == 0:
+            # Either n_poles is set or the automatic initial pole estimation failed.
+
+            # Space out the poles linearly or logarithmically over the frequency range
+            omega_min = np.amin(omega)
+            omega_max = np.amax(omega)
+
+            # Poles cannot be at f=0; hence, f_min for starting pole must be greater than 0
+            if omega_min == 0.0:
+                omega_min = omega[1]
+
+            pole_spacing = pole_spacing.lower()
+            if pole_spacing == 'log':
+                poles = np.geomspace(omega_min, omega_max, n_poles)
+
+            elif pole_spacing == 'lin':
+                poles = np.linspace(omega_min, omega_max, n_poles)
+
+            else:
+                warnings.warn('Invalid choice of initial pole spacing; proceeding with linear spacing.',
+                              UserWarning, stacklevel=2)
+                poles = np.linspace(omega_min, omega_max, n_poles)
+
+        # Multiply by -1 for real poles or by (-0.01+1j) for complex poles
+        pole_type = pole_type.lower()
+        if pole_type == 'real':
+            poles = -1.0 * poles
+
+        elif pole_type == 'complex':
+            poles = (-0.01 + 1j) * poles
+
         else:
-            warnings.warn('Invalid choice of initial pole spacing; proceeding with linear spacing.',
+            warnings.warn('Invalid choice of initial pole type; proceeding with complex poles.',
                           UserWarning, stacklevel=2)
-            pole_freqs_real = np.linspace(fmin, fmax, n_poles_real)
-            pole_freqs_cmplx = np.linspace(fmin, fmax, n_poles_cmplx)
+            poles=(-0.01 + 1j) * poles
 
-        if pole_freqs_real is not None and pole_freqs_cmplx is not None:
-            # init poles array of correct length
-            poles = np.zeros(n_poles_real + n_poles_cmplx, dtype=complex)
+        return poles
 
-            # add real poles
-            for i, f in enumerate(pole_freqs_real):
-                omega = 2 * np.pi * f
-                poles[i] = -1 * omega
+    def _clear_history(self):
+        # Clears global history variables
+        self.d_tilde_history = []
+        self.delta_rel_max_singular_value_A_dense_history = []
+        self.history_cond_A_dense = []
+        self.history_rank_deficiency_A_dense = []
+        self.max_singular_value_A_dense = 1
 
-            # add complex-conjugate poles (store only positive imaginary parts)
-            i_offset = len(pole_freqs_real)
-            for i, f in enumerate(pole_freqs_cmplx):
-                omega = 2 * np.pi * f
-                poles[i_offset + i] = (-0.01 + 1j) * omega
+    def _save_results(self, poles, residues, constant, proportional):
+        # Saves the results
+        self.poles = poles
+        self.residues = residues
+        self.constant = constant
+        self.proportional = proportional
 
-            return poles
+    def _get_omega(self):
+        # Calculates omega
+        omega = 2.0 * np.pi * np.array(self.network.f)
+        return omega
+
+    def get_n_poles_complex(self, poles=None) -> int:
+        # Returns the number of complex conjugate pole pairs
+
+        # Use internal poles if not provided
+        if poles is None:
+            poles = self.poles
+
+        if isinstance(poles, list):
+            n_poles_complex=0
+            for _poles in poles:
+                n_poles_complex += np.sum(_poles.imag > 0.0)
+        else:
+            n_poles_complex = np.sum(poles.imag > 0.0)
+
+        return n_poles_complex
+
+    def get_n_poles_real(self, poles=None) -> int:
+        # Returns the number of real poles
+
+        # Use internal poles if not provided
+        if poles is None:
+            poles = self.poles
+
+        if isinstance(poles, list):
+            n_poles_real=0
+            for _poles in poles:
+                n_poles_real += np.sum(_poles.imag == 0.0)
+        else:
+            n_poles_real = np.sum(poles.imag == 0.0)
+
+        return n_poles_real
+
+    def print_model_summary(self, verbose=False):
+        # Prints a model summary
+
+        n_ports=self._get_n_ports()
+        print('Model summary:')
+        print(f'Number of ports = {n_ports}')
+        print(f'Number of responses = {n_ports**2}')
+        print(f'Model order = {self.get_model_order()}')
+        print(f'Number of real poles = {self.get_n_poles_real()}')
+        print(f'Number of complex conjugate pole pairs = {self.get_n_poles_complex()}')
+
+        # Can't evaluate passivity if non-zero proportional terms exist
+        if len(np.flatnonzero(self.proportional)) == 0:
+            print(f'Model is passive = {self.is_passive()}')
+        else:
+            print('Model is passive = unknown (Passivity test works only for models without proportional terms)')
+
+        if self.network:
+            print(f'Total absolute error (RMS) = {self.get_total_abs_error():.4e}')
+            print(f'Total relative error (RMS) = {self.get_total_rel_error():.4e}')
+
+        if isinstance(self.poles, list):
+            print('Every response has its own set of poles')
+
+            if not verbose:
+                print('Run print_model_summary(verbose=True) for an extended summary')
+                return
+
+            for i in range(n_ports):
+                for j in range(n_ports):
+                    i_response=i * (n_ports-1) + j
+                    poles=self.poles[i_response]
+                    print(f'Response {i}, {j}:')
+                    print(f'\tModel order = {self.get_model_order(poles)}')
+                    print(f'\tNumber of real poles = {self.get_n_poles_real(poles)}')
+                    print(f'\tNumber of complex conjugate pole pairs = {self.get_n_poles_complex(poles)}')
 
         else:
-            return None
+            print('Poles are shared between responses')
+
+        if not verbose:
+            print('Run print_model_summary(verbose=True) for an extended summary')
+            return
+
+        if self.network:
+            abs_err=self.get_abs_error_vs_responses()
+            rel_err=self.get_rel_error_vs_responses()
+            for i in range(n_ports):
+                for j in range(n_ports):
+                    print(f'Response {i}, {j}: AbsErr={abs_err[i, j]:.4e} RelErr={rel_err[i, j]:.4e}')
+
+    def _get_n_ports(self):
+        # Returns the number of ports derived from self.residues
+        if isinstance(self.residues, list):
+            n_ports = int(np.sqrt(len(self.residues)))
+        else:
+            n_ports = int(np.sqrt(np.shape(self.residues)[0]))
+
+        return n_ports
+
+    def _get_weights(self, weighting, weighting_accuracy_db, responses):
+        # Calculates the weights w(s)
+
+        if weighting.lower() == 'uniform':
+            weights=np.ones(np.shape(responses))
+
+        elif weighting.lower() == 'inverse_magnitude':
+            weights = 1/np.clip(np.abs(responses), np.pow(10, weighting_accuracy_db/20), np.inf)
+
+        else:
+            warnings.warn('Invalid choice of weighting. Proceeding with uniform weighting'
+                           ,UserWarning, stacklevel=2)
+            weights=np.ones(np.shape(responses))
+
+        return weights
+
+    def _get_responses(self, parameter_type: str = 's'):
+        # Get responses in vector fitting format
+
+        # Get network responses
+        nw_responses=self._get_nw_responses(parameter_type)
+
+        # Stack frequency responses as a single vector
+        # stacking order (row-major):
+        # s11, s12, s13, ..., s21, s22, s23, ...
+        responses = []
+        for i in range(self.network.nports):
+            for j in range(self.network.nports):
+                responses.append(nw_responses[:, i, j])
+        responses = np.array(responses)
+
+        return responses
+
+    def _get_nw_responses(self, parameter_type: str = 's'):
+        # Get network responses
+
+        # Select network representation type
+        parameter_type=parameter_type.lower()
+        if parameter_type == 's':
+            nw_responses = self.network.s
+        elif parameter_type == 'z':
+            nw_responses = self.network.z
+        elif parameter_type == 'y':
+            nw_responses = self.network.y
+        else:
+            warnings.warn('Invalid choice of matrix parameter type (S, Z, or Y); proceeding with scattering '
+                          'representation.', UserWarning, stacklevel=2)
+            nw_responses = self.network.s
+
+        return nw_responses
 
     @staticmethod
-    def _pole_relocation(poles, freqs, freq_responses, weights_responses, fit_constant, fit_proportional):
-        n_responses, n_freqs = np.shape(freq_responses)
+    def _add_poles(poles, poles_add, delta_omega_min):
+        # Adds poles_add into poles in order of poles_add, keeping a minimum
+        # delta_omega_min between each add-pole and all other poles.
+        # If an add-pole falls within the zone of an already existing pole,
+        # it is moved and inserted either to the right or left of the existing
+        # pole's zone, depending on which is closer add-pole.
+
+        # Step 1: Sort original poles according to their norm. This step is equivalent
+        # to rotating the poles onto the imaginary axis, as described in the VF-AS paper.
+        i_sort = np.argsort(np.abs(poles))
+        poles=poles[i_sort]
+
+        # Step 2: Create zones for each pole, defined by the beginning (b)
+        # and end (e) for each zone
+        zones_begin = np.abs(poles) - delta_omega_min
+        zones_end = np.abs(poles) + delta_omega_min
+
+        # Convert to list so we can append
+        poles=poles.tolist()
+        zones_begin=zones_begin.tolist()
+        zones_end=zones_end.tolist()
+
+        # Merge overlapping zones if we have more than 1 zone
+        if len(zones_begin) > 1:
+            # Merged zones will be collected
+            zones_merged_begin = []
+            zones_merged_end = []
+            # Initialize zone candidate for merging
+            zone_candidate_begin=zones_begin[0]
+            zone_candidate_end=zones_end[0]
+            # Iterate over all zones and possibly merge multiple consecutive zones
+            for i in np.arange(start=1, stop=len(zones_begin)):
+                # Check if candidate overlaps into next zone
+                if zone_candidate_end > zones_begin[i]:
+                    # Merge the candidate and the next zone into new candidate
+                    zone_candidate_end = zones_end[i]
+                else:
+                    # No overlap. Save the candidate zone
+                    zones_merged_begin.append(zone_candidate_begin)
+                    zones_merged_end.append(zone_candidate_end)
+                    # Set new candidate to next zone
+                    zone_candidate_begin=zones_begin[i]
+                    zone_candidate_end=zones_end[i]
+            # Overwrite original zones with merged zones
+            zones_begin=zones_merged_begin
+            zones_end=zones_merged_end
+
+        # Step 3: For each add-pole p
+        if len(zones_begin) > 0:
+            for p in poles_add:
+                # Rotate p onto imaginary axis. p_abs is used for all comparisons
+                # with the zones, but the complex valued p is actually appended
+                # to poles
+                p_abs=np.abs(p)
+
+                # Make sure that p is not too close to the origin
+                if p_abs < delta_omega_min:
+                    p=(-0.01 + 1j) * delta_omega_min
+                    p_abs=np.abs(p)
+
+                # Directly prepend the pole if it is below the first zone
+                if p_abs < zones_begin[0]:
+                    # Merge new zone with first zone if it overlaps
+                    if p_abs+delta_omega_min > zones_begin[0]:
+                        zones_begin[0]=p_abs-delta_omega_min
+                    else:
+                        # Create new zone on index 0
+                        zones_begin.insert(0, p_abs-delta_omega_min)
+                        zones_end.insert(0, p_abs+delta_omega_min)
+                    # Append pole and process next pole
+                    poles.append(p)
+                    continue
+
+                # Directly append the pole if it is above the last zone
+                if p_abs > zones_end[-1]:
+                    # Merge new zone with last zone if it overlaps
+                    if p_abs-delta_omega_min < zones_end[-1]:
+                        zones_end[-1]=p_abs+delta_omega_min
+                    else:
+                        # Append new zone
+                        zones_begin.append(p_abs-delta_omega_min)
+                        zones_end.append(p_abs+delta_omega_min)
+                    # Append pole and process next pole
+                    poles.append(p)
+                    continue
+
+                # Step 3a: Find the first index idx in zones_begin, for which p < b
+                # Note: If p < zones_begin is not true for any b, idx=0 will be returned.
+                # In this case, because we already have handled the case p < zones_begin[0]
+                # above, we know that p > zones_begin[-1]
+                idx=np.argmax(p_abs < zones_begin)
+
+                # Handle special case where idx=0
+                if idx == 0:
+                    # Check if p > zone_e[-1]
+                    if p_abs > zones_end[-1]:
+                        # Merge or insert
+                        if p_abs-delta_omega_min < zones_end[-1]:
+                            # Merge new zone with left zone if it overlaps
+                            zones_end[-1]=p_abs+delta_omega_min
+                        else:
+                            # Append new zone
+                            zones_begin.append(p_abs-delta_omega_min)
+                            zones_end.append(p_abs+delta_omega_min)
+                    # Otherwise p is inside the last zone
+                    else:
+                        # Check distance from p to b and e of last zone
+                        if zones_end[-1] - p_abs >= p_abs - zones_begin[-1]:
+                            # Abut on the left of zone -1
+                            p=(-0.01 + 1j) * zones_begin[-1]
+                            p_abs=np.abs(p)
+
+                            # The new zone overlaps into the last zone, so we merge them
+                            zones_begin[-1]=p_abs-delta_omega_min
+                            # Check if the merged zone overlaps on the left
+                            if len(zones_begin) > 1:
+                                if zones_begin[-1] < zones_end[-2]:
+                                    zones_end[-2]=zones_end[-1]
+                                    del zones_end[-1]
+                                    del zones_begin[-1]
+                        else:
+                            # Abut on the right of zone -1
+                            p=(-0.01 + 1j) * zones_end[-1]
+                            p_abs=np.abs(p)
+                            # The new zone overlaps into the last zone, so we merge them
+                            zones_end[-1]=p_abs+delta_omega_min
+                    # Append pole and process next pole
+                    poles.append(p)
+                    continue
+
+                # Step 3b: We know now the index at which we would insert the new zone
+                # for p but we only know that p is between zone_b[idx-1] and
+                # zone_b[idx], so we have to distinguish two cases:
+
+                # Check if p > zone_e[idx-1] (p is not inside of left zone)
+                if p_abs > zones_end[idx-1]:
+                    # Merge or insert
+                    if p_abs-delta_omega_min < zones_end[idx-1]:
+                        # Merge new zone with left zone
+                        zones_end[idx-1]=p_abs+delta_omega_min
+                    else:
+                        # Insert new zone before index idx
+                        zones_begin.insert(idx, p_abs-delta_omega_min)
+                        zones_end.insert(idx, p_abs+delta_omega_min)
+
+                    # The new zone or the merged zone is now at idx-1
+                    # Check if the new or merged zone overlaps on the right
+                    if idx <= len(zones_begin)-1:
+                        if zones_end[idx-1] > zones_begin[idx]:
+                            zones_end[idx-1]=zones_end[idx]
+                            del zones_end[idx]
+                            del zones_begin[idx]
+
+                    # Append pole and process next pole
+                    poles.append(p)
+                    continue
+
+                # Otherwise p is inside the left zone
+                else:
+                    # Check distance from p to b and e of left zone
+                    if zones_end[idx-1] - p_abs >= p_abs - zones_begin[idx-1]:
+                        # Abut on the left of zone idx-1
+                        p=(-0.01 + 1j) * zones_begin[idx-1]
+                        p_abs=np.abs(p)
+                        # The new zone overlaps into the idx-1 zone, so we merge them
+                        zones_begin[idx-1]=p_abs-delta_omega_min
+                        # Check if the merged zone overlaps on the left
+                        if idx-2 >= 0:
+                            if zones_begin[idx-1] < zones_end[idx-2]:
+                                zones_end[idx-2]=zones_end[idx-1]
+                                del zones_end[idx-1]
+                                del zones_begin[idx-1]
+                    else:
+                        # Abut on the right of zone idx-1
+                        p=(-0.01 + 1j) * zones_end[idx-1]
+                        p_abs=np.abs(p)
+                        # The new zone overlaps into the idx-1 zone, so we merge them
+                        zones_end[idx-1]=p_abs+delta_omega_min
+                        # Check if the merged zone overlaps on the right
+                        if idx <= len(zones_begin)-1:
+                            if zones_end[idx-1] > zones_begin[idx]:
+                                zones_end[idx-1]=zones_end[idx]
+                                del zones_end[idx]
+                                del zones_begin[idx]
+                    # Append pole and process next pole
+                    poles.append(p)
+                    continue
+
+                # If we reached the end of this loop, there is a bug in the code
+                raise RuntimeError('Error in _add_poles')
+
+        # Convert back to np array and return
+        return np.array(poles)
+
+    def _relocate_poles(self, poles, omega, responses, weights, fit_constant, fit_proportional, memory_saver):
+        n_responses, n_freqs = np.shape(responses)
         n_samples = n_responses * n_freqs
-        omega = 2 * np.pi * freqs
         s = 1j * omega
 
-        # weight of extra equation to avoid trivial solution
-        weight_extra = np.linalg.norm(weights_responses[:, None] * freq_responses) / n_samples
+        # In general, we have one "big" system Ax=b, in which the solution
+        # vector x contains all Ci and C~:
+        #
+        # [W1 X, 0,       ..., -W1 H1 X~ ] [C1]   [0]
+        # [0,    W2 X, 0, ..., -W2 H2 X~ ] [C2]   [0]
+        # [0, ...,       Wn X, -Wn Hn X~ ] [..] = [0]
+        # [0, ...,                    J ] [C~]   [weight_extra*n_samples]
 
-        # weights w are applied directly to the samples, which get squared during least-squares fitting; hence sqrt(w)
-        weights_responses = np.sqrt(weights_responses)
-        weight_extra = np.sqrt(weight_extra)
+        # Notes on the solution vector x: We are only interested in the C~.
 
-        # count number of rows and columns in final coefficient matrix to solve for (c_res, d_res)
-        # (ratio #real/#complex poles might change during iterations)
+        # Notes on the result vector b: In VF-Relaxed, all equations
+        # except the last will have b=0. In the original-VF, we would have
+        # b=Hi for every row that has b=0 in VF-Relaxed. This is a direct
+        # result of not setting d=1 in the sigma(s) in VF-Relaxed but instead
+        # putting d~ into the solution vector and just enforcing a non-zero
+        # solution for d~ by adding the extra equation represented by the last
+        # row in the big system.
 
-        # We need two columns for complex poles and one column for real poles in A matrix.
-        # This number equals the model order.
-        n_cols_unused = VectorFitting.get_model_order(poles)
+        # Notes on the last row: This represents eq. 8 in Gustavsen-Relaxed-VF.
+        # J=weight_extra*sum(real(X)) size: 1 x (n_poles+1)
+        # The summation goes over all n_freq points
 
-        n_cols_used = n_cols_unused
-        n_cols_used += 1
-        idx_constant = []
-        idx_proportional = []
+        # Notes on the remaining rows:
+        #
+        # X := rational basis functions with size n_freqs x (n_poles+n_extra)
+        #       Xkj := 1/(sk-aj) (for j=1..n_poles and for all k)
+        # and   Xkj := 1 (for j=n_poles+1* and for all k) (only if fit_constant == True)
+        # and   Xkj := s (for j=n_poles+2* and for all k) (only if fit_constant == True and fit_proportional == True)
+        # and   Xkj := s (for j=n_poles+1* and for all k) (only if fit_constant == False and fit_proportional == True)
+
+        # Y := rational basis functions with size n_freqs x (n_poles+1)
+        #       Xkj := 1/(sk-aj) (for j=1..n_poles and for all k)
+        # and   Xkj := 1 (for j=n_poles+1 and for all k) (only if fit_constant == True)
+        # The Y represent the rational basis functions of sigma(s) including
+        # all the same poles as in X, but only one extra element for the d~ term,
+        # which is always present. The e term does not go into sigma(s).
+
+        # If fit_proportional == False and fit_constant == True, X==Y.
+        # In all other cases, only the rational basis functions will be the
+        # same for X and Y.
+
+        #
+        # Wi := weights: diag(wi1,...wi_n_freqs)
+        #
+        # Hi := response: diag(hi(s1), ..., hi(s_n_freqs)),
+        #
+        # Ci=[c1i, ..., cn_polesi, di (optional), ei(optional)]^T
+        # C~=[c1~, ..., cn_poles~, d~]^T
+
+        # The big system could directly be solved but it quickly becomes
+        # pretty big, so some authors developed a method to reduce the
+        # computational complexity, which is implemented in this method.
+        # It is based on this publication:
+        #
+        # "Macromodeling of Multiport Systems Using a Fast Implementation of the Vector
+        # Fitting Method", Dirk Deschrijver, Michal Mrozowski, Tom Dhaene, Daniel De Zutter,
+        # IEEE MICROWAVE AND WIRELESS COMPONENTS LETTERS, VOL. 18, NO. 6, JUNE 2008.
+
+        # Because the rows of A contain only zeros except for two
+        # elements, the rows Ai of A can be written like this:
+
+        # [Wi*X -Wi Hi X~] [Ci] = [0]
+        #                  [C~]   [0]
+        #
+        # and the last row of A yields
+        # [J] [C~] = [weight_extra*n_samples]
+        #
+        # All those rows still form one equation system that can't be treated
+        # separately. But we can do a QR factorization of each of those
+        # rows, except for the last one: Ai=Q [R11, R12; 0, R22]
+        #
+        # Because we are only interested in the C~ of the solution vector x,
+        # and we have the 0 in the R matrix in the lower diagonal of R,
+        # we can write the equations for C~:
+        # R22*C~ = 0
+        # This is possible because the C~ depend only on R22 but not
+        # on the other elements of R.
+        #
+        # To account for all rows Ai representing the entire equation system,
+        # we have to do a QR for each row and combine all the R22_i into
+        # the final equation system that has now only the C~ in the solution vector:
+        #
+        # [R22_1               ]        [0]
+        # [R22_2,              ]        [0]
+        # [R22_3,              ] [C~] = [0]
+        # [...,                ]        ...
+        # [R22_(n_responses+1) ]        [0]
+        # [J                   ]        [weight_extra*n_freqs]
+
+        ##############
+        # Further notes on the residual basis functions used in X and Y:
+        # In general, for complex conjugate pole pairs, also the residues
+        # are complex conjugate.
+        #
+        # After the first step of pole relocation described above is complete,
+        # (i.e. the calculation of the C~), the second (and final) step
+        # of pole relocation is done: We calculate the eigvals of another matrix,
+        # and those eigvals are directly the poles.
+        #
+        # In general, this matrix is complex. We coud calculate its eigvals
+        # directly from the complex matrix, but we have a constraint:
+
+        # We know that for complex conjugate pole pairs, we get complex conjugate
+        # eigenvalues, but the eigenvalues of a complex matrix are not necessarily
+        # complex conjugate pairs. Only for real matrices we are guaranteed to get
+        # complex conjugate pair eigenvalues.
+        # This is a direct result of the
+        # definition of eigenvalues as the roots of the characteristic polynomial.
+        # If the coefficients of this polynomial are all real (which are the
+        # elements of the matrix!), the roots will be complex conjugate pairs.
+        #
+        # And this is also what we need, because we will save only
+        # one pole per pair and expect that the other pole of the pair
+        # is exactly its conjugate.
+        #
+        # The reason why we want this is that later in the synthesis, we rely
+        # on complex poles to occur in complex conjugate pairs. An arbitrary, single
+        # complex pole can't be synthesized! Only a conjugate complex pole pair can.
+        #
+        # Because of this, we can't just calculate the eigenvalues in the last
+        # step using a complex matrix (this would be simpler and faster),
+        # but instead we have to transform the complex matrix into a real matrix
+        # using a similarity transformation.
+        #
+        # In this transformation, a diagonal 2x2 block submatrix with complex
+        # conjugate pairs will be transformed into a real matrix that has the
+        # same eigenvalues:
+        #
+        # eigvals([a+jb, 0; 0, a-jb]) == eigvals([a, b; -b, a])
+        #
+        # a.k.a. complex diagonal form (cdf) vs. real diagonal form (rdf)
+        #
+        # The final matrix is not a diagonal matrix as in the example, but will also
+        # contain off diagonal, non zero elements. The eigenvalue problem to solve
+        # will be eigvals(A-BD^-1C~^T).
+
+        # The final matrix comes from transforming sigma(s) into a state space model
+        # in parallel/diagonal form: sigma(s)=C(sI-A)^-1 B + D
+        # A := Diagonal state/system matrix A=diag(p1,...pn) containing the initial poles
+        # B := Input matrix: A column vector of ones
+        # C := Output matrix, which is a row vector with the C~
+        # D := Feed through/feed forward matrix D.
+        #
+        # For the similarity transformation we need the exact real and imaginary parts
+        # of all elements of the matrix A-BD^-1C~^T.
+        # The real an imaginary parts of A (which contains the poles on the diagonal)
+        # for complex conjugate initial poles are directly available from the
+        # initial complex pole that is saved in the poles array.
+        # B and D are real, so only for C~ we need to make sure to get the real
+        # and imaginary parts of complex conjugate residues.
+        #
+        # Normally C~ contains C~[i] and C~[i+1]=C~[i]* for a complex conjugate residue.
+        # so we could solve the least squares problem in step 1 and then postprocess
+        # it for complex poles by calculating Real(C~[i]) and Imag(C~[i]) from the
+        # complex C~[i] or we can alternatively modify the least squares problem
+        # such that for complex conjugate pole pairs, we get the real part of
+        # the complex conjugate pair in C~[i] and the imaginary part of the
+        # complex conjugate pair in C~[i+1] by doing the following modification:
+        #
+        # Xkj     =     (1/(sk-aj)+1/(sk-aj*))
+        # Xk(j+1) = j * (1/(sk-aj)-1/(sk-aj*))
+        #
+        # With this modification C~ is real and we can directly use it
+        # to build the final real matrix for the eigenvalue calculation.
+
+        # Get total number of poles, counting complex conjugate pairs as 2 poles
+        n_poles=self.get_model_order(poles)
+
+        # Get indices of real poles
+        idx_poles_real = np.nonzero(poles.imag == 0)[0]
+
+        # Get indices of complex poles
+        idx_poles_complex = np.nonzero(poles.imag != 0)[0]
+
+        # Initialize number of elements in C
+        n_C=n_poles
+
+        # Get index of constant term if we have it
         if fit_constant:
-            idx_constant = [n_cols_unused]
-            n_cols_unused += 1
+            idx_const = [n_C]
+            n_C += 1
+
+        # Get index of proportional term if we have it
         if fit_proportional:
-            idx_proportional = [n_cols_unused]
-            n_cols_unused += 1
+            idx_prop = [n_C]
+            n_C += 1
 
-        real_mask = poles.imag == 0
-        # list of indices in 'poles' with real values
-        idx_poles_real = np.nonzero(real_mask)[0]
-        # list of indices in 'poles' with complex values
-        idx_poles_complex = np.nonzero(~real_mask)[0]
+        # Number of elements in C~=C_tilde
+        n_C_tilde = n_poles + 1
 
-        # positions (columns) of coefficients for real and complex-conjugate terms in the rows of A determine the
-        # respective positions of the calculated residues in the results vector.
-        # to have them ordered properly for the subsequent assembly of the test matrix H for eigenvalue extraction,
-        # place real poles first, then complex-conjugate poles with their respective real and imaginary parts:
-        # [r1', r2', ..., (r3', r3''), (r4', r4''), ...]
+        # Build components of rational basis functions (RBF)
+        rbf_real = 1 / (s[:, None] - poles[None, idx_poles_real])
+
+        rbf_complex_re = (1 / (s[:, None] - poles[None, idx_poles_complex]) +
+                            1 / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
+        rbf_complex_im = (1j / (s[:, None] - poles[None, idx_poles_complex]) -
+                            1j / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
+
         n_real = len(idx_poles_real)
         n_cmplx = len(idx_poles_complex)
-        idx_res_real = np.arange(n_real)
-        idx_res_complex_re = n_real + 2 * np.arange(n_cmplx)
-        idx_res_complex_im = idx_res_complex_re + 1
+        idx_real = np.arange(n_real)
+        idx_complex_re = n_real + 2 * np.arange(n_cmplx)
+        idx_complex_im = idx_complex_re + 1
 
-        # complex coefficient matrix of shape [N_responses, N_freqs, n_cols_unused + n_cols_used]
-        # layout of each row:
-        # [pole1, pole2, ..., (constant), (proportional), pole1, pole2, ..., constant]
-        A = np.empty((n_responses, n_freqs, n_cols_unused + n_cols_used), dtype=complex)
+        # Calculate n_rows of R22
+        K=min(n_freqs * 2, n_C + n_C_tilde)
+        n_rows_R22=K-n_C
 
-        # calculate coefficients for real and complex residues in the solution vector
-        #
-        # real pole-residue term (r = r', p = p'):
-        # fractional term is r' / (s - p')
-        # coefficient for r' is 1 / (s - p')
-        coeff_real = 1 / (s[:, None] - poles[None, idx_poles_real])
+        # Initialize R22
+        R22=np.empty((n_responses, n_rows_R22, n_C_tilde))
 
-        # complex-conjugate pole-residue pair (r = r' + j r'', p = p' + j p''):
-        # fractional term is r / (s - p) + conj(r) / (s - conj(p))
-        #                   = [1 / (s - p) + 1 / (s - conj(p))] * r' + [1j / (s - p) - 1j / (s - conj(p))] * r''
-        # coefficient for r' is 1 / (s - p) + 1 / (s - conj(p))
-        # coefficient for r'' is 1j / (s - p) - 1j / (s - conj(p))
-        coeff_complex_re = (1 / (s[:, None] - poles[None, idx_poles_complex]) +
-                            1 / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
-        coeff_complex_im = (1j / (s[:, None] - poles[None, idx_poles_complex]) -
-                            1j / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
+        if not memory_saver:
+            # We build all rows of A at once and run the QR factorization using
+            # numpy. I guess that numpy will use multiple threads to parallelize.
+            #
+            # Matrix A can be pretty big because it is of size:
+            # n_responses*n_freqs*(n_C + n_C_tilde)
+            #
+            # If A is too big, we can also compute the QR factorization for
+            # each row of A serially and save only the resulting R22.
+            # This is done if memory_saver == True
 
-        # part 1: first sum of rational functions (variable c)
-        A[:, :, idx_res_real] = coeff_real
-        A[:, :, idx_res_complex_re] = coeff_complex_re
-        A[:, :, idx_res_complex_im] = coeff_complex_im
+            A = np.empty((n_responses, n_freqs, n_C + n_C_tilde), dtype=complex)
 
-        # part 2: constant (variable d) and proportional term (variable e)
-        A[:, :, idx_constant] = 1
-        A[:, :, idx_proportional] = s[:, None]
+            # Components W X
+            A[:, :, idx_real] = weights[:, :, None] * rbf_real[None, :, :]
+            A[:, :, idx_complex_re] = weights[:, :, None] * rbf_complex_re[None, :, :]
+            A[:, :, idx_complex_im] = weights[:, :, None] * rbf_complex_im[None, :, :]
+            if fit_constant:
+                A[:, :, idx_const] = 1 * weights[:, :, None]
+            if fit_proportional:
+                A[:, :, idx_prop] = weights[:, :, None] * s[None, :, None]
 
-        # part 3: second sum of rational functions multiplied with frequency response (variable c_res)
-        A[:, :, n_cols_unused + idx_res_real] = -1 * freq_responses[:, :, None] * coeff_real
-        A[:, :, n_cols_unused + idx_res_complex_re] = -1 * freq_responses[:, :, None] * coeff_complex_re
-        A[:, :, n_cols_unused + idx_res_complex_im] = -1 * freq_responses[:, :, None] * coeff_complex_im
+            # Components W X~
+            A[:, :, n_C + idx_real] = -1 * weights[:, :, None] * rbf_real[None, :, :] * responses[:, :, None]
+            A[:, :, n_C + idx_complex_re] = \
+                -1 * weights[:, :, None] * rbf_complex_re[None, :, :] * responses[:, :, None]
+            A[:, :, n_C + idx_complex_im] = \
+                -1 * weights[:, :, None] * rbf_complex_im[None, :, :] * responses[:, :, None]
+            A[:, :, -1] = -1 * weights[:, :] * responses[:, :]
 
-        # part 4: constant (variable d_res)
-        A[:, :, -1] = -1 * freq_responses
+            # The numpy QR decomposition in mode 'r' will be A = Q R
+            # size A=M, N then size R=min(M,N), N
+            #
+            # To get R22, we need to make sure that we get enough columns
+            # so that R22 fits to the size of C~. This condition can always
+            # be fulfilled because the N size of R22 is the same as for A.
 
-        # calculation of matrix sizes after QR decomposition:
-        # stacked coefficient matrix (A.real, A.imag) has shape (L, M, N)
-        # with
-        # L = n_responses = n_ports ** 2
-        # M = 2 * n_freqs (because of hstack with 2x n_freqs)
-        # N = n_cols_unused + n_cols_used
-        # then
-        # R has shape (L, K, N) with K = min(M, N)
-        dim_k = min(2 * n_freqs, n_cols_unused + n_cols_used)
+            # The number of rows that we need (from the bottom of R) needs to be chosen such that
+            # all components of C are multiplied with a zero of the lower triangle. So if we
+            # have K rows, the second row has one zero, the third row has two zeros, effectively
+            # removing the first and second component of C and so on.
+            # Thus, the number of rows left until the bottom of R22 is reached is
+            # n_rows_R22=K-n_C
 
-        # QR decomposition
-        # R = np.linalg.qr(np.hstack((A.real, A.imag)), 'r')
+            # QR decomposition. Note: The hstack is not actually stacking
+            # "horizontally" but it's stacking along the second dimension.
+            # The first dimension is responses, the second is freqs.
+            # Thus, dimension two is doubled to 2*n_freqs by the stack.
+            #
+            # We could basically also run a half sized QR of the complex A
+            # but this will yield also complex C_tilde because we will get a
+            # complex R. So what we do is Re(A)x=0 && Im(A)x=0 because this
+            # is the equivalent of Ax=0 doubling the number of equations.
+            # Only then we get a real x (C_tilde) which fulfils both the real
+            # and imaginary part equations. The complex Ax=0 would lead to
+            # complex C_tilde and it would be impossible to convert it back to
+            # real only because (a+jb)*(c+jd)=ac-bd+j(bc+ad) so all the parts
+            # are mixed up between A and x in the solution.
+            R = np.linalg.qr(np.hstack((A.real, A.imag)), 'r')
 
-        # direct QR of stacked matrices for linalg.qr() only works with numpy>=1.22.0
-        # workaround for old numpy:
-        R = np.empty((n_responses, dim_k, n_cols_unused + n_cols_used))
-        A_ri = np.hstack((A.real, A.imag))
-        for i in range(n_responses):
-            R[i] = np.linalg.qr(A_ri[i], mode='r')
+            # Get R22
+            R22=R[:, n_C:, n_C:]
 
-        # only R22 is required to solve for c_res and d_res
-        # R12 and R22 can have a different number of rows, depending on K
-        if dim_k == 2 * n_freqs:
-            n_rows_r12 = n_freqs
-            n_rows_r22 = n_freqs
+        # Memory saver: Run in serial for each response. The code is essentially
+        # the same as above. See comments above for comments on the code.
         else:
-            n_rows_r12 = n_cols_unused
-            n_rows_r22 = n_cols_used
-        R22 = R[:, n_rows_r12:, n_cols_unused:]
+            for i in range(n_responses):
+                A = np.empty((n_freqs, n_C + n_C_tilde), dtype=complex)
 
-        # weighting
-        R22 = weights_responses[:, None, None] * R22
+                # Components W X
+                A[:, idx_real] = weights[i, :, None] * rbf_real[None, :, :]
+                A[:, idx_complex_re] = weights[i, :, None] * rbf_complex_re[None, :, :]
+                A[:, idx_complex_im] = weights[i, :, None] * rbf_complex_im[None, :, :]
+                if fit_constant:
+                    A[:, idx_const] = 1 * weights[i, :, None]
+                if fit_proportional:
+                    A[:, idx_prop] = weights[i, :, None] * s[None, :, None]
 
-        # assemble compressed coefficient matrix A_fast by row-stacking individual upper triangular matrices R22
-        A_fast = np.empty((n_responses * n_rows_r22 + 1, n_cols_used))
-        A_fast[:-1, :] = R22.reshape((n_responses * n_rows_r22, n_cols_used))
+                # Components W X~
+                A[:, n_C + idx_real] = -1 * weights[i, :, None] * rbf_real[None, :, :] * responses[i, :, None]
+                A[:, n_C + idx_complex_re] = \
+                    -1 * weights[i, :, None] * rbf_complex_re[None, :, :] * responses[i, :, None]
+                A[:, n_C + idx_complex_im] = \
+                    -1 * weights[i, :, None] * rbf_complex_im[None, :, :] * responses[i, :, None]
+                A[:, -1] = -1 * weights[i, :] * responses[i, :]
 
-        # extra equation to avoid trivial solution
-        A_fast[-1, idx_res_real] = np.sum(coeff_real.real, axis=0)
-        A_fast[-1, idx_res_complex_re] = np.sum(coeff_complex_re.real, axis=0)
-        A_fast[-1, idx_res_complex_im] = np.sum(coeff_complex_im.real, axis=0)
-        A_fast[-1, -1] = n_freqs
+                # QR decomposition. Note: Here we have to use vstack instead of hstack
+                # to stack in the first dimension (freq).
+                R = np.linalg.qr(np.vstack((A.real, A.imag)), 'r')
 
-        # weighting
-        A_fast[-1, :] = weight_extra * A_fast[-1, :]
+                # Get R22
+                R22[i]=R[n_C:, n_C:]
 
-        # right hand side vector (weighted)
-        b = np.zeros(n_responses * n_rows_r22 + 1)
-        b[-1] = weight_extra * n_samples
+        # Build A_dense. This is the representation of the initial big system
+        # matrix A with the sparsity and the unused C terms removed.
+        A_dense = np.empty((n_responses * n_rows_R22 + 1, n_C_tilde))
+        A_dense[:-1,:] = R22.reshape((n_responses * n_rows_R22, n_C_tilde))
 
-        # check condition of the linear system
-        cond = np.linalg.cond(A_fast)
-        full_rank = np.min(A_fast.shape)
+        # The extra equation is weighted such that its influence in the least
+        # squares is equal to all other equations. In the original Gustavsen
+        # VF-Relaxed paper, norm(H)/(n_responses*n_freqs) is used.
+        weight_extra = np.linalg.norm(responses*weights) / np.size(responses)
 
-        # solve least squares for real parts
-        x, residuals, rank, singular_vals = np.linalg.lstsq(A_fast, b, rcond=None)
+        # Extra equation for d~
+        A_dense[-1, idx_real] = weight_extra * np.sum(rbf_real.real, axis=0)
+        A_dense[-1, idx_complex_re] = weight_extra * np.sum(rbf_complex_re.real, axis=0)
+        A_dense[-1, idx_complex_im] = weight_extra * np.sum(rbf_complex_im.real, axis=0)
+        A_dense[-1, -1] = weight_extra * n_freqs # Results from summing a 1 over n_freqs
 
-        # rank deficiency
-        rank_deficiency = full_rank - rank
+        d_tilde_norm=np.linalg.norm(A_dense[:, :-1])/(np.size(A_dense, axis=0)*(np.size(A_dense, axis=1)-1))
+        A_dense[:, -1]*=d_tilde_norm
 
-        # assemble individual result vectors from single LS result x
-        c_res = x[:-1]
-        d_res = x[-1]
+        # Right hand side b_dense
+        b_dense = np.zeros(n_responses * n_rows_R22 + 1)
+        b_dense[-1] = weight_extra * n_samples
 
-        # check if d_res is suited for zeros calculation
-        tol_res = 1e-8
-        if np.abs(d_res) < tol_res:
-            # d_res is too small, discard solution and proceed the |d_res| = tol_res
-            logger.info(f'Replacing d_res solution as it was too small ({d_res}).')
-            d_res = tol_res * (d_res / np.abs(d_res))
+        # Condition number of the linear system
+        cond_A_dense = np.linalg.cond(A_dense)
 
-        # build test matrix H, which will hold the new poles as eigenvalues
-        H = np.zeros((len(c_res), len(c_res)))
+        # Solve least squares for C~
+        C_tilde, residuals_A_dense, rank_A_dense, singular_values_A_dense = \
+            np.linalg.lstsq(A_dense, b_dense, rcond=None)
 
-        poles_real = poles[np.nonzero(real_mask)]
-        poles_cplx = poles[np.nonzero(~real_mask)]
+        # Rank deficiency
+        full_rank_A_dense = np.min(A_dense.shape)
+        rank_deficiency_A_dense = full_rank_A_dense - rank_A_dense
 
-        H[idx_res_real, idx_res_real] = poles_real.real
-        H[idx_res_real] -= c_res / d_res
+        # Build H=A-BD^-1C^T
+        d_tilde = C_tilde[-1]*d_tilde_norm
+        C_tilde = C_tilde[:-1]
 
-        H[idx_res_complex_re, idx_res_complex_re] = poles_cplx.real
-        H[idx_res_complex_re, idx_res_complex_im] = poles_cplx.imag
-        H[idx_res_complex_im, idx_res_complex_re] = -1 * poles_cplx.imag
-        H[idx_res_complex_im, idx_res_complex_im] = poles_cplx.real
-        H[idx_res_complex_re] -= 2 * c_res / d_res
+        # Check whether d_tilde is suited for zeros calculation
+        # The tolerance suggested in the original VF-Relaxed paper from
+        # Gustavsen is tol_d_tilde_low=1e-8 but in the example code from Gustavsen
+        # 1e-18 is used. Additionally, in the example code, a high tol of 1e18
+        # is implemented.
+        tol_d_tilde_low=1e-18
+        tol_d_tilde_high=1e18
 
+        if np.abs(d_tilde) < tol_d_tilde_low:
+            raise RuntimeError('Pole relocation failed because d_tilde is too small')
+            # In this case we will do a non-relaxed vector-fitting with a fixed
+            # d~. We have to completely build a new big system and run all the
+            # process with QR factorization and A_dense building and solving again
+            # and obtain a new C_tilde and d_tilde. This is not yet implemented so we
+            # fail with error.
+            # Fixed d_tilde to be used in non-relaxed VF:
+            # d_tilde = tol_d_tilde_low * (d_tilde / np.abs(d_tilde))
+
+        if np.abs(d_tilde) > tol_d_tilde_high:
+            raise RuntimeError('Pole relocation failed because d_tilde is too large')
+            # Fixed d_tilde to be used in non-relaxed VF:
+            # d_tilde = tol_d_tilde_high * (d_tilde / np.abs(d_tilde))
+
+        # Build H
+        H = np.zeros((len(C_tilde), len(C_tilde)))
+
+        poles_real = poles[idx_poles_real]
+        poles_complex = poles[idx_poles_complex]
+
+        H[idx_real, idx_real] = poles_real.real
+        H[idx_real] -= C_tilde / d_tilde
+
+        H[idx_complex_re, idx_complex_re] = poles_complex.real
+        H[idx_complex_re, idx_complex_im] = poles_complex.imag
+        H[idx_complex_im, idx_complex_re] = -1 * poles_complex.imag
+        H[idx_complex_im, idx_complex_im] = poles_complex.real
+        H[idx_complex_re] -= 2 * C_tilde / d_tilde
+
+        # Compute eigenvalues of H. These are the new poles.
         poles_new = np.linalg.eigvals(H)
 
-        # replace poles for next iteration
-        # complex poles need to come in complex conjugate pairs; append only the positive part
+        # Replace poles for next iteration by new ones. For complex conjugate
+        # pole pairs, only the pole with the positive imaginary part is saved.
         poles = poles_new[np.nonzero(poles_new.imag >= 0)]
 
-        # flip real part of unstable poles (real part needs to be negative for stability)
+        # Flip real part of unstable poles
         poles.real = -1 * np.abs(poles.real)
 
-        return poles, d_res, cond, rank_deficiency, residuals, singular_vals
+        # Append convergence metrics to history
+        self.d_tilde_history.append(d_tilde)
+        self.history_cond_A_dense.append(cond_A_dense)
+        self.history_rank_deficiency_A_dense.append(rank_deficiency_A_dense)
 
-    @staticmethod
-    def _fit_residues(poles, freqs, freq_responses, fit_constant, fit_proportional):
-        n_responses, n_freqs = np.shape(freq_responses)
-        omega = 2 * np.pi * freqs
+        # Maximum singular value of A_dense
+        new_max_singular_value_A_dense = np.amax(singular_values_A_dense)
+
+        # Calculate relative change of max_singular_value_A_dense
+        delta_rel_max_singular_value_A_dense = np.abs(
+            (new_max_singular_value_A_dense-self.max_singular_value_A_dense) / self.max_singular_value_A_dense)
+
+        # Save new_max_singular_value_A_dense
+        self.max_singular_value_A_dense = new_max_singular_value_A_dense
+
+        self.delta_rel_max_singular_value_A_dense_history.append(delta_rel_max_singular_value_A_dense)
+
+        logger.info(f'PoleRelocation: Cond = {cond_A_dense:.1e} RankDeficiency = {rank_deficiency_A_dense} '
+                    f'dRelMaxSv = {delta_rel_max_singular_value_A_dense:.4e}')
+
+        return poles, d_tilde
+
+    def _fit_residues(self, poles, omega, responses, weights, fit_constant, fit_proportional):
+        n_responses, n_freqs = np.shape(responses)
         s = 1j * omega
 
-        # We need two columns for complex poles and one column for real poles in A matrix.
-        # This number equals the model order.
-        n_cols = VectorFitting.get_model_order(poles)
+        # Get total number of poles, counting complex conjugate pairs as 2 poles
+        n_poles=self.get_model_order(poles)
 
-        idx_constant = []
-        idx_proportional = []
+        # Get indices of real poles
+        idx_poles_real = np.nonzero(poles.imag == 0)[0]
+
+        # Get indices of complex poles
+        idx_poles_complex = np.nonzero(poles.imag != 0)[0]
+
+        # Initialize number of elements in C
+        n_C=n_poles
+
+        # Get index of constant term if we have it
         if fit_constant:
-            idx_constant = [n_cols]
-            n_cols += 1
+            idx_const = [n_C]
+            n_C += 1
+
+        # Get index of proportional term if we have it
         if fit_proportional:
-            idx_proportional = [n_cols]
-            n_cols += 1
+            idx_prop = [n_C]
+            n_C += 1
 
-        # list of indices in 'poles' with real and with complex values
-        real_mask = poles.imag == 0
-        idx_poles_real = np.nonzero(real_mask)[0]
-        idx_poles_complex = np.nonzero(~real_mask)[0]
+        # Build  components of RBF
+        rbf_real = 1 / (s[:, None] - poles[None, idx_poles_real])
 
-        # find and save indices of real and complex poles in the poles list
-        i = 0
-        idx_res_real = []
-        idx_res_complex_re = []
-        idx_res_complex_im = []
-        for pole in poles:
-            if pole.imag == 0:
-                idx_res_real.append(i)
-                i += 1
-            else:
-                idx_res_complex_re.append(i)
-                idx_res_complex_im.append(i + 1)
-                i += 2
-
-        # complex coefficient matrix of shape [N_freqs, n_cols]
-        # layout of each row:
-        # [pole1, pole2, ..., (constant), (proportional)]
-        A = np.empty((n_freqs, n_cols), dtype=complex)
-
-        # calculate coefficients for real and complex residues in the solution vector
-        #
-        # real pole-residue term (r = r', p = p'):
-        # fractional term is r' / (s - p')
-        # coefficient for r' is 1 / (s - p')
-        coeff_real = 1 / (s[:, None] - poles[None, idx_poles_real])
-
-        # complex-conjugate pole-residue pair (r = r' + j r'', p = p' + j p''):
-        # fractional term is r / (s - p) + conj(r) / (s - conj(p))
-        #                   = [1 / (s - p) + 1 / (s - conj(p))] * r' + [1j / (s - p) - 1j / (s - conj(p))] * r''
-        # coefficient for r' is 1 / (s - p) + 1 / (s - conj(p))
-        # coefficient for r'' is 1j / (s - p) - 1j / (s - conj(p))
-        coeff_complex_re = (1 / (s[:, None] - poles[None, idx_poles_complex]) +
+        rbf_complex_re = (1 / (s[:, None] - poles[None, idx_poles_complex]) +
                             1 / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
-        coeff_complex_im = (1j / (s[:, None] - poles[None, idx_poles_complex]) -
+
+        rbf_complex_im = (1j / (s[:, None] - poles[None, idx_poles_complex]) -
                             1j / (s[:, None] - np.conj(poles[None, idx_poles_complex])))
 
-        # part 1: first sum of rational functions (variable c)
-        A[:, idx_res_real] = coeff_real
-        A[:, idx_res_complex_re] = coeff_complex_re
-        A[:, idx_res_complex_im] = coeff_complex_im
+        n_real = len(idx_poles_real)
+        n_cmplx = len(idx_poles_complex)
+        idx_real = np.arange(n_real)
+        idx_complex_re = n_real + 2 * np.arange(n_cmplx)
+        idx_complex_im = idx_complex_re + 1
 
-        # part 2: constant (variable d) and proportional term (variable e)
-        A[:, idx_constant] = 1
-        A[:, idx_proportional] = s[:, None]
+        # Build matrix A
+        A = np.empty((n_responses, n_freqs, n_C), dtype=complex)
 
-        logger.info(f'Condition number of coefficient matrix = {int(np.linalg.cond(A))}')
+        # Components W X
+        A[:, :, idx_real] = weights[:, :, None] * rbf_real[None, :, :]
+        A[:, :, idx_complex_re] = weights[:, :, None] * rbf_complex_re[None, :, :]
+        A[:, :, idx_complex_im] = weights[:, :, None] * rbf_complex_im[None, :, :]
 
-        # solve least squares and obtain results as stack of real part vector and imaginary part vector
-        x, residuals, rank, singular_vals = np.linalg.lstsq(np.vstack((A.real, A.imag)),
-                                                            np.hstack((freq_responses.real, freq_responses.imag)).T,
-                                                            rcond=None)
-
-        # extract residues from solution vector and align them with poles to get matching pole-residue pairs
-        residues = np.empty((len(freq_responses), len(poles)), dtype=complex)
-        residues[:, idx_poles_real] = np.transpose(x[idx_res_real])
-        residues[:, idx_poles_complex] = np.transpose(x[idx_res_complex_re] + 1j * x[idx_res_complex_im])
-
-        # extract constant and proportional coefficient, if available
         if fit_constant:
-            constant_coeff = x[idx_constant][0]
-        else:
-            constant_coeff = np.zeros(n_responses)
+            d_norm=np.empty(n_responses)
+            d_norm[:]=np.asarray(
+                [np.linalg.norm(A[i, :, :idx_const[0]-1]) / (n_freqs*(idx_const[0])) for i in range(n_responses)])
+            A[:, :, idx_const] = 1 * d_norm[:, None, None] * weights[:, :, None]
 
         if fit_proportional:
-            proportional_coeff = x[idx_proportional][0]
-        else:
-            proportional_coeff = np.zeros(n_responses)
+            d_norm=np.empty(n_responses)
+            d_norm[:]=np.asarray(
+                [np.linalg.norm(A[i, :, :idx_const[0]-1])/(n_freqs*(idx_const[0])) for i in range(n_responses)])
+            e_norm=d_norm/(np.linalg.norm(s)/n_freqs)
+            A[:, :, idx_prop] = e_norm[:, None, None] * weights[:, :, None] * s[None, :, None]
 
-        return residues, constant_coeff, proportional_coeff, residuals, rank, singular_vals
+        # Build responses_weigthed
+        responses_weighted=responses*weights
+
+        # Solve for C with least squares for every response
+        x = np.empty((n_responses, n_C))
+        for i in range(n_responses):
+            Ai = np.vstack((A[i, :, :].real, A[i, :, :].imag))
+            bi = np.hstack((responses_weighted[i, :].real, responses_weighted[i].imag)).T
+
+            # Solve least squares and obtain results as stack of real part vector and imaginary part vector
+            xi, residuals, rank, singular_values = np.linalg.lstsq(Ai, bi, rcond=None)
+
+            # Append solution vector to x
+            x[i] = xi
+
+        # Extract residues from solution vector and align them with poles to get matching pole-residue pairs
+        residues = np.empty((len(responses), len(poles)), dtype=complex)
+        residues[:, idx_poles_real] = x[:, idx_real]
+        residues[:, idx_poles_complex] = x[:, idx_complex_re] + 1j * x[:, idx_complex_im]
+
+        # Extract constant if we have it
+        if fit_constant:
+            constant = np.matrix.flatten(x[:, idx_const]) * d_norm
+        else:
+            constant = np.zeros(n_responses)
+
+        if fit_proportional:
+            proportional = np.matrix.flatten(x[:, idx_prop]) * e_norm
+        else:
+            proportional = np.zeros(n_responses)
+
+        return residues, constant, proportional
 
     @staticmethod
-    def _get_delta(poles, residues, constant_coeff, proportional_coeff, freqs, freq_responses, weights_responses):
-        s = 2j * np.pi * freqs
-        model = proportional_coeff[:, None] * s + constant_coeff[:, None]
+    def _get_delta(poles, residues, constant, proportional, omega, responses, weights):
+        s = 1j * omega
+
+        # Initialize model with zeros
+        model=np.zeros(np.shape(responses), dtype=complex)
+
+        # Constant and proportional terms
+        model += constant[:, None] + proportional[:, None] * s
+
+        # Poles
         for i, pole in enumerate(poles):
             if np.imag(pole) == 0.0:
-                # real pole
+                # Real residue/pole
                 model += residues[:, i, None] / (s - pole)
             else:
-                # complex conjugate pole
+                # Complex conjugate residue/pole pair
                 model += (residues[:, i, None] / (s - pole) +
                           np.conjugate(residues[:, i, None]) / (s - np.conjugate(pole)))
 
-        # compute weighted error and return global maximum at each frequency across all individual responses
-        delta = np.abs(model - freq_responses) * weights_responses[:, None]
+        # Weighted absolute error
+        delta = np.abs(model - responses) * weights
 
+        # Global maximum at each frequency across all individual responses
         return np.max(delta, axis=0)
 
     @staticmethod
-    def _find_error_bands(freqs, delta):
-        # compute error bands (maximal fit deviation)
-        delta_mean = np.mean(delta)
-        error = delta - delta_mean
+    def _get_pole_candidates(delta, omega):
+        # Determines new pole candidates. The delta is split into frequency bands
+        # for which delta > mean(delta) and the maximum in each of those bands
+        # are the candidates.
 
-        # find limits of error bands
-        idx_limits = np.nonzero(np.diff(error > 0))[0]
-        idx_limits_filtered = idx_limits[np.diff(idx_limits, prepend=0) > 2]
+        # Subtract mean from delta
+        delta = delta - np.mean(delta)
 
-        freqs_bands = np.split(freqs, idx_limits_filtered)
-        error_bands = np.split(error, idx_limits_filtered)
-        n_bands = len(freqs_bands)
+        # Stores the maximum of each band
+        delta_max_in_bands=[]
 
-        idx_freqs_start = []
-        idx_freqs_stop = []
-        idx_freqs_max = []
-        delta_mean_bands = []
-        for i_band in range(n_bands):
-            band_error_mean = np.mean(error_bands[i_band])
-            if band_error_mean > 0:
-                # band with excess error;
-                # find frequency index of error maximum inside this band
-                i_band_max_error = np.argmax(error_bands[i_band])
-                i_start = np.nonzero(freqs == freqs_bands[i_band][0])[0][0]
-                i_stop = np.nonzero(freqs == freqs_bands[i_band][-1])[0][0]
-                i_max = np.nonzero(freqs == freqs_bands[i_band][i_band_max_error])[0][0]
-                idx_freqs_start.append(i_start)
-                idx_freqs_stop.append(i_stop)
-                idx_freqs_max.append(i_max)
-                delta_mean_bands.append(np.mean(delta[i_start:i_stop]))
+        # Stores the index of the maximum of each band
+        index_of_delta_max_in_bands=[]
 
-        idx_freqs_start = np.array(idx_freqs_start)
-        idx_freqs_stop = np.array(idx_freqs_stop)
-        idx_freqs_max = np.array(idx_freqs_max)
-        delta_mean_bands = np.array(delta_mean_bands)
+        # Find the maximum in each band
+        delta_max_in_current_band=0
+        index_of_delta_max_in_current_band=0
+        is_inside_of_band=False
+        for i in range(len(delta)):
+            # Outside_of_band
+            if delta[i] < 0:
+                # Transition from inside_of_band to outside_of_band
+                if is_inside_of_band:
+                    # Store maximum and its index
+                    delta_max_in_bands.append(delta_max_in_current_band)
+                    index_of_delta_max_in_bands.append(index_of_delta_max_in_current_band)
 
-        i_sort = np.flip(np.argsort(delta_mean_bands))
+                    # Reset for next band
+                    is_inside_of_band=False
+            # Inside_of_band
+            else:
+                if is_inside_of_band:
+                    # Check if we have a new maximum
+                    if delta[i] >= delta_max_in_current_band:
+                        # Save new maximum and its index for current band
+                        delta_max_in_current_band=delta[i]
+                        index_of_delta_max_in_current_band=i
+                else:
+                    is_inside_of_band=True
+                    delta_max_in_current_band=delta[i]
+                    index_of_delta_max_in_current_band=i
 
-        return idx_freqs_start[i_sort], idx_freqs_stop[i_sort], idx_freqs_max[i_sort], delta_mean_bands[i_sort]
+        # Process potential last band
+        if is_inside_of_band:
+            # Store maximum and its index
+            delta_max_in_bands.append(delta_max_in_current_band)
+            index_of_delta_max_in_bands.append(index_of_delta_max_in_current_band)
+
+        # Convert lists to array
+        delta_max_in_bands = np.array(delta_max_in_bands)
+        index_of_delta_max_in_bands = np.array(index_of_delta_max_in_bands)
+
+        # Plot for debug
+        # import matplotlib.pyplot as plt
+        # plt.plot(delta)
+        # plt.plot(index_of_delta_max_in_bands, delta[index_of_delta_max_in_bands], "x")
+        # plt.plot(np.zeros_like(delta), "--", color="gray")
+        # plt.show()
+
+        # Sort delta_max_in_bands and get indices from sort
+        index_sorted_delta_max_in_bands = np.flip(np.argsort(delta_max_in_bands))
+
+        # Create pole candidate with the omega corresponding to the obtained indices
+        pole_candidates=np.array((-0.01 + 1j) * omega[index_sorted_delta_max_in_bands])
+
+        return pole_candidates
 
     def get_rms_error(self, i=-1, j=-1, parameter_type: str = 's'):
+        return self.get_total_abs_error(i, j, parameter_type)
+
+    def get_total_abs_error(self, i=-1, j=-1, parameter_type: str = 's'):
         r"""
         Returns the root-mean-square (rms) error magnitude of the fit, i.e.
         :math:`\sqrt{ \mathrm{mean}(|S - S_\mathrm{fit} |^2) }`,
@@ -1088,14 +1950,8 @@ class VectorFitting:
         else:
             list_j = j
 
-        if parameter_type.lower() == 's':
-            nw_responses = self.network.s
-        elif parameter_type.lower() == 'z':
-            nw_responses = self.network.z
-        elif parameter_type.lower() == 'y':
-            nw_responses = self.network.y
-        else:
-            raise ValueError(f'Invalid parameter type `{parameter_type}`. Valid options: `s`, `z`, or `y`')
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
 
         error_mean_squared = 0
         for i in list_i:
@@ -1104,9 +1960,233 @@ class VectorFitting:
                 fit_ij = self.get_model_response(i, j, self.network.f)
                 error_mean_squared += np.mean(np.square(np.abs(nw_ij - fit_ij)))
 
-        return np.sqrt(error_mean_squared)
+        return np.sqrt(error_mean_squared / (len(list_i) * len(list_j)))
 
-    def _get_ABCDE(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    def get_total_rel_error(self, i=-1, j=-1, parameter_type: str = 's'):
+        r"""
+        Returns the weighted root-mean-square (rms) error magnitude of the fit, i.e.
+        :math:`\sqrt{ \mathrm{mean}(|S - S_\mathrm{fit} |^2) }`,
+        either for an individual response :math:`S_{i+1,j+1}` or for larger slices of the network.
+
+        Parameters
+        ----------
+        i : int, optional
+            Row indices of the responses to be evaluated. Either a single row selected by an integer
+            :math:`i \in [0, N_\mathrm{ports}-1]`, or multiple rows selected by a list of integers, or all rows
+            selected by :math:`i = -1` (*default*).
+
+        j : int, optional
+            Column indices of the responses to be evaluated. Either a single column selected by an integer
+            :math:`j \in [0, N_\mathrm{ports}-1]`, or multiple columns selected by a list of integers, or all columns
+            selected by :math:`j = -1` (*default*).
+
+        parameter_type: str, optional
+            Representation type of the fitted frequency responses. Either *scattering* (:attr:`s` or :attr:`S`),
+            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`).
+
+        Returns
+        -------
+        rms_error : ndarray
+            The rms error magnitude between the vector fitted model and the original network data.
+
+        Raises
+        ------
+        ValueError
+            If the specified parameter representation type is not :attr:`s`, :attr:`z`, nor :attr:`y`.
+        """
+
+        if i == -1:
+            list_i = range(self.network.nports)
+        elif isinstance(i, int):
+            list_i = [i]
+        else:
+            list_i = i
+
+        if j == -1:
+            list_j = range(self.network.nports)
+        elif isinstance(j, int):
+            list_j = [j]
+        else:
+            list_j = j
+
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
+
+        error_mean_squared = 0
+        for i in list_i:
+            for j in list_j:
+                nw_ij = nw_responses[:, i, j]
+                fit_ij = self.get_model_response(i, j, self.network.f)
+                error_mean_squared += np.mean(np.square(np.abs(nw_ij - fit_ij)/np.abs(nw_ij)))
+
+        return np.sqrt(error_mean_squared / (len(list_i) * len(list_j)))
+
+    def get_abs_error_vs_responses(self, parameter_type: str = 's'):
+        r"""
+        Returns the root-mean-square (rms) error magnitude of the fit, i.e.
+        :math:`\sqrt{ \mathrm{mean}(|S - S_\mathrm{fit} |^2) }`,
+
+        Parameters
+        ----------
+        parameter_type: str, optional
+            Representation type of the fitted frequency responses. Either *scattering* (:attr:`s` or :attr:`S`),
+            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`).
+
+        Returns
+        -------
+        rms_error : ndarray
+            The rms error magnitude between the vector fitted model and the original network data.
+
+        Raises
+        ------
+        ValueError
+            If the specified parameter representation type is not :attr:`s`, :attr:`z`, nor :attr:`y`.
+        """
+
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
+
+        n_responses=np.size(nw_responses, axis=1)
+        error_mean_squared = np.zeros((n_responses, n_responses))
+        for i in range(n_responses):
+            for j in range(n_responses):
+                nw_ij = nw_responses[:, i, j]
+                fit_ij = self.get_model_response(i, j, self.network.f)
+                error_mean_squared[i, j] = np.sqrt(np.mean(np.square(np.abs(nw_ij - fit_ij))))
+
+        return error_mean_squared
+
+    def get_rel_error_vs_responses(self, parameter_type: str = 's'):
+        r"""
+        Returns the weighted root-mean-square (rms) error magnitude of the fit, i.e.
+        :math:`\sqrt{ \mathrm{mean}(|S - S_\mathrm{fit} |^2) }`,
+
+        Parameters
+        ----------
+        parameter_type: str, optional
+            Representation type of the fitted frequency responses. Either *scattering* (:attr:`s` or :attr:`S`),
+            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`).
+
+        Returns
+        -------
+        rms_error : ndarray
+            The rms error magnitude between the vector fitted model and the original network data.
+
+        Raises
+        ------
+        ValueError
+            If the specified parameter representation type is not :attr:`s`, :attr:`z`, nor :attr:`y`.
+        """
+
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
+
+        n_responses=np.size(nw_responses, axis=1)
+        error_mean_squared = np.zeros((n_responses, n_responses))
+        for i in range(n_responses):
+            for j in range(n_responses):
+                nw_ij = nw_responses[:, i, j]
+                fit_ij = self.get_model_response(i, j, self.network.f)
+                error_mean_squared[i, j] = np.sqrt(np.mean(np.square(np.abs(nw_ij - fit_ij)/np.abs(nw_ij))))
+
+        return error_mean_squared
+
+    def get_abs_error(self, i: int = -1, j: int = -1, parameter_type: str = 's'):
+        r"""
+        Returns the absolute error magnitude of the fit
+
+        Parameters
+        ----------
+        i, j : int, optional
+            Row and column index of the response. If both are set to a value >= 0
+            only the results for this response is returned. Otherwise the results
+            for all responses are returned
+
+        parameter_type: str, optional
+            Representation type of the fitted frequency responses. Either *scattering* (:attr:`s` or :attr:`S`),
+            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`).
+
+        Returns
+        -------
+        error : ndarray
+            The error magnitude between the vector fitted model and the original network data.
+
+        Raises
+        ------
+        ValueError
+            If the specified parameter representation type is not :attr:`s`, :attr:`z`, nor :attr:`y`.
+        """
+
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
+
+        n_responses=np.size(nw_responses, axis=1)
+        n_freqs=np.size(nw_responses, axis=0)
+
+        if i >= 0 and j >= 0:
+            nw_ij = nw_responses[:, i, j]
+            fit_ij = self.get_model_response(i, j, self.network.f)
+            error = np.abs(nw_ij - fit_ij)
+
+        else:
+            error = np.empty((n_responses, n_responses, n_freqs))
+            for i in range(n_responses):
+                for j in range(n_responses):
+                    nw_ij = nw_responses[:, i, j]
+                    fit_ij = self.get_model_response(i, j, self.network.f)
+                    error[i, j, :] = np.abs(nw_ij - fit_ij)
+
+        return error
+
+    def get_rel_error(self, i: int = -1, j: int = -1, parameter_type: str = 's'):
+        r"""
+        Returns the relative error magnitude of the fit
+
+        Parameters
+        ----------
+        i, j : int, optional
+            Row and column index of the response. If both are set to a value >= 0
+            only the results for this response is returned. Otherwise the results
+            for all responses are returned
+
+        parameter_type: str, optional
+            Representation type of the fitted frequency responses. Either *scattering* (:attr:`s` or :attr:`S`),
+            *impedance* (:attr:`z` or :attr:`Z`) or *admittance* (:attr:`y` or :attr:`Y`).
+
+        Returns
+        -------
+        error : ndarray
+            The error magnitude between the vector fitted model and the original network data.
+
+        Raises
+        ------
+        ValueError
+            If the specified parameter representation type is not :attr:`s`, :attr:`z`, nor :attr:`y`.
+        """
+
+        # Get network responses
+        nw_responses = self._get_nw_responses(parameter_type)
+
+        n_responses=np.size(nw_responses, axis=1)
+        n_freqs=np.size(nw_responses, axis=0)
+
+        if i >= 0 and j >= 0:
+            nw_ij = nw_responses[:, i, j]
+            fit_ij = self.get_model_response(i, j, self.network.f)
+            error = np.abs(nw_ij - fit_ij) / np.abs(nw_ij)
+
+        else:
+            error = np.empty((n_responses, n_responses, n_freqs))
+            for i in range(n_responses):
+                for j in range(n_responses):
+                    nw_ij = nw_responses[:, i, j]
+                    fit_ij = self.get_model_response(i, j, self.network.f)
+                    error[i, j, :] = np.abs(nw_ij - fit_ij) / np.abs(nw_ij)
+
+        return error
+
+    def _get_ABCDE(self, poles, residues, constant, proportional
+                   ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
         Private method.
         Returns the real-valued system matrices of the state-space representation of the current rational model, as
@@ -1138,39 +2218,37 @@ class VectorFitting:
             Dec. 2008, DOI: 10.1109/TMTT.2008.2007319.
         """
 
-        # initial checks
-        if self.poles is None:
-            raise ValueError('self.poles = None; nothing to do. You need to run vector_fit() first.')
+
+        # Initial checks
+        if poles is None:
+            raise ValueError('poles = None; nothing to do. You need to run vector_fit() first.')
         if self.residues is None:
             raise ValueError('self.residues = None; nothing to do. You need to run vector_fit() first.')
-        if self.proportional_coeff is None:
-            raise ValueError('self.proportional_coeff = None; nothing to do. You need to run vector_fit() first.')
-        if self.constant_coeff is None:
-            raise ValueError('self.constant_coeff = None; nothing to do. You need to run vector_fit() first.')
+        if self.proportional is None:
+            raise ValueError('self.proportional = None; nothing to do. You need to run vector_fit() first.')
+        if self.constant is None:
+            raise ValueError('self.constant = None; nothing to do. You need to run vector_fit() first.')
 
-        # assemble real-valued state-space matrices A, B, C, D, E from fitted complex-valued pole-residue model
+        # Assemble real-valued state-space matrices A, B, C, D, E from fitted complex-valued pole-residue model
 
-        # determine size of the matrix system
-        n_ports = int(np.sqrt(len(self.constant_coeff)))
-        n_poles_real = 0
-        n_poles_cplx = 0
-        for pole in self.poles:
-            if np.imag(pole) == 0.0:
-                n_poles_real += 1
-            else:
-                n_poles_cplx += 1
-        n_matrix = (n_poles_real + 2 * n_poles_cplx) * n_ports
+        # Determine size of the matrix system
+        n_ports = int(np.sqrt(np.shape(residues)[0]))
 
-        # state-space matrix A holds the poles on the diagonal as real values with imaginary parts on the sub-diagonal
-        # state-space matrix B holds coefficients (1, 2, or 0), depending on the respective type of pole in A
-        # assemble A = [[poles_real,   0,                  0],
-        #               [0,            real(poles_cplx),   imag(poles_cplx],
-        #               [0,            -imag(poles_cplx),  real(poles_cplx]]
+        n_poles_real = self.get_n_poles_real(poles)
+        n_poles_complex = self.get_n_poles_complex(poles)
+
+        n_matrix = (n_poles_real + 2 * n_poles_complex) * n_ports
+
+        # State-space matrix A holds the poles on the diagonal as real values with imaginary parts on the sub-diagonal
+        # State-space matrix B holds coefficients (1, 2, or 0), depending on the respective type of pole in A
+        # Assemble A = [[poles_real,   0,                  0],
+        #               [0,            real(poles_complex),   imag(poles_complex],
+        #               [0,            -imag(poles_complex),  real(poles_complex]]
         A = np.identity(n_matrix)
         B = np.zeros(shape=(n_matrix, n_ports))
         i_A = 0  # index on diagonal of A
         for j in range(n_ports):
-            for pole in self.poles:
+            for pole in poles:
                 if np.imag(pole) == 0.0:
                     # adding a real pole
                     A[i_A, i_A] = np.real(pole)
@@ -1185,44 +2263,43 @@ class VectorFitting:
                     B[i_A, j] = 2
                     i_A += 2
 
-        # state-space matrix C holds the residues
-        # assemble C = [[R1.11, R1.12, R1.13, ...], [R2.11, R2.12, R2.13, ...], ...]
+        # State-space matrix C holds the residues
+        # Assemble C = [[R1.11, R1.12, R1.13, ...], [R2.11, R2.12, R2.13, ...], ...]
         C = np.zeros(shape=(n_ports, n_matrix))
         for i in range(n_ports):
             for j in range(n_ports):
                 # i: row index
                 # j: column index
                 i_response = i * n_ports + j
-
                 j_residues = 0
-                for zero in self.residues[i_response]:
-                    if np.imag(zero) == 0.0:
-                        C[i, j * (n_poles_real + 2 * n_poles_cplx) + j_residues] = np.real(zero)
+                for residue in residues[i_response]:
+                    if np.imag(residue) == 0.0:
+                        C[i, j * (n_poles_real + 2 * n_poles_complex) + j_residues] = np.real(residue)
                         j_residues += 1
                     else:
-                        C[i, j * (n_poles_real + 2 * n_poles_cplx) + j_residues] = np.real(zero)
-                        C[i, j * (n_poles_real + 2 * n_poles_cplx) + j_residues + 1] = np.imag(zero)
+                        C[i, j * (n_poles_real + 2 * n_poles_complex) + j_residues] = np.real(residue)
+                        C[i, j * (n_poles_real + 2 * n_poles_complex) + j_residues + 1] = np.imag(residue)
                         j_residues += 2
 
-        # state-space matrix D holds the constants
-        # assemble D = [[d11, d12, ...], [d21, d22, ...], ...]
+        # State-space matrix D holds the constants
+        # Assemble D = [[d11, d12, ...], [d21, d22, ...], ...]
         D = np.zeros(shape=(n_ports, n_ports))
         for i in range(n_ports):
             for j in range(n_ports):
                 # i: row index
                 # j: column index
                 i_response = i * n_ports + j
-                D[i, j] = self.constant_coeff[i_response]
+                D[i, j] = constant[i_response]
 
-        # state-space matrix E holds the proportional coefficients (usually 0 in case of fitted S-parameters)
-        # assemble E = [[e11, e12, ...], [e21, e22, ...], ...]
+        # Etate-space matrix E holds the proportional coefficients (usually 0 in case of fitted S-parameters)
+        # Assemble E = [[e11, e12, ...], [e21, e22, ...], ...]
         E = np.zeros(shape=(n_ports, n_ports))
         for i in range(n_ports):
             for j in range(n_ports):
                 # i: row index
                 # j: column index
                 i_response = i * n_ports + j
-                E[i, j] = self.proportional_coeff[i_response]
+                E[i, j] = proportional[i_response]
 
         return A, B, C, D, E
 
@@ -1256,7 +2333,7 @@ class VectorFitting:
         stsp_S += D + 2j * np.pi * freqs[:, None, None] * E
         return stsp_S
 
-    def passivity_test(self, parameter_type: str = 's') -> np.ndarray:
+    def passivity_test(self, poles = None, residues=None, constant=None, proportional=None, parameter_type: str = 's'):
         """
         Evaluates the passivity of reciprocal vector fitted models by means of a half-size test matrix [#]_. Any
         existing frequency bands of passivity violations will be returned as a sorted list.
@@ -1305,72 +2382,97 @@ class VectorFitting:
 
         if parameter_type.lower() != 's':
             raise NotImplementedError('Passivity testing is currently only supported for scattering (S) parameters.')
-        if parameter_type.lower() == 's' and len(np.flatnonzero(self.proportional_coeff)) > 0:
+        if parameter_type.lower() == 's' and len(np.flatnonzero(self.proportional)) > 0:
             raise ValueError('Passivity testing of scattering parameters with nonzero proportional coefficients does '
                              'not make any sense; you need to run vector_fit() with option `fit_proportional=False` '
                              'first.')
 
+        # Todo: Clarify why the following code is commented out.
         # # the network needs to be reciprocal for this passivity test method to work: S = transpose(S)
         # if not np.allclose(self.residues, np.transpose(self.residues)) or \
-        #         not np.allclose(self.constant_coeff, np.transpose(self.constant_coeff)) or \
-        #         not np.allclose(self.proportional_coeff, np.transpose(self.proportional_coeff)):
+        #         not np.allclose(self.constant, np.transpose(self.constant)) or \
+        #         not np.allclose(self.proportional, np.transpose(self.proportional)):
         #     logger.error('Passivity testing with unsymmetrical model parameters is not supported. '
         #                   'The model needs to be reciprocal.')
         #     return
 
-        # get state-space matrices
-        A, B, C, D, E = self._get_ABCDE()
+        if poles is None or residues is None or constant is None or proportional is None:
+            poles=self.poles
+            residues=self.residues
+            constant=self.constant
+            proportional=self.proportional
+
+        if isinstance(poles, list):
+            violation_bands=[]
+            n_responses=len(poles)
+            for i_response in range(n_responses):
+                poles=self.poles[i_response]
+                residues=self.residues[i_response]
+                constant=self.constant[i_response]
+                proportional=self.proportional[i_response]
+                violation_bands.append(self._passivity_test(poles, residues, constant, proportional))
+        else:
+            violation_bands=self._passivity_test(poles, residues, constant, proportional)
+
+        return violation_bands
+
+    def _passivity_test(self, poles, residues, constant, proportional) -> np.ndarray:
+        # Implements the core of passivity test. Description of arguments see passivity_test
+
+        # Get state-space matrices
+        A, B, C, D, E = self._get_ABCDE(poles, residues, constant, proportional)
         n_ports = np.shape(D)[0]
 
-        # build half-size test matrix P from state-space matrices A, B, C, D
+        # Build half-size test matrix P from state-space matrices A, B, C, D
         inv_neg = np.linalg.inv(D - np.identity(n_ports))
         inv_pos = np.linalg.inv(D + np.identity(n_ports))
         prod_neg = np.matmul(np.matmul(B, inv_neg), C)
         prod_pos = np.matmul(np.matmul(B, inv_pos), C)
         P = np.matmul(A - prod_neg, A - prod_pos)
 
-        # extract eigenvalues of P
+        # Extract eigenvalues of P
         P_eigs = np.linalg.eigvals(P)
 
-        # purely imaginary square roots of eigenvalues identify frequencies (2*pi*f) of borders of passivity violations
+        # Purely imaginary square roots of eigenvalues identify frequencies (2*pi*f) of borders of passivity violations
+        # Note: np.sqrt can't handle negative arguments. Need to use np.emath.sqrt for this code to work:
         freqs_violation = []
-        for sqrt_eigenval in np.sqrt(P_eigs):
+        for sqrt_eigenval in np.emath.sqrt(P_eigs):
             if np.real(sqrt_eigenval) == 0.0:
                 freqs_violation.append(np.imag(sqrt_eigenval) / 2 / np.pi)
 
-        # include dc (0) unless it's already included
+        # Include dc (0) unless it's already included
         if len(np.nonzero(np.array(freqs_violation) == 0.0)[0]) == 0:
             freqs_violation.append(0.0)
 
-        # sort the output from lower to higher frequencies
+        # Sort the output from lower to higher frequencies
         freqs_violation = np.sort(freqs_violation)
 
-        # identify frequency bands of passivity violations
+        # Identify frequency bands of passivity violations
 
-        # sweep the bands between crossover frequencies and identify bands of passivity violations
+        # Sweep the bands between crossover frequencies and identify bands of passivity violations
         violation_bands = []
         for i, freq in enumerate(freqs_violation):
             if i == len(freqs_violation) - 1:
-                # last band stops always at infinity
+                # Last band stops always at infinity
                 f_start = freq
                 f_stop = np.inf
                 f_center = 1.1 * f_start # 1.1 is chosen arbitrarily to have any frequency for evaluation
             else:
-                # intermediate band between this frequency and the previous one
+                # Intermediate band between this frequency and the previous one
                 f_start = freq
                 f_stop = freqs_violation[i + 1]
                 f_center = 0.5 * (f_start + f_stop)
 
-            # calculate singular values at the center frequency between crossover frequencies to identify violations
+            # Calculate singular values at the center frequency between crossover frequencies to identify violations
             s_center = self._get_s_from_ABCDE(np.array([f_center]), A, B, C, D, E)
             sigma = np.linalg.svd(s_center[0], compute_uv=False)
             passive = True
             for singval in sigma:
                 if singval > 1:
-                    # passivity violation in this band
+                    # Passivity violation in this band
                     passive = False
             if not passive:
-                # add this band to the list of passivity violations
+                # Add this band to the list of passivity violations
                 if violation_bands is None:
                     violation_bands = [[f_start, f_stop]]
                 else:
@@ -1378,7 +2480,8 @@ class VectorFitting:
 
         return np.array(violation_bands)
 
-    def is_passive(self, parameter_type: str = 's') -> bool:
+    def is_passive(self, poles = None, residues = None, constant = None,
+                   proportional = None, parameter_type: str = 's') -> bool:
         """
         Returns the passivity status of the model as a boolean value.
 
@@ -1409,13 +2512,24 @@ class VectorFitting:
         >>> vf.is_passive() # returns True or False
         """
 
-        viol_bands = self.passivity_test(parameter_type)
-        if len(viol_bands) == 0:
-            return True
-        else:
-            return False
+        violation_bands = self.passivity_test(poles, residues, constant, proportional, parameter_type)
 
-    def passivity_enforce(self, n_samples: int = 200, f_max: float = None, parameter_type: str = 's') -> None:
+        if isinstance(violation_bands, list):
+            for _violation_bands in violation_bands:
+                if len(_violation_bands) != 0:
+                    return False
+        else:
+            if len(violation_bands) != 0:
+                return False
+
+        return True
+
+    def passivity_enforce(self,
+                          n_samples: int = 200,
+                          f_max: float = None,
+                          parameter_type: str = 's',
+                          max_iterations: int = 100,
+                          ) -> None:
         """
         Enforces the passivity of the vector fitted model, if required. This is an implementation of the method
         presented in [#]_. Passivity is achieved by updating the residues and the constants.
@@ -1472,24 +2586,52 @@ class VectorFitting:
             Feb. 2009, DOI: 10.1109/TMTT.2008.2011201.
         """
 
+        if isinstance(self.poles, list):
+            n_responses=len(self.poles)
+            for i_response in range(n_responses):
+                poles=self.poles[i_response]
+                residues=self.residues[i_response]
+                constant=self.constant[i_response]
+                proportional=self.proportional[i_response]
+                self._passivity_enforce(poles, residues, constant, proportional, n_samples,
+                                        f_max, parameter_type, max_iterations)
+        else:
+            self._passivity_enforce(self.poles, self.residues, self.constant,self.proportional,
+                                    n_samples, f_max, parameter_type, max_iterations)
+
+        # Print model summary
+        self.print_model_summary()
+
+        # Run final passivity test to make sure passivation was successful
+        violation_bands = self.passivity_test(parameter_type=parameter_type)
+
+        if not self.is_passive(parameter_type=parameter_type):
+            warnings.warn('Passivity enforcement was not successful.\nModel is still non-passive in these frequency '
+                          f'bands:\n{violation_bands}.\nTry running this routine again with a larger number of samples '
+                          '(parameter `n_samples`).', RuntimeWarning, stacklevel=2)
+
+    def _passivity_enforce(self, poles, residues, constant, proportional,
+                           n_samples, f_max, parameter_type, max_iterations) -> None:
+        # Implements core of passivity_enforce. Description of arguments see passivity_enforce()
+
         if parameter_type.lower() != 's':
             raise NotImplementedError('Passivity testing is currently only supported for scattering (S) parameters.')
-        if parameter_type.lower() == 's' and len(np.flatnonzero(self.proportional_coeff)) > 0:
+        if parameter_type.lower() == 's' and len(np.flatnonzero(self.proportional)) > 0:
             raise ValueError('Passivity testing of scattering parameters with nonzero proportional coefficients does '
                              'not make any sense; you need to run vector_fit() with option `fit_proportional=False` '
                              'first.')
 
-        # always run passivity test first; this will write 'self.violation_bands'
-        if self.is_passive():
-            # model is already passive; do nothing and return
+        # Run passivity test first
+        if self.is_passive(poles, residues, constant, proportional, parameter_type):
+            # Model is already passive; do nothing and return
             logger.info('Passivity enforcement: The model is already passive. Nothing to do.')
             return
 
-        # find the highest relevant frequency; either
+        # Find the highest relevant frequency; either
         # 1) the highest frequency of passivity violation (f_viol_max)
         # or
         # 2) the highest fitting frequency (f_samples_max)
-        violation_bands = self.passivity_test()
+        violation_bands = self.passivity_test(poles, residues, constant, proportional, parameter_type)
         f_viol_max = violation_bands[-1, 1]
 
         if f_max is None:
@@ -1501,7 +2643,7 @@ class VectorFitting:
         else:
             f_samples_max = f_max
 
-        # deal with unbounded violation interval (f_viol_max == np.inf)
+        # Deal with unbounded violation interval (f_viol_max == np.inf)
         if np.isinf(f_viol_max):
             f_viol_max = 1.5 * violation_bands[-1, 0]
             warnings.warn(
@@ -1510,25 +2652,25 @@ class VectorFitting:
                 'and/or without the constants (`fit_constant=False`) if the results are not satisfactory.',
                 UserWarning, stacklevel=2)
 
-        # the frequency band for the passivity evaluation is from dc to 20% above the highest relevant frequency
+        # The frequency band for the passivity evaluation is from dc to 20% above the highest relevant frequency
         if f_viol_max < f_samples_max:
             f_eval_max = 1.2 * f_samples_max
         else:
             f_eval_max = 1.2 * f_viol_max
         freqs_eval = np.linspace(0, f_eval_max, n_samples)
 
-        A, B, C, D, E = self._get_ABCDE()
+        A, B, C, D, E = self._get_ABCDE(poles, residues, constant, proportional)
         dim_A = np.shape(A)[0]
         C_t = C
 
-        # only include constant if it has been fitted (not zero)
+        # Only include constant if it has been fitted (not zero)
         if len(np.nonzero(D)[0]) == 0:
             D_t = None
         else:
             D_t = D
 
         if self.network is not None:
-            # find highest singular value among all frequencies and responses to use as target for the perturbation
+            # Find highest singular value among all frequencies and responses to use as target for the perturbation
             # singular value decomposition
             sigma = np.linalg.svd(self.network.s, compute_uv=False)
             delta = np.amax(sigma)
@@ -1537,10 +2679,10 @@ class VectorFitting:
         else:
             delta = 0.999  # predefined tolerance parameter (users should not need to change this)
 
-        # calculate coefficient matrix
+        # Calculate coefficient matrix
         A_freq = np.linalg.inv(2j * np.pi * freqs_eval[:, None, None] * np.identity(dim_A)[None, :, :] - A[None, :, :])
 
-        # construct coefficient matrix with an extra column for the constants (if present)
+        # Construct coefficient matrix with an extra column for the constants (if present)
         if D_t is not None:
             coeffs = np.empty((len(freqs_eval), np.shape(B)[0] + 1, np.shape(B)[1]), dtype=complex)
             coeffs[:, :-1, :] = np.matmul(A_freq, B[None, :, :])
@@ -1548,10 +2690,10 @@ class VectorFitting:
         else:
             coeffs = np.matmul(A_freq, B[None, :, :])
 
-        # iterative compensation of passivity violations
+        # Iterative compensation of passivity violations
         t = 0
         self.history_max_sigma = []
-        while t < self.max_iterations:
+        while t < max_iterations:
             logger.info(f'Passivity enforcement; Iteration {t + 1}')
 
             # calculate S-matrix at this frequency (shape fxNxN)
@@ -1560,41 +2702,41 @@ class VectorFitting:
             else:
                 s_eval = self._get_s_from_ABCDE(freqs_eval, A, B, C_t, D, E)
 
-            # singular value decomposition
+            # Singular value decomposition
             u, sigma, vh = np.linalg.svd(s_eval, full_matrices=False)
 
-            # keep track of the greatest singular value in every iteration step
+            # Keep track of the greatest singular value in every iteration step
             sigma_max = np.amax(sigma)
 
-            # find and perturb singular values that cause passivity violations
+            # Find and perturb singular values that cause passivity violations
             idx_viol = np.nonzero(sigma > delta)
             sigma_viol = np.zeros_like(sigma)
             sigma_viol[idx_viol] = sigma[idx_viol] - delta
 
-            # construct a stack of diagonal matrices with the perturbed singular values on the diagonal
+            # Construct a stack of diagonal matrices with the perturbed singular values on the diagonal
             sigma_viol_diag = np.zeros_like(u, dtype=float)
             idx_diag = np.arange(np.shape(sigma)[1])
             sigma_viol_diag[:, idx_diag, idx_diag] = sigma_viol
 
-            # calculate violation S-responses
+            # Calculate violation S-responses
             s_viol = np.matmul(np.matmul(u, sigma_viol_diag), vh)
 
-            # fit perturbed residues C_t for each response S_{i,j}
+            # Fit perturbed residues C_t for each response S_{i,j}
             for i in range(np.shape(s_viol)[1]):
                 for j in range(np.shape(s_viol)[2]):
-                    # mind the transpose of the system to compensate for the exchanged order of matrix multiplication:
-                    # wanting to solve S = C_t * coeffs
+                    # Mind the transpose of the system to compensate for the exchanged order of matrix multiplication:
+                    # Want to solve S = C_t * coeffs
                     # but actually solving S = coeffs * C_t
                     # S = C_t * coeffs <==> transpose(S) = transpose(coeffs) * transpose(C_t)
 
-                    # solve least squares (real-valued)
-                    x, residuals, rank, singular_vals = np.linalg.lstsq(np.vstack((np.real(coeffs[:, :, i]),
+                    # Solve least squares (real-valued)
+                    x, residuals, rank, singular_values = np.linalg.lstsq(np.vstack((np.real(coeffs[:, :, i]),
                                                                                    np.imag(coeffs[:, :, i]))),
                                                                         np.hstack((np.real(s_viol[:, j, i]),
                                                                                    np.imag(s_viol[:, j, i]))),
                                                                         rcond=None)
 
-                    # perturb residues by subtracting respective row and column in C_t
+                    # Perturb residues by subtracting respective row and column in C_t
                     # one half of the solution will always be 0 due to construction of A and B
                     # also perturb constants (if present)
                     if D_t is not None:
@@ -1606,48 +2748,39 @@ class VectorFitting:
             t += 1
             self.history_max_sigma.append(sigma_max)
 
-            # stop iterations when model is passive
+            # Stop iterations when model is passive
             if sigma_max < 1.0:
                 break
 
         # PASSIVATION PROCESS DONE; model is either passive or max. number of iterations have been exceeded
-        if t == self.max_iterations:
+        if t == max_iterations:
             warnings.warn('Passivity enforcement: Aborting after the max. number of iterations has been '
                           'exceeded.', RuntimeWarning, stacklevel=2)
 
-        # save/update model parameters (perturbed residues)
+        # Save/update model parameters (perturbed residues)
         self.history_max_sigma = np.array(self.history_max_sigma)
 
         n_ports = np.shape(D)[0]
         for i in range(n_ports):
-            k = 0   # column index in C_t
+            k = 0   # Column index in C_t
             for j in range(n_ports):
                 i_response = i * n_ports + j
-                z = 0   # column index self.residues
-                for pole in self.poles:
+                for z, pole in enumerate(poles):
                     if np.imag(pole) == 0.0:
-                        # real pole --> real residue
-                        self.residues[i_response, z] = C_t[i, k]
+                        # Real pole -> Real residue
+                        residues[i_response, z] = C_t[i, k]
                         k += 1
                     else:
-                        # complex-conjugate pole --> complex-conjugate residue
-                        self.residues[i_response, z] = C_t[i, k] + 1j * C_t[i, k + 1]
+                        # Complex-conjugate pole -> Complex-conjugate residue
+                        residues[i_response, z] = C_t[i, k] + 1j * C_t[i, k + 1]
                         k += 2
-                    z += 1
                 if D_t is not None:
-                    self.constant_coeff[i_response] = D_t[i, j]
-
-        # run final passivity test to make sure passivation was successful
-        violation_bands = self.passivity_test()
-        if len(violation_bands) > 0:
-            warnings.warn('Passivity enforcement was not successful.\nModel is still non-passive in these frequency '
-                          f'bands: {violation_bands}.\nTry running this routine again with a larger number of samples '
-                          '(parameter `n_samples`).', RuntimeWarning, stacklevel=2)
+                    constant[i_response] = D_t[i, j]
 
     def write_npz(self, path: str) -> None:
         """
         Writes the model parameters in :attr:`poles`, :attr:`residues`,
-        :attr:`proportional_coeff` and :attr:`constant_coeff` to a labeled NumPy .npz file.
+        :attr:`proportional` and :attr:`constant` to a labeled NumPy .npz file.
 
         Parameters
         ----------
@@ -1691,25 +2824,43 @@ class VectorFitting:
         if self.residues is None:
             warnings.warn('Nothing to export; Residues have not been fitted.', RuntimeWarning, stacklevel=2)
             return
-        if self.proportional_coeff is None:
+        if self.proportional is None:
             warnings.warn('Nothing to export; Proportional coefficients have not been fitted.', RuntimeWarning,
                           stacklevel=2)
             return
-        if self.constant_coeff is None:
+        if self.constant is None:
             warnings.warn('Nothing to export; Constants have not been fitted.', RuntimeWarning, stacklevel=2)
             return
 
         filename = self.network.name
+        path=os.path.join(path, f'coefficients_{filename}')
+        logger.info(f'Exporting results as compressed NumPy array to {path}.npz')
 
-        logger.info(f'Exporting results as compressed NumPy array to {path}')
-        np.savez_compressed(os.path.join(path, f'coefficients_{filename}'),
-                            poles=self.poles, residues=self.residues, proportionals=self.proportional_coeff,
-                            constants=self.constant_coeff)
+        # Initialize the save dictionary
+        save_dict = {}
+
+        # Helper function to handle numpy arrays or lists of numpy arrays
+        def process_data(key, data):
+            if isinstance(data, list):
+                for idx, item in enumerate(data):
+                    save_dict[f"{key}{idx}"] = item
+                save_dict[f"n_{key}"] = len(data)  # Save the number of list elements
+            else:
+                save_dict[key] = data
+
+        # Process each attribute
+        process_data("poles", self.poles)
+        process_data("residues", self.residues)
+        process_data("proportionals", self.proportional)
+        process_data("constants", self.constant)
+
+        # Save the data
+        np.savez_compressed(path, **save_dict)
 
     def read_npz(self, file: str) -> None:
         """
-        Reads all model parameters :attr:`poles`, :attr:`residues`, :attr:`proportional_coeff` and
-        :attr:`constant_coeff` from a labeled NumPy .npz file.
+        Reads all model parameters :attr:`poles`, :attr:`residues`, :attr:`proportional` and
+        :attr:`constant` from a labeled NumPy .npz file.
 
         Parameters
         ----------
@@ -1749,32 +2900,29 @@ class VectorFitting:
         >>> vf.passivity_enforce()
         """
 
-        with np.load(file) as data:
-            poles = data['poles']
 
-            # legacy support for exported residues
-            if 'zeros' in data:
-                # old .npz file from deprecated write_npz() with residues called 'zeros'
-                residues = data['zeros']
-            else:
-                # new .npz file from current write_npz()
-                residues = data['residues']
+        # Load the data
+        data = np.load(file)
 
-            proportional_coeff = data['proportionals']
-            constant_coeff = data['constants']
+        # Helper function to reconstruct numpy arrays or lists of numpy arrays
+        def reconstruct_data(key):
+            if f"n_{key}" in data:
+                n_items = int(data[f"n_{key}"])
+                return [data[f"{key}{i}"] for i in range(n_items)]
+            return data[key]
 
-            n_ports = int(np.sqrt(len(constant_coeff)))
-            n_resp = n_ports ** 2
-            if np.shape(residues)[0] == np.shape(proportional_coeff)[0] == np.shape(constant_coeff)[0] == n_resp:
-                self.poles = poles
-                self.residues = residues
-                self.proportional_coeff = proportional_coeff
-                self.constant_coeff = constant_coeff
-            else:
-                raise ValueError('The shapes of the provided parameters are not compatible. The coefficient file needs '
-                                 'to contain NumPy arrays labled `poles`, `residues`, `proportionals`, and '
-                                 '`constants`. Their shapes must match the number of network ports and the number of '
-                                 'frequencies.')
+        # Reconstruct each attribute
+        self.poles = reconstruct_data("poles")
+        self.proportional = reconstruct_data("proportionals")
+        self.constant = reconstruct_data("constants")
+
+        # legacy support for exported residues
+        if 'zeros' in data:
+            # old .npz file from deprecated write_npz() with residues called 'zeros'
+            self.residues = reconstruct_data("zeros")
+        else:
+            # new .npz file from current write_npz()
+            self.residues = reconstruct_data("residues")
 
     def get_model_response(self, i: int, j: int, freqs: Any = None) -> np.ndarray:
         """
@@ -1815,11 +2963,11 @@ class VectorFitting:
             warnings.warn('Returning a zero-vector; Residues have not been fitted.',
                           RuntimeWarning, stacklevel=2)
             return np.zeros_like(freqs)
-        if self.proportional_coeff is None:
+        if self.proportional is None:
             warnings.warn('Returning a zero-vector; Proportional coefficients have not been fitted.',
                           RuntimeWarning, stacklevel=2)
             return np.zeros_like(freqs)
-        if self.constant_coeff is None:
+        if self.constant is None:
             warnings.warn('Returning a zero-vector; Constants have not been fitted.',
                           RuntimeWarning, stacklevel=2)
             return np.zeros_like(freqs)
@@ -1827,19 +2975,28 @@ class VectorFitting:
             freqs = np.linspace(np.amin(self.network.f), np.amax(self.network.f), 1000)
 
         s = 2j * np.pi * np.array(freqs)
-        n_ports = int(np.sqrt(len(self.constant_coeff)))
+        n_ports = self._get_n_ports()
         i_response = i * n_ports + j
-        residues = self.residues[i_response]
 
-        resp = self.proportional_coeff[i_response] * s + self.constant_coeff[i_response]
-        for i, pole in enumerate(self.poles):
+        # Get residues
+        residues = np.matrix.flatten(self.residues[i_response])
+
+        # Calculate model_response
+        model_response = self.proportional[i_response] * s + self.constant[i_response]
+
+        if isinstance(self.poles, list):
+            poles=self.poles[i_response]
+        else:
+            poles=self.poles
+
+        for i, pole in enumerate(poles):
             if np.imag(pole) == 0.0:
                 # real pole
-                resp += residues[i] / (s - pole)
+                model_response += residues[i] / (s - pole)
             else:
                 # complex conjugate pole
-                resp += residues[i] / (s - pole) + np.conjugate(residues[i]) / (s - np.conjugate(pole))
-        return resp
+                model_response += residues[i] / (s - pole) + np.conjugate(residues[i]) / (s - np.conjugate(pole))
+        return model_response
 
     @axes_kwarg
     def plot(self, component: str, i: int = -1, j: int = -1, freqs: Any = None,
@@ -1892,12 +3049,26 @@ class VectorFitting:
             Also if `component` and/or `parameter` are not valid.
         """
 
-        components = ['db', 'mag', 'deg', 'deg_unwrap', 're', 'im']
-        if component.lower() in components:
+        components = ['db', 'mag', 'deg', 'deg_unwrap', 're', 'im', 'rel_err', 'abs_err']
+
+        # Convert to lower case
+        component=component.lower()
+        parameter=parameter.lower()
+
+        if component == 'rel_err' or component == 'abs_err':
+            plot_error=True
+
+            # For error plots the frequency can't be specified because
+            # we only have the frequency of the samples.
+            freqs = self.network.f
+        else:
+            plot_error=False
+
+        if component in components:
             if self.residues is None or self.poles is None:
                 raise RuntimeError('Poles and/or residues have not been fitted. Cannot plot the model response.')
 
-            n_ports = int(np.sqrt(np.shape(self.residues)[0]))
+            n_ports = self._get_n_ports()
 
             if i == -1:
                 list_i = range(n_ports)
@@ -1913,17 +3084,9 @@ class VectorFitting:
             else:
                 list_j = j
 
-            if self.network is not None:
-                # plot the original network response at each sample frequency (scatter plot)
-                if parameter.lower() == 's':
-                    responses = self.network.s
-                elif parameter.lower() == 'z':
-                    responses = self.network.z
-                elif parameter.lower() == 'y':
-                    responses = self.network.y
-                else:
-                    raise ValueError('The network parameter type is not valid, must be `s`, `z`, or `y`, '
-                                     f'got `{parameter}`.')
+            if self.network is not None and not plot_error:
+                # Plot the original network response at each sample frequency (scatter plot)
+                responses = self._get_nw_responses(parameter)
 
                 i_samples = 0
                 for i in list_i:
@@ -1935,20 +3098,20 @@ class VectorFitting:
                         i_samples += 1
 
                         y_vals = None
-                        if component.lower() == 'db':
+                        if component == 'db':
                             y_vals = 20 * np.log10(np.abs(responses[:, i, j]))
-                        elif component.lower() == 'mag':
+                        elif component == 'mag':
                             y_vals = np.abs(responses[:, i, j])
-                        elif component.lower() == 'deg':
+                        elif component == 'deg':
                             y_vals = np.rad2deg(np.angle(responses[:, i, j]))
-                        elif component.lower() == 'deg_unwrap':
+                        elif component == 'deg_unwrap':
                             y_vals = np.rad2deg(np.unwrap(np.angle(responses[:, i, j])))
-                        elif component.lower() == 're':
+                        elif component == 're':
                             y_vals = np.real(responses[:, i, j])
-                        elif component.lower() == 'im':
+                        elif component == 'im':
                             y_vals = np.imag(responses[:, i, j])
 
-                        ax.scatter(self.network.f, y_vals, color='r', label=label)
+                        ax.scatter(self.network.f[:], y_vals[:], color='r', label=label)
 
                 if freqs is None:
                     # get frequency array from the network
@@ -1959,9 +3122,10 @@ class VectorFitting:
                     'Neither `freqs` nor `self.network` is specified. Cannot plot model response without any '
                     'frequency information.')
 
-            # plot the fitted responses
+            # Plot the fitted responses or errors
             y_label = ''
             i_fit = 0
+
             for i in list_i:
                 for j in list_j:
                     if i_fit == 0:
@@ -1970,26 +3134,36 @@ class VectorFitting:
                         label = '_nolegend_'
                     i_fit += 1
 
-                    y_model = self.get_model_response(i, j, freqs)
-                    y_vals = None
-                    if component.lower() == 'db':
-                        y_vals = 20 * np.log10(np.abs(y_model))
-                        y_label = 'Magnitude (dB)'
-                    elif component.lower() == 'mag':
-                        y_vals = np.abs(y_model)
-                        y_label = 'Magnitude'
-                    elif component.lower() == 'deg':
-                        y_vals = np.rad2deg(np.angle(y_model))
-                        y_label = 'Phase (Degrees)'
-                    elif component.lower() == 'deg_unwrap':
-                        y_vals = np.rad2deg(np.unwrap(np.angle(y_model)))
-                        y_label = 'Phase (Degrees)'
-                    elif component.lower() == 're':
-                        y_vals = np.real(y_model)
-                        y_label = 'Real Part'
-                    elif component.lower() == 'im':
-                        y_vals = np.imag(y_model)
-                        y_label = 'Imaginary Part'
+                    if component == 'rel_err':
+                        y_vals = self.get_rel_error(i, j)
+                        y_label = 'Rel. Error'
+
+                    elif component == 'abs_err':
+                        y_vals = self.get_abs_error(i, j)
+                        y_label = 'Abs. Error'
+
+                    else:
+                        y_model = self.get_model_response(i, j, freqs)
+
+                        y_vals = None
+                        if component == 'db':
+                            y_vals = 20 * np.log10(np.abs(y_model))
+                            y_label = 'Magnitude (dB)'
+                        elif component == 'mag':
+                            y_vals = np.abs(y_model)
+                            y_label = 'Magnitude'
+                        elif component == 'deg':
+                            y_vals = np.rad2deg(np.angle(y_model))
+                            y_label = 'Phase (Degrees)'
+                        elif component == 'deg_unwrap':
+                            y_vals = np.rad2deg(np.unwrap(np.angle(y_model)))
+                            y_label = 'Phase (Degrees)'
+                        elif component == 're':
+                            y_vals = np.real(y_model)
+                            y_label = 'Real Part'
+                        elif component == 'im':
+                            y_vals = np.imag(y_model)
+                            y_label = 'Imaginary Part'
 
                     ax.plot(freqs, y_vals, color='k', label=label)
 
@@ -1997,13 +3171,63 @@ class VectorFitting:
             ax.set_ylabel(y_label)
             ax.legend(loc='best')
 
-            # only print title if a single response is shown
+            # Only print title if a single response is shown
             if i_fit == 1:
                 ax.set_title(f'Response i={i}, j={j}')
 
             return ax
         else:
             raise ValueError(f'The specified component ("{component}") is not valid. Must be in {components}.')
+
+    def plot_abs_err(self, *args, **kwargs) -> Axes:
+        """
+        Plots the absolute error of the fit
+
+        Parameters
+        ----------
+        *args : any, optional
+            Additonal arguments to be passed to :func:`plot`.
+
+        **kwargs : dict, optional
+            Additonal keyword arguments to be passed to :func:`plot`.
+
+        Returns
+        -------
+        :class:`matplotlib.Axes`
+            matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
+            figure.
+
+        Notes
+        -----
+        This simply calls ``plot('abs_err', *args, **kwargs)``.
+        """
+
+        return self.plot('abs_err', *args, **kwargs)
+
+    def plot_rel_err(self, *args, **kwargs) -> Axes:
+       """
+       Plots the relative error of the fit
+
+       Parameters
+       ----------
+       *args : any, optional
+           Additonal arguments to be passed to :func:`plot`.
+
+       **kwargs : dict, optional
+           Additonal keyword arguments to be passed to :func:`plot`.
+
+       Returns
+       -------
+       :class:`matplotlib.Axes`
+           matplotlib axes used for drawing. Either the passed :attr:`ax` argument or the one fetch from the current
+           figure.
+
+       Notes
+       -----
+       This simply calls ``plot('rel_err', *args, **kwargs)``.
+       """
+
+       return self.plot('rel_err', *args, **kwargs)
 
     def plot_s_db(self, *args, **kwargs) -> Axes:
         """
@@ -2156,7 +3380,7 @@ class VectorFitting:
         return self.plot('im', *args, **kwargs)
 
     @axes_kwarg
-    def plot_s_singular(self, freqs: Any = None, *, ax: Axes = None) -> Axes:
+    def plot_s_singular(self, freqs: Any = None, *, ax: Axes = None, i = None, j = None) -> Axes:
         """
         Plots the singular values of the vector fitted S-matrix in linear scale.
 
@@ -2168,6 +3392,9 @@ class VectorFitting:
 
         ax : :class:`matplotlib.Axes` object or None
             matplotlib axes to draw on. If None, the current axes is fetched with :func:`gca()`.
+
+        i, j: integers, required if shared_poles==False. I this case, i and j are the indices
+            for which response the singular values are plotted
 
         Returns
         -------
@@ -2189,15 +3416,33 @@ class VectorFitting:
             else:
                 freqs = self.network.f
 
-        # get system matrices of state-space representation
-        A, B, C, D, E = self._get_ABCDE()
+        if isinstance(self.poles, list):
+            if i is None or j is None:
+                raise ValueError(
+                    'i and j need to be specified if shared_poles==False to select the response')
+            n_ports = self._get_n_ports()
 
+            i_response=i*(n_ports-1)+j
+            poles=self.poles[i_response]
+            residues=self.residues[i_response]
+            constant=self.constant[i_response]
+            proportional=self.proportional[i_response]
+        else:
+            poles=self.poles
+            residues=self.residues
+            constant=self.constant
+            proportional=self.proportional
+
+        # Get system matrices of state-space representation
+        A, B, C, D, E = self._get_ABCDE(poles, residues, constant, proportional)
+
+        # Reset n_ports according to shape of D because for shared_poles==False, n_ports is always 1
         n_ports = np.shape(D)[0]
 
-        # calculate and save singular values for each frequency
+        # Calculate singular values for each frequency
         u, sigma, vh = np.linalg.svd(self._get_s_from_ABCDE(freqs, A, B, C, D, E))
 
-        # plot the frequency response of each singular value
+        # Plot the frequency response of each singular value
         for n in range(n_ports):
             ax.plot(freqs, sigma[:, n], label=fr'$\sigma_{n + 1}$')
         ax.set_xlabel('Frequency (Hz)')
@@ -2208,7 +3453,7 @@ class VectorFitting:
     @axes_kwarg
     def plot_convergence(self, ax: Axes = None) -> Axes:
         """
-        Plots the history of the model residue parameter **d_res** during the iterative pole relocation process of the
+        Plots the history of the model residue parameter **d_tilde** during the iterative pole relocation process of the
         vector fitting, which should eventually converge to a fixed value. Additionally, the relative change of the
         maximum singular value of the coefficient matrix **A** are plotted, which serve as a convergence indicator.
 
@@ -2224,11 +3469,12 @@ class VectorFitting:
             figure.
         """
 
-        ax.semilogy(np.arange(len(self.delta_max_history)) + 1, self.delta_max_history, color='darkblue')
+        ax.semilogy(np.arange(len(self.delta_rel_max_singular_value_A_dense_history)) + 1,
+                    self.delta_rel_max_singular_value_A_dense_history, color='darkblue')
         ax.set_xlabel('Iteration step')
         ax.set_ylabel('Max. relative change', color='darkblue')
         ax2 = ax.twinx()
-        ax2.plot(np.arange(len(self.d_res_history)) + 1, self.d_res_history, color='orangered')
+        ax2.plot(np.arange(len(self.d_tilde_history)) + 1, self.d_tilde_history, color='orangered')
         ax2.set_ylabel('Residue', color='orangered')
         return ax
 
@@ -2386,8 +3632,8 @@ class VectorFitting:
                     # Start with proportional and constant term of the model
                     # H(s) = d + s * e  model
                     # Y(s) = G + s * C  equivalent admittance
-                    g = self.constant_coeff[i_response]
-                    c = self.proportional_coeff[i_response]
+                    g = self.constant[i_response]
+                    c = self.proportional[i_response]
 
                     # R for constant term
                     if g < 0:
@@ -2401,10 +3647,19 @@ class VectorFitting:
                     elif c > 0:
                         f.write(f'C{n + 1}_{j + 1} nt_p_{j + 1} nt_c_{n + 1} {c}\n')
 
+                    # Get residues
+                    residues = np.matrix.flatten(self.residues[i_response])
+
+                    # Get poles
+                    if isinstance(self.poles, list):
+                        poles=self.poles[i_response]
+                    else:
+                        poles=self.poles
+
                     # Transfer admittances represented by poles and residues
-                    for i_pole in range(len(self.poles)):
-                        pole = self.poles[i_pole]
-                        residue = self.residues[i_response, i_pole]
+                    for i_pole in range(len(poles)):
+                        pole = poles[i_pole]
+                        residue = residues[i_pole]
                         node = get_new_subckt_identifier()
 
                         if np.real(residue) < 0.0:


### PR DESCRIPTION
This pull request introduces three new features to the vectorFitting class:

1. Frequency dependent weighting: Every single sample of every response can be weighted in the least squares fit thus, trading off the accuracy between big and small magnitudes. I created an example how to use it in doc/source/examples/vectorfitting/vectorfitting_ex5_weighting.ipynb
2. Multi-SISO-Fitting: The vectorFitting class is now prepared to support different number of poles for one or more responses. The class data structures 'poles', 'residues', 'constant' and 'proportional', that have previously been numpy arrays can now also be python-lists containing numpy arrays. The entire class and all methods support those four data structures to be lists or numpy arrays. The parameter pole_sharing can now be passed to vector_fit and auto_fit. The default is pole_sharing='MIMO', which means the same behavior as before (poles are shared between responses). It is also possible to set pole_sharing='Multi-SISO', which will use a separate set of poles for every response. I am working on also implementing 'Multi-SIMO', which will use a separate set of poles for every input, but common to all outputs. This will come in a future pull request, however. I created an example how to use it in doc/source/examples/vectorfitting/doc/source/examples/vectorfitting/vectorfitting_ex6_shared_poles.ipynb
3. Automatic initial poles estimation from data: Previously, both auto_fit and vector_fit had a fixed number of initial poles, distributed along the frequency axis, which had to be provided by the user. An automatic placement of initial poles is now implemented in a new method called _get_initial_poles(). It scans the responses for the amount of significant ripples and adds complex conjugate pole pairs for each. If the responses have no ripples but are totally smooth, it adds real poles. These choices are suggested in the original Gustavsen vector fitting paper and seem to work well for all the example sNp files in scikit-rf and some more that I tested. 
4.  Memory saver: When fitting larger networks with > 70 ports, I encountered memory problems and thus introduced serialization of the solving of the A_dense matrix in _relocate_poles. This can be enabled via the new argument memory_saver to auto_fit and vector_fit. If memory_saver=False, the system matrix is built for all responses and then solved by numpy. If memory_saver=True, the system matrix is built only for each response, then solved by numby and so on, collecting the way smaller result matrix R22.
5. Model-Summary-Print: After auto_fit and vector_fit, a short summary of the model that contains the number of poles, real poles, complex poles, absolute and relative erros, and model passivity, etc. is printed.
6.  Spurious pole detection improvement: The code in get_spurious is based on an integration of the transfer function L2-Norm of every complex conjugated pole-residue pair. This integral was based on a fixed-spacing-sampling with 101 samples and I observed cases in which this can fail because the responses can be very sharp and might not be covered accurately by those fixed spaced samples. I added a proper intergral using scipy.integrate.quad() which has a more sophisticated numerical integration that is more robust against this. It can happen though, if that it shows a user warning if the responses to be integrated are extremely sharp. The warning is about reduced accuracy of the integral in these cases, which is good, because it indicates potential problems. Still, it will not fail, just warn and try to integrate as good as possible. Also, I changed the spurious pole detection to only consider complex conjugate pole pairs instead of all poles. This is suggested in the corresponding VF adding and skimming (VF-AS) paper and saves a bit of computing time also.
7.  Pole collision avoidance algorithm:  In the VF-AS paper, it is described that new added poles need to keep a minimum distance to already existing poles. If they collide, the new poles will be moved to the best possible position without a collision. This is implemented differently in the previous vectorFitting class. It apparently still works but I nevertheless wrote a new method _add_poles() that implements exactly the procedure that is described in the mentioned paper.
8. Explicit computation of pole candidates for adding after skimming: In the current vectorFitting class, this is implemented in _find_error_bands and in auto_fit. I had a hard time to understand the error band finding code in _find_error_bands because it is pretty dense and has a lot of complexity to make it work in numpy. But actually this code is not "hot" at all, because it operates only on n_freqs samples (200-1000 maybe), so I just wrote it out in plain python, thus making it readable and easy to understand for new readers and also debuggable because you can see what's going on. I moved it into _get_pole_candidates(). Thus keeping error-band related stuff inside of this method, making auto_fit() more concise because it just calls this and gets the new pole candidates.
9. Important fix in the calculation of the RMS error: In get_rms_error(), for every response the RMS errors are summed up to calculate the final RMS error. But we actually need to sum up all mean-squared errors of all responses and then take the square root to get the total RMS error. I corrected this and this will affect all reported RMS errors. They will not be comparable with the RMS errors reported by the current implementation.
10. Initial poles placement and type: The current vectorFitting class has parameters n_poles_init_real and n_poles_init_complex. They are both independently distributed along the frequency axis and this can lead to problems if they are both the same value because then, a real pole and a complex conjugated pole pair will be placed exactly on the same frequency which will lead to an ill conditioned system matrix. In the VF-AS paper it is also warned to avoid this by all means. We could fix that by adding a messy code that avoids collisions moving the poles apart from each other if this problem occurs. But I decided to fix it differently: You can now provide n_poles_init and poles_init_type to auto_fit and vector_fit instead. This is also according to the recommendation of the original Gustavsen paper that states that for smooth responses, real poles should be used only and for non-smooth responses, complex-conjugate pole pairs should be used as initial poles. Specifying a mixture of both is not recommended in the literature even though it could of course, be done. But then we have to find a way to avoid collisions and need to specify where the real poles go and where the complex poles go, making it more complicated. In practical applications, specifying all initial poles as real or all poles as complex conjugate pole pairs is also not a problem because they will be changed one into the other by the vector fitting algorithm in any case, if necessary.
11. Argument and variable naming: I changed the parameter "alpha" and "gamma" in auto_fit to "error_stagnation_threshold" and "spurious_pole_threshold". It's just confusing to forget what gamma and alpha represent and you have to look it up every time. With the new names it's clear instantly without need to look up the documentation.
12. Argument error_target in auto_fit was renamed to "abstol". Abstol is the standard name for the absolute error below which we don't care. It's not a target, but rather a tolerance that represents how much absolute error we are willing to tolerate. 
13. Vector-Fitting pole relocation loop: in vector_fit(), the pole relocation loop used various flags like "stop" and "converged" and "n_iterations" to determine if the loop should stop or not. I had a really hard time to understand what is going on with all of those variables and the many logical combinations of them checked by all kinds of conditionals. I think the whole process can be boiled down to two clean stopping criterions: delta-relative-change-of-singular-values < threshold and n_iteration < max_iterations. If we run into max_iterations, we print the convergence hints. Otherwise we consider it converged. I changed the stopping conditions like this and it seems to work just like in the current version but it is way easier to read and understand. If I missed something maybe we can also change it back to the current code.  I also added a third stopping condition: maximum_error < abstol. This is actually the same stopping condition as used in auto_fit. If we reached the abstol, we can stop. I do it only every 25 iterations because it involves creating the entire model which in turn involves a residue fit. So we maybe don't do it every single iteration.
14. auto_fit and vector_fit are now "high-level" functions dealing with the SISO/MIMO/etc stuff and the actual code is in _auto_fit() and _vector_fit(), which are called by the high level functions multiple times to achieve the siso/mimo/etc. sub-fits.
15. Here and there, I changed a variable name in the implementation to match the corresponding paper's notation. It makes it easier for future contributors to match the code against the literature I hope. I don't remember all of them but they are obvious and hopefully don't add much confusion for those familiar with the current code.
16. Relative Errors: In order to assess the weighted fits, also the relative errors become important. So I added new methods get_total_abs_err, get_total_rel_err, get_abs_err_vs_responses, get_rel_err_vs_responses, get_abs_err and get_rel_err. The existing get_rms_error() reports the get_total_abs_err() value. (but including the bugfix mentioned above)

That was a lot of text, but to make it a bit more exciting, here you can see what the new weighting feature can do:

Normal fit: (bad accuracy for small magnitudes)
![normal-fit](https://github.com/user-attachments/assets/b19a3c50-073f-4ddf-85ec-d7d7e15944ad)

Weighted fit: (balanced the accuracy between small and large magnitudes, sacrificing accuracy at large magnitudes in favor of more accuracy for small magnitudes) 
![weighted-fit](https://github.com/user-attachments/assets/45925abf-f6d2-47cb-b2c2-06d542ffcb5b)

