### PR TITLE
Vector Fitting: DC point enforcement

### DIFF
--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -74,17 +74,18 @@ class VectorFittingTestCase(unittest.TestCase):
         # rough check on fit quality
         self.assertLess(vf.get_rms_error(), 0.2)
 
-        # evaluate model error at the dc point
+        # evaluate model error at the dc point (real part)
+        # the dc point should always be real (it still often has a tiny imaginary part)
         vf_fit = np.empty(nw.nports ** 2, dtype=complex)
-        abs_errors = np.empty(nw.nports ** 2)
+        abs_real_errors = np.empty(nw.nports ** 2)
 
         for i in range(nw.nports):
             for j in range(nw.nports):
                 vf_ij = vf.get_model_response(i, j, nw.f[0])
                 vf_fit[i * nw.nports + j] = vf_ij
-                abs_errors[i * nw.nports + j] = np.abs(vf_ij - nw.s[0, i, j])
+                abs_real_errors[i * nw.nports + j] = np.abs(np.real(vf_ij - nw.s[0, i, j]))
 
-        self.assertTrue(np.all(abs_errors < 1e-10))
+        self.assertTrue(np.all(abs_real_errors < 1e-10))
 
 
     def test_read_write_npz(self):

--- a/skrf/tests/test_vectorfitting.py
+++ b/skrf/tests/test_vectorfitting.py
@@ -71,7 +71,7 @@ class VectorFittingTestCase(unittest.TestCase):
         vf = skrf.VectorFitting(nw)
         vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
         # quality of the fit is not important in this test; it only needs to finish
-        self.assertLess(vf.get_rms_error(), 0.2)
+        self.assertLess(vf.get_rms_error(), 0.3)
 
     def test_read_write_npz(self):
         # fit ring slot example network
@@ -81,7 +81,7 @@ class VectorFittingTestCase(unittest.TestCase):
         with pytest.warns(UserWarning) as record:
             vf.vector_fit(n_poles_real=3, n_poles_cmplx=0)
 
-        assert len(record) == 1
+        self.assertTrue(len(record) == 1)
 
         # export (write) fitted parameters to .npz file in tmp directory
         with  tempfile.TemporaryDirectory() as name:
@@ -127,12 +127,10 @@ class VectorFittingTestCase(unittest.TestCase):
         vf = skrf.VectorFitting(skrf.data.ring_slot)
         vf.auto_fit()
 
-        assert vf.get_model_order(vf.poles) == 6
-        assert np.sum(vf.poles.imag == 0.0) == 0
-        assert np.sum(vf.poles.imag > 0.0) == 3
-
-        assert np.allclose(vf.get_rms_error(), 1.2748979815157275e-06)
-
+        self.assertTrue(vf.get_model_order(vf.poles) == 6)
+        self.assertTrue(np.sum(vf.poles.imag == 0.0) == 0)
+        self.assertTrue(np.sum(vf.poles.imag > 0.0) == 3)
+        self.assertLess(vf.get_rms_error(), 1e-05)
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(VectorFittingTestCase)

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1706,8 +1706,8 @@ class VectorFitting:
             # stacking order (row-major):
             # s11, s12, s13, ..., s21, s22, s23, ...
             S_viol_stacked = []
-            for i in range(self.network.nports):
-                for j in range(self.network.nports):
+            for i in range(n_ports):
+                for j in range(n_ports):
                     S_viol_stacked.append(S_viol[:, i, j])
             S_viol_stacked = np.array(S_viol_stacked)
 

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -850,6 +850,20 @@ class VectorFitting:
 
         # DC POINT ENFORCEMENT
         if freqs[0] == 0.0:
+            # data contains the dc point; enforce dc point via linear equality constraint:
+            # 1: remove one variable from the solution vector (choice: residue at index 0).
+            # 2: solve remaining linear system (without data at dc) with regular least-squares, as usual. the size of
+            #    the solution vector, the coefficient matrix, and the right-hand side are reduced by 1
+            # 3: calculate the removed variable (residue 0) with the data from the dc point
+            #
+            # linear system: A_fast * x = b
+            # solution vector x contains the unknown residues
+            # right-hand side b contains the frequency response to be fitted, sorted by ascending frequency (dc first)
+            # coefficient matrix A_fast and vector b are split: A_fast = [[A11, A12], [A21, A22]], b = [[b1], [b2]]
+            # [A11, A12] is the first row used later for dc enforcement
+            # A21 is a column vector, which is not required anymore
+            # A22 is the rest of the matrix for usual least-squares fitting
+
             A11 = A_fast[0, 0]
             A12 = A_fast[0, 1:]
             A22 = A_fast[1:, 1:]
@@ -988,9 +1002,9 @@ class VectorFitting:
         # DC POINT ENFORCEMENT
         if freqs[0] == 0.0:
             # data contains the dc point; enforce dc point via linear equality constraint:
-            # 1: remove any one variable from the solution vector (choice: residue at index 0)
-            # 2: solve remaining linear system (without data at dc) with regular least-squares
-            #    the size of the solution vector, the coefficient matrix, and the right-hand side are reduced by 1
+            # 1: remove one variable from the solution vector (choice: residue at index 0).
+            # 2: solve remaining linear system (without data at dc) with regular least-squares, as usual. the size of
+            #    the solution vector, the coefficient matrix, and the right-hand side are reduced by 1
             # 3: calculate the removed variable (residue 0) with the data from the dc point
             #
             # linear system: A * x = b
@@ -999,7 +1013,7 @@ class VectorFitting:
             # coefficient matrix A and vector b are split: A = [[A11, A12], [A21, A22]], b = [[b1], [b2]]
             # [A11, A12] is the first row used later for dc enforcement
             # A21 is a column vector, which is not required anymore
-            # A22 is the rest of the matrix
+            # A22 is the rest of the matrix for usual least-squares fitting
 
             A11 = A[0, 0]
             A12 = A[0, 1:]

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -421,7 +421,7 @@ class VectorFitting:
             Threshold for the detection of spurious poles.
 
         nu_samples: float, optional
-            Required and enforced (relative) spacing in termins of frequency samples between existing poles and
+            Required and enforced (relative) spacing in terms of frequency samples between existing poles and
             relocated or added poles. The number can be a float, it does not have to be an integer.
 
         parameter_type: str, optional

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1603,22 +1603,6 @@ class VectorFitting:
         A, B, C, D, E = self._get_ABCDE()
         dim_A = np.shape(A)[0]
 
-        # predefined tolerance parameter (users should not need to change this)
-        delta_threshold = 0.999
-
-        if self.network is not None:
-            # find highest singular value among all frequencies and responses to use as target for the perturbation
-            # singular value decomposition
-            sigma = np.linalg.svd(self.network.s, compute_uv=False)
-            sigma_max = np.amax(sigma)
-            if sigma_max > delta_threshold:
-                delta = delta_threshold
-            else:
-                delta = sigma_max
-        else:
-            sigma_max = 1.1     # just > 1, so that enforcement loop is entered
-            delta = delta_threshold
-
         # ASYMPTOTIC PASSIVITY ENFORCEMENT
 
         # check if constant term has been fitted (not zero)
@@ -1681,6 +1665,10 @@ class VectorFitting:
         n_ports = np.shape(C_viol)[0]
         model_order = self.get_model_order(self.poles)
 
+        # predefined tolerance parameter (users should not need to change this)
+        delta_threshold = 0.999
+        sigma_max = 1.1     # just to enter iteration loop for the first time
+
         # iterative compensation of passivity violations
         t = 0
         self.history_max_sigma = []
@@ -1700,6 +1688,11 @@ class VectorFitting:
             # keep track of the greatest singular value in every iteration step
             sigma_max = np.amax(sigma)
             self.history_max_sigma.append(sigma_max)
+
+            if sigma_max > delta_threshold:
+                delta = delta_threshold
+            else:
+                delta = sigma_max
 
             # find and perturb singular values that cause passivity violations
             # sigma_viol = sigma * upsilon - psi with

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -994,9 +994,11 @@ class VectorFitting:
             # solve least squares and obtain results as stack of real part vector and imaginary part vector
             x2, residuals, rank, singular_vals = np.linalg.lstsq(A22, b2.T, rcond=None)
 
+            # solve for x1
             x1 = 1 / A11 * (b1 - np.dot(A12, x2))
-            x = np.vstack((x1, x2))
 
+            # reassemble x from x1 and x2
+            x = np.vstack((x1, x2))
         else:
             # dc point not included; use and solve the entire linear system with least-squares
             logger.info(f'Condition number of coefficient matrix = {int(np.linalg.cond(A_ri))}')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -957,12 +957,48 @@ class VectorFitting:
         A[:, idx_constant] = 1
         A[:, idx_proportional] = s[:, None]
 
-        logger.info(f'Condition number of coefficient matrix = {int(np.linalg.cond(A))}')
+        # DC POINT ENFORCEMENT
+        if freqs[0] == 0.0:
+            # data contains the dc point; enforce dc point via linear equality constraint:
+            # 1: remove any one variable from the solution vector (choice: residue at index 0)
+            # 2: solve remaining linear system (without data at dc) with regular least-squares
+            #    the size of the solution vector, the coefficient matrix, and the right-hand side are reduced by 1
+            # 3: calculate the removed variable (residue 0) with the data from the dc point
+            #
+            # linear system: A * x = b
+            # solution vector x contains the unknown residues
+            # right-hand side b contains the frequency response to be fitted, sorted by ascending frequency (dc first)
+            # coefficient matrix A and vector b are split: A = [[A11, A12], [A21, A22]], b = [[b1], [b2]]
+            # [A11, A12] is the first row used later for dc enforcement
+            # A21 is a column vector, which is not required anymore
+            # A22 is the rest of the matrix
 
-        # solve least squares and obtain results as stack of real part vector and imaginary part vector
-        x, residuals, rank, singular_vals = np.linalg.lstsq(np.vstack((A.real, A.imag)),
-                                                            np.hstack((freq_responses.real, freq_responses.imag)).T,
-                                                            rcond=None)
+            A11 = A[0, 0]
+            A12 = A[0, 1:]
+            A22 = A[1:, 1:]
+            b1 = freq_responses[:, 0]
+            b2 = freq_responses[:, 1:]
+
+            A_lstsq = np.vstack((A22.real, A22.imag))
+            b_lstsq = np.hstack((b2.real, b2.imag)).T
+
+            logger.info(f'Condition number of coefficient matrix = {int(np.linalg.cond(A_lstsq))}')
+
+            # solve least squares and obtain results as stack of real part vector and imaginary part vector
+            x2, residuals, rank, singular_vals = np.linalg.lstsq(A_lstsq, b_lstsq, rcond=None)
+
+            x1 = 1 / A11 * (b1 - np.dot(A12, x2))
+            x = np.vstack((x1, x2))
+
+        else:
+            # dc point not included; use and solve the entire linear system with least-squares
+            A_lstsq = np.vstack((A.real, A.imag))
+            b_lstsq = np.hstack((freq_responses.real, freq_responses.imag)).T
+
+            logger.info(f'Condition number of coefficient matrix = {int(np.linalg.cond(A_lstsq))}')
+
+            # solve least squares and obtain results as stack of real part vector and imaginary part vector
+            x, residuals, rank, singular_vals = np.linalg.lstsq(A_lstsq, b_lstsq, rcond=None)
 
         # extract residues from solution vector and align them with poles to get matching pole-residue pairs
         residues = np.empty((len(freq_responses), len(poles)), dtype=complex)


### PR DESCRIPTION
This PR adds a new feature to the vector fitting functions to enforce the dc point in the solution, if provided in the data.
The enforcement is realized using linear equality constraints ~~in the pole relocation and~~ in the residue fitting routine. 

In the vector fitting book (S. Grivet-Talocia, B. Gustavsen, "Passive Macromodeling", Wiley 2016), this method is described in a very general way. I adopted and simplified it, because most of it does not seem to be required if only the dc point is to be enforced. In general, all sorts of frequency samples could be enforced in the solution.

As always, everything comes at a price. In case of dc point enforcement, we pay with accuracy in the remaining fit. The difference is not huge, but it's there. However, the fit of the dc point is nearly perfect, as desired. In case of the automatic fitting with `auto_fit()` the model order can also be slightly greater.

Currently, I have not added an argument to the fitting functions to turn dc point enforcement on or off. Instead, it's always enforced if the dc point is sampled in the data. I can't think of a use case where someone would not want this, but who knows?. Any other opinions on this?

Here is a comparison with the current code (branch _master_) and the new code using dc point enforcement (branch _vf_dc_) for a large 18-port network (324 frequency responses).

- _master_ using `auto_fit()`: `dc error magnitude < 1e-5`
- _vf_dc_ using `auto_fit()`: `dc error magnitude < 3e-15`

![Via_array_impedance_dc-error_master](https://github.com/user-attachments/assets/fb509f22-ebd9-4086-bdb9-67e50d27dc6f)
![Via_array_impedance_dc-error_vf_dc](https://github.com/user-attachments/assets/37cefacc-f4ed-4148-95cc-af0d3e6bdaee)


