### PR TITLE
Export NetworkSet with Noise Parameters to valid MDIF

### DIFF
--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -475,7 +475,7 @@ class Mdif:
                 mdif.write("\nBEGIN ACDATA\n")
                 mdif.write(optionstring + "\n")
                 mdif.write("! network name: " + ntwk.name + "\n")
-                data = ntwk.write_touchstone(return_string=True, **kwargs)
+                data = ntwk.write_touchstone(return_string=True, to_mdif=True, **kwargs)
                 mdif.write(data)
                 mdif.write("END\n\n")
 

--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -475,8 +475,17 @@ class Mdif:
                 mdif.write("\nBEGIN ACDATA\n")
                 mdif.write(optionstring + "\n")
                 mdif.write("! network name: " + ntwk.name + "\n")
-                data = ntwk.write_touchstone(return_string=True, to_mdif=True, **kwargs)
+
+                data = ntwk.write_touchstone(return_string=True, write_noise=False, **kwargs)
                 mdif.write(data)
+
+                # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
+                mdif.write("END\n\nBEGIN NDATA\n")
+                mdif.write("%F nfmin n11x n11y rn\n")
+                mdif.write(f"# {ntwk.frequency.unit} S MA R {ntwk.z0[0, 0].real}\n")
+
+                ntwk._write_noisedata(output=mdif)
+
                 mdif.write("END\n\n")
 
     def __eq__(self, other) -> bool:

--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -453,6 +453,7 @@ class Mdif:
                 mdif.write(f"! {c}\n")
 
             nports = ns[0].nports
+            is_noisy = ns[0].noisy
 
             optionstring = Mdif.__create_optionstring(nports)
 
@@ -479,12 +480,12 @@ class Mdif:
                 data = ntwk.write_touchstone(return_string=True, write_noise=False, **kwargs)
                 mdif.write(data)
 
-                # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
-                mdif.write("END\n\nBEGIN NDATA\n")
-                mdif.write("%F nfmin n11x n11y rn\n")
-                mdif.write(f"# {ntwk.frequency.unit} S MA R {ntwk.z0[0, 0].real}\n")
-
-                ntwk._write_noisedata(output=mdif)
+                if is_noisy:
+                    # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
+                    mdif.write("END\n\nBEGIN NDATA\n")
+                    mdif.write("%F nfmin n11x n11y rn\n")
+                    mdif.write(f"# {ntwk.frequency.unit} S MA R {ntwk.z0[0, 0].real}\n")
+                    ntwk._write_noisedata(output=mdif)
 
                 mdif.write("END\n\n")
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2337,7 +2337,7 @@ class Network:
                          format_spec_freq: str = '{}', r_ref: float = None,
                          format_spec_nf_freq: str = '{}', format_spec_nf_min: str = '{}',
                          format_spec_g_opt_mag: str = '{}', format_spec_g_opt_phase: str = '{}',
-                         format_spec_rn: str = '{}') -> str | None:
+                         format_spec_rn: str = '{}', to_mdif: bool = False) -> str | None:
 
         """
         Write a contents of the :class:`Network` to a touchstone file.
@@ -2402,6 +2402,8 @@ class Network:
             Any valid format specifying string as given by
             https://docs.python.org/3/library/string.html#format-string-syntax
             This specifies the formatting in the resulting touchstone file for the noise resistance.
+        to_mdif : bool, optional
+            Write MDIF formatting when exporting noise parameters.
 
         Note
         ----
@@ -2580,7 +2582,16 @@ class Network:
 
                 # write noise data if it exists
                 if ntwk.noisy:
-                    output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
+                    # if this is an MDIF file, format accordingly
+                    if to_mdif:
+                        # this "END" terminates "ACDATA"
+                        output.write("END\n\nBEGIN NDATA\n")
+                        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
+                        output.write("# GHz\tS\tMA\tR\t50\n")
+                        output.write("%F  nfmin n11x n11y rn\n")
+                    else:
+                        # not an MDIF, just a Touchstone file
+                        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
                     new = ntwk.copy()
                     new.resample(ntwk.f_noise) # only write data from original noise freqs
                     for f, nf, g_opt, rn, z0 in zip(new.f_noise.f_scaled, new.nfmin_db, new.g_opt, new.rn, new.z0):

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2587,8 +2587,8 @@ class Network:
                         # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
                         output.write("END\n\nBEGIN NDATA\n")
                         output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
-                        output.write("# GHz\tS\tMA\tR\t50\n")
-                        output.write("%F  nfmin n11x n11y rn\n")
+                        output.write("# GHz S MA R 50\n")
+                        output.write("%F nfmin n11x n11y rn\n")
                     # not an MDIF, just a Touchstone file
                     else:
                         output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2584,13 +2584,13 @@ class Network:
                 if ntwk.noisy:
                     # if this is an MDIF file, format accordingly
                     if to_mdif:
-                        # this "END" terminates "ACDATA"
+                        # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
                         output.write("END\n\nBEGIN NDATA\n")
                         output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
                         output.write("# GHz\tS\tMA\tR\t50\n")
                         output.write("%F  nfmin n11x n11y rn\n")
+                    # not an MDIF, just a Touchstone file
                     else:
-                        # not an MDIF, just a Touchstone file
                         output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
                     new = ntwk.copy()
                     new.resample(ntwk.f_noise) # only write data from original noise freqs

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2587,7 +2587,7 @@ class Network:
                         # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
                         output.write("END\n\nBEGIN NDATA\n")
                         output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
-                        output.write("# GHz S MA R 50\n")
+                        output.write(f"# {ntwk.frequency.unit} S MA R {r_ref.real}\n")
                         output.write("%F nfmin n11x n11y rn\n")
                     # not an MDIF, just a Touchstone file
                     else:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2337,7 +2337,7 @@ class Network:
                          format_spec_freq: str = '{}', r_ref: float = None,
                          format_spec_nf_freq: str = '{}', format_spec_nf_min: str = '{}',
                          format_spec_g_opt_mag: str = '{}', format_spec_g_opt_phase: str = '{}',
-                         format_spec_rn: str = '{}', to_mdif: bool = False) -> str | None:
+                         format_spec_rn: str = '{}', write_noise: bool = True) -> str | None:
 
         """
         Write a contents of the :class:`Network` to a touchstone file.
@@ -2402,8 +2402,8 @@ class Network:
             Any valid format specifying string as given by
             https://docs.python.org/3/library/string.html#format-string-syntax
             This specifies the formatting in the resulting touchstone file for the noise resistance.
-        to_mdif : bool, optional
-            Write MDIF formatting when exporting noise parameters.
+        write_noise : bool, optional
+            Write noise parameters.
 
         Note
         ----
@@ -2581,25 +2581,10 @@ class Network:
                         output.write('\n')
 
                 # write noise data if it exists
-                if ntwk.noisy:
-                    # if this is an MDIF file, format accordingly
-                    if to_mdif:
-                        # this "END" terminates "ACDATA" (s-parameters) and begins noise ("NDATA")
-                        output.write("END\n\nBEGIN NDATA\n")
-                        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
-                        output.write(f"# {ntwk.frequency.unit} S MA R {r_ref.real}\n")
-                        output.write("%F nfmin n11x n11y rn\n")
-                    # not an MDIF, just a Touchstone file
-                    else:
-                        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
-                    new = ntwk.copy()
-                    new.resample(ntwk.f_noise) # only write data from original noise freqs
-                    for f, nf, g_opt, rn, z0 in zip(new.f_noise.f_scaled, new.nfmin_db, new.g_opt, new.rn, new.z0):
-                        output.write(format_spec_nf_freq.format(f) + ' ' \
-                             + format_spec_nf_min.format(nf) + ' ' \
-                             + format_spec_g_opt_mag.format(mf.complex_2_magnitude(g_opt)) + ' ' \
-                             + format_spec_g_opt_phase.format(mf.complex_2_degree(g_opt)) + ' ' \
-                             + format_spec_rn.format(rn/z0[0].real) + ' ' "\n")
+                if ntwk.noisy and write_noise:
+                    self._write_noisedata(output, format_spec_nf_freq, format_spec_nf_min,
+                                          format_spec_g_opt_mag, format_spec_g_opt_phase,
+                                          format_spec_rn)
 
             elif ntwk.number_of_ports == 3:
                 # 3-port is written over 3 lines / matrix order
@@ -2665,6 +2650,22 @@ class Network:
                 to_archive.writestr(filename, output.getvalue())
             elif return_string is True:
                 return output.getvalue()
+
+    def _write_noisedata(self, output, format_spec_nf_freq: str = '{}', format_spec_nf_min: str = '{}',
+                         format_spec_g_opt_mag: str = '{}', format_spec_g_opt_phase: str = '{}',
+                         format_spec_rn: str = '{}'):
+        ntwk = self.copy()
+
+        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
+        new = ntwk.copy()
+        new.resample(ntwk.f_noise) # only write data from original noise freqs
+        for f, nf, g_opt, rn, z0 in zip(new.f_noise.f_scaled, new.nfmin_db, new.g_opt, new.rn, new.z0):
+            output.write(format_spec_nf_freq.format(f) + ' ' \
+                    + format_spec_nf_min.format(nf) + ' ' \
+                    + format_spec_g_opt_mag.format(mf.complex_2_magnitude(g_opt)) + ' ' \
+                    + format_spec_g_opt_phase.format(mf.complex_2_degree(g_opt)) + ' ' \
+                    + format_spec_rn.format(rn/z0[0].real) + ' ' "\n")
+
 
     def write(self, file: str | Path = None, *args, **kwargs) -> None:
         r"""


### PR DESCRIPTION
Exporting a `NetworkSet` with noise parameters to an MDIF file resulted in an invalid MDIF file.

To be specific, the following lines need to be added between the s-parameters and the noise parameters:

```
END

BEGIN NDATA
! Noise Data
! freq	nf_min_db	magGOpt	degGOpt	Rn_eff
# GHz	S	MA	R	50
%F  nfmin n11x n11y rn
```

This is achieved by modifying `Network.write_touchstone()`.

Example of _invalid_ exported MDIF. Notice the missing directives between the s-parameters and noise parameters.
```
!-------------------------------------------------------------------------------
VAR VG = -0.2

BEGIN ACDATA
%F n11x n11y n21x n21y n12x n12y n22x n22y
! network name: Vg -0.20V
! AWR Design Environment (17559) Wed Dec 11 13:28:10 2024
! Document = 'Combined_Large_Sections.AP'
! nPorts: 2, nXvals: 240
!
! Created with skrf (http://scikit-rf.org).
# GHz S RI R 50.0 
!freq ReS11 ImS11 ReS21 ImS21 ReS12 ImS12 ReS22 ImS22
0.5 0.9723395874399081 -0.24447707711727576 0.012664801868822554 0.05419255574994864 -4.043132476300212e-12 1.0216923507091784e-11 0.9692850654456098 -0.2584233213441386
1.0 0.8802510214386609 -0.4709223766439499 0.005209833415019585 0.009677477217569033 -8.78526525639332e-12 1.2619273966031229e-11 0.8743564617439761 -0.49999789902518454
...
119.5 -9.066662584903437 17.11856292912364 1.4238946283205192 -1.3440646228945223 0.0020000582976137556 0.000988455197821118 14.431542940190655 3.600954758969315
120.0 -8.54194086368141 17.549366536249924 0.9532089877748885 -1.5027712740256662 0.0020187189197815193 0.0004885327547758919 15.00068850403278 2.4738267207790514
! Noise Data
! freq	nf_min_db	magGOpt	degGOpt	Rn_eff
0.5 2.3138309999994107 0.9956296900000006 14.174066000000002 478.54002 
1.0 10.269609999988683 0.9960307800000154 28.173379999999998 1684.6619 
...
119.5 0.04451231500026699 0.05145356200000003 -117.80091000000009 2754.8789999999995 
120.0 0.04460254199749647 0.051104351000000006 -115.86644000000004 3582.6842000000006 
END

!-------------------------------------------------------------------------------
VAR VG = -0.25
...
```

Example of an valid exported MDIF:
```
!-------------------------------------------------------------------------------
VAR VG = -0.2

BEGIN ACDATA
%F n11x n11y n21x n21y n12x n12y n22x n22y
! network name: Vg -0.20V
! AWR Design Environment (17559) Wed Dec 11 13:28:10 2024
! Document = 'Combined_Large_Sections.AP'
! nPorts: 2, nXvals: 240
!
! Created with skrf (http://scikit-rf.org).
# GHz S RI R 50.0 
!freq ReS11 ImS11 ReS21 ImS21 ReS12 ImS12 ReS22 ImS22
0.5 0.9723395874399081 -0.24447707711727576 0.012664801868822554 0.05419255574994864 -4.043132476300212e-12 1.0216923507091784e-11 0.9692850654456098 -0.2584233213441386
1.0 0.8802510214386609 -0.4709223766439499 0.005209833415019585 0.009677477217569033 -8.78526525639332e-12 1.2619273966031229e-11 0.8743564617439761 -0.49999789902518454
...
119.5 -9.066662584903437 17.11856292912364 1.4238946283205192 -1.3440646228945223 0.0020000582976137556 0.000988455197821118 14.431542940190655 3.600954758969315
120.0 -8.54194086368141 17.549366536249924 0.9532089877748885 -1.5027712740256662 0.0020187189197815193 0.0004885327547758919 15.00068850403278 2.4738267207790514
END

BEGIN NDATA
! Noise Data
! freq	nf_min_db	magGOpt	degGOpt	Rn_eff
# GHz	S	MA	R	50
%F  nfmin n11x n11y rn
0.5 2.3138309999994107 0.9956296900000006 14.174066000000002 478.54002 
1.0 10.269609999988683 0.9960307800000154 28.173379999999998 1684.6619 
...
119.5 0.04451231500026699 0.05145356200000003 -117.80091000000009 2754.8789999999995 
120.0 0.04460254199749647 0.051104351000000006 -115.86644000000004 3582.6842000000006 
END

!-------------------------------------------------------------------------------
VAR VG = -0.25
...
```

This fix has been validated by exporting an MDIF file with noise parameters from scikit-rf and importing it into Microwave Office. The results from the imported MDIF are compared against the individual Touchstone files:

![image](https://github.com/user-attachments/assets/1e047c59-c0a5-4ef7-9212-a9648389ffb8)

Finally, there is some additional work to be done (not necessarily in this PR):

- [ ]  It would be great if someone could validate that ADS is able to import the MDIF file generated with scikit-rf.
- [ ] `NetworkSet.from_mdif()` fails to import MDIF with noise parameters (see bug https://github.com/scikit-rf/scikit-rf/issues/1239)
- [ ] Once https://github.com/scikit-rf/scikit-rf/issues/1239 is fixed, write some scikit-rf tests to import and export MDIF files with noise parameters.
