### PR TITLE
Vector Fitting: State-space topology for equivalent circuits

### DIFF
--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2574,15 +2574,18 @@ class VectorFitting:
                     d = self.constant_coeff[idx_S_i_j]
                     # e = self.proportional_coeff[idx_S_i_j]    # E is currently ignored
 
-                    # VCCS and CCCS adding their currents to represent the incident wave a_j
-                    gain_vccs_a_j = 1 / 2 / np.sqrt(z0_j)
-                    gain_cccs_a_j = np.sqrt(z0_j) / 2
+                    if d != 0.0:
+                        # avoid zero-valued coefficients (in case of fit_constant=False)
 
-                    # input a_j is scaled by constant term d_i_j and by current gain for b_i
-                    g_ij = gain_b_i * d * gain_vccs_a_j
-                    f_ij = gain_b_i * d * gain_cccs_a_j
-                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g_ij}\n')
-                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f_ij}\n')
+                        # VCCS and CCCS adding their currents to represent the incident wave a_j
+                        gain_vccs_a_j = 1 / 2 / np.sqrt(z0_j)
+                        gain_cccs_a_j = np.sqrt(z0_j) / 2
+
+                        # input a_j is scaled by constant term d_i_j and by current gain for b_i
+                        g_ij = gain_b_i * d * gain_vccs_a_j
+                        f_ij = gain_b_i * d * gain_cccs_a_j
+                        f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g_ij}\n')
+                        f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f_ij}\n')
 
                     # each residue rk_i_j at port i is multiplied by its respective state signal xk_j
                     for k in range(len(self.poles)):

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2543,9 +2543,9 @@ class VectorFitting:
                         f.write(f'Gd{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g_ij}\n')
                         f.write(f'Fd{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f_ij}\n')
 
-                    if e != 0.0:
+                    if build_e and e != 0.0:
                         # avoid zero-valued coefficients (in case of fit_proportional=False)
-                        # proportional coefficients require an extra node for the differentiation using a capacitor
+                        # proportional coefficients require an extra node for the differentiation using an inductor
                         # [Y(s) ~ s * E * U(s)]
 
                         # differentiated input a_j is scaled by proportional term e_i_j and by current gain for b_i
@@ -2605,6 +2605,7 @@ class VectorFitting:
                         f.write(f'Gp{k + 1}_im_re_a{i + 1} 0 {xk_im_i} {xk_re_i} 0 {-1 * pole_im}\n')
                         f.write(f'Rp{k + 1}_im_im_a{i + 1} 0 {xk_im_i} {-1 / pole_re}\n')
 
+                # create differentiation network for this port i (input variable u = a_i)
                 if build_e:
                     f.write('*\n')
                     f.write(f'* Network with derivative of input a_{i + 1} for proportional term\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2533,6 +2533,7 @@ class VectorFitting:
                         # Complex pole of a conjugate pair; represented by two states
                         # real part at x_{k + 1}_re_{i + 1}, input a_i is scaled by b = 2
                         xk_re_i = f'x{k + 1}_re_{i + 1}'
+                        xk_im_i = f'x{k + 1}_im_{i + 1}'
                         gp_re = np.real(pole)
                         gp_im = np.imag(pole)
                         f.write(f'C{k + 1}_re_{i + 1} {xk_re_i} 0 1.0\n')
@@ -2542,7 +2543,6 @@ class VectorFitting:
                         f.write(f'Gp_{k + 1}_re_im_{i + 1} 0 {xk_re_i} {xk_im_i} 0 {gp_im}\n')
 
                         # imaginary part at x_{k + 1}_im_{i + 1}, input a_i is inactive (b = 0)
-                        xk_im_i = f'x{k + 1}_im_{i + 1}'
                         f.write(f'C{k + 1}_im_{i + 1} {xk_im_i} 0 1.0\n')
                         f.write(f'Gp_{k + 1}_im_re_{i + 1} 0 {xk_im_i} {xk_re_i} 0 {-1 * gp_im}\n')
                         f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 {xk_im_i} {xk_im_i} 0 {gp_re}\n')
@@ -2572,10 +2572,10 @@ class VectorFitting:
                     gain_cccs_a_j = np.sqrt(z0_j) / 2
 
                     # input a_j is scaled by constant term d_i_j and by current gain for b_i
-                    g = gain_b_i * d * gain_vccs_a_j
-                    f = gain_b_i * d * gain_cccs_a_j
-                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g}\n')
-                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f}\n')
+                    g_ij = gain_b_i * d * gain_vccs_a_j
+                    f_ij = gain_b_i * d * gain_cccs_a_j
+                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g_ij}\n')
+                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f_ij}\n')
 
                     # each residue rk_i_j at port i is multiplied by its respective state signal xk_j
                     for k in range(len(self.poles)):

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2623,7 +2623,7 @@ class VectorFitting:
                     f.write('*\n')
                     f.write(f'* Network with derivative of input a_{i + 1} for proportional term\n')
                     # voltage on node 'e{i + 1}' to gnd (0) represents time-derivative of input a_i for terms e_j_i
-                    f.write(f'Le{i + 1} e{i + 1} 0 1.0\n')  # 1H capacitor makes math easy
+                    f.write(f'Le{i + 1} e{i + 1} 0 1.0\n')  # 1H inductor makes math easy
                     f.write(f'Ge{i + 1} 0 e{i + 1} p{i + 1} {node_ref_i} {gain_vccs_a_i}\n')
                     f.write(f'Fe{i + 1} 0 e{i + 1} V{i + 1} {gain_cccs_a_i}\n')
 

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2343,195 +2343,89 @@ class VectorFitting:
                 gain_vccs_a_i = 1 / 2 / np.sqrt(z0_i)
                 gain_cccs_a_i = np.sqrt(z0_i) / 2
 
+                # transfer gain of the controlled current source representing the reflected power wave b_i at port i
+                #
+                # the gain values result from the definition of the reflected power wave:
+                # b_i = 1 / 2 / sqrt(Z0_i) * (V_i - Z0_i * I_i)
+                #
+                # depending on the circuit topology used for the equivalent port network, this can be implemented
+                # with either controlled current and/or controlled voltage sources. in case of the Norton current
+                # source used in this implementation, the reflected power wave relates to the source current as:
+                # b_i = sqrt(Z0_i) / 2 * I_b_i <==> I_b_i = 2 / sqrt(Z0_i) * b_i
+                gain_b_i = 2 / np.sqrt(z0_i)
+
                 # dummy voltage source (v = 0) for port current sensing (I_i)
                 f.write(f'V{i + 1} p{i + 1} s{i + 1} 0\n')
 
                 # Port reference impedance Z0_i
                 f.write(f'R{i + 1} s{i + 1} {node_ref_i} {z0_i}\n')
 
-                # total node count in the series connections for transfer networks
-                n_nodes_total = self.network.nports * (
-                        len(np.nonzero([self.constant_coeff[0], self.proportional_coeff[0]])[0]) + len(self.poles))
+                # create state networks driven by a_i
+                for k in range(len(self.poles)):
+                    pole = self.poles[k]
 
-                if n_nodes_total == 0:
-                    break
+                    # Transfer of input (a_i) to state networks (node xk_i)
+                    if np.imag(pole) == 0.0:
+                        # Real pole; represented by one state, input a_i is scaled by b = 1
+                        f.write(f'C{k + 1}_{i + 1} x{k + 1}_{i + 1} 0 1.0\n')
+                        f.write(f'Ga_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} p{i + 1} {node_ref_i} {1 * gain_vccs_a_i}\n')
+                        f.write(f'Fa_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} V{i + 1} {1 * gain_cccs_a_i}\n')
+                        f.write(f'Gp_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} x{k + 1}_{i + 1} 0 {np.real(pole)}\n')
+                    else:
+                        # Complex pole of a conjugate pair; represented by two states
+                        # real part at x_{k + 1}_re_{i + 1}, input a_i is scaled by b = 2
+                        f.write(f'C{k + 1}_re_{i + 1} x{k + 1}_re_{i + 1} 0 1.0\n')
+                        f.write(f'Ga_{k + 1}_re_{i + 1} 0 x{k + 1}_re_{i + 1} p{i + 1} {node_ref_i} {2 * gain_vccs_a_i}\n')
+                        f.write(f'Fa_{k + 1}_re_{i + 1} 0 x{k + 1}_re_{i + 1} V{i + 1} {2 * gain_cccs_a_i}\n')
+                        f.write(f'Gp_{k + 1}_re_re_{i + 1} 0 x{k + 1}_re_{i + 1} x{k + 1}_re_{i + 1} 0 {np.real(pole)}\n')
+                        f.write(f'Gp_{k + 1}_re_im_{i + 1} 0 x{k + 1}_re_{i + 1} x{k + 1}_im_{i + 1} 0 {np.imag(pole)}\n')
 
-                # prepare first node
-                n_current = 0
-                node_pos = f'n_{i + 1}_{n_current}'
+                        # imaginary part at x_{k + 1}_im_{i + 1}, input a_i is inactive (b = 0)
+                        f.write(f'C{k + 1}_im_{i + 1} x{k + 1}_im_{i + 1} 0 1.0\n')
+                        f.write(f'Gp_{k + 1}_im_re_{i + 1} 0 x{k + 1}_im_{i + 1} x{k + 1}_re_{i + 1} 0 {-1 * np.imag(pole)}\n')
+                        f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 x{k + 1}_im_{i + 1} x{k + 1}_im_{i + 1} 0 {np.real(pole)}\n')
 
-                # VCCS and CCCS adding their currents to represent the incident wave a_i
-                # I_a_i = U_i / 2 / sqrt(Z0_i) + sqrt(Z0_i) / 2 * I_i
-                f.write(f'Ga{i + 1} 0 {node_pos} p{i + 1} {node_ref_i} {gain_vccs_a_i}\n')
-                f.write(f'Fa{i + 1} 0 {node_pos} V{i + 1} {gain_cccs_a_i}\n')
-
+                # transfer of states and inputs from port j to port i
                 for j in range(self.network.nports):
-                    # transfer impedances connected in series to current sources representing a_i
-                    # the voltages across the individual impedances represents fragments of S_j_i
-                    # k is the index for the pole/residue pairs or the constant and proportional terms
-                    # I_a_i ~ a_i
-                    # Z_j_i_k ~ S_j_i_k
-                    # U_j_i_k ~ b_j_k
-                    f.write('*\n')
-                    f.write(f'* Transfer from port {i + 1} to port {j + 1}\n')
-
-                    # reference impedance (real, i.e. resistance) of port i
-                    z0_j = np.real(self.network.z0[0, j])
-
-                    # transfer gain of the controlled current source representing the reflected power wave b_i at port i
-                    #
-                    # the gain values result from the definition of the reflected power wave:
-                    # b_i = 1 / 2 / sqrt(Z0_i) * (V_i - Z0_i * I_i)
-                    #
-                    # depending on the circuit topology used for the equivalent port network, this can be implemented
-                    # with either controlled current and/or controlled voltage sources. in case of the Norton current
-                    # source used in this implementation, the reflected power wave relates to the source current as:
-                    # b_i = sqrt(Z0_i) / 2 * I_b_i <==> I_b_i = 2 / sqrt(Z0_i) * b_i
-                    gain_vccs_b_j = 2 / np.sqrt(z0_j)
-
                     if create_reference_pins:
                         node_ref_j = f'p{j + 1}_ref'
                     else:
                         node_ref_j = '0'
 
+                    # reference impedance (real, i.e. resistance) of port i
+                    z0_j = np.real(self.network.z0[0, j])
+
                     # Stacking order in VectorFitting class variables:
                     # s11, s12, s13, ..., s21, s22, s23, ...
-                    # idx_S_i_j = i * self.network.nports + j
-                    idx_S_j_i = j * self.network.nports + i
+                    idx_S_i_j = i * self.network.nports + j
 
                     # Start with proportional and constant term of the model
                     # H(s) = d + s * e  model
                     # Z(s) = R + s * L  equivalent impedance
-                    d = self.constant_coeff[idx_S_j_i]
-                    e = self.proportional_coeff[idx_S_j_i]
+                    d = self.constant_coeff[idx_S_i_j]
+                    e = self.proportional_coeff[idx_S_i_j]
 
-                    # prepare nodes for first impedance
-                    n_nodes_remaining = n_nodes_total - n_current
-                    if n_nodes_remaining == 1:
-                        node_neg = '0'
-                    else:
-                        node_neg = f'n_{i + 1}_{n_current + 1}'
+                    # VCCS and CCCS adding their currents to represent the incident wave a_j
+                    gain_vccs_a_j = 1 / 2 / np.sqrt(z0_j)
+                    gain_cccs_a_j = np.sqrt(z0_j) / 2
 
-                    # R for constant term
-                    if d != 0.0:
-                        # calculated resistence can be negative, but implementation must use positive values
-                        # R = |d|
-                        f.write(f'R{j + 1}_{i + 1} {node_pos} {node_neg} {np.abs(d)}\n')
+                    # input a_j is scaled by constant term d_i_j and by current gain for b_i
+                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {gain_b_i * d * gain_vccs_a_j}\n')
+                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {gain_b_i * d * gain_cccs_a_j}\n')
 
-                        # correction of the sign inversion by flipping the polarity of the control voltage for the VCCS
-                        # transferring the voltage across L to port j
-                        if d < 0:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_neg} {node_pos} '
-                                    f'{gain_vccs_b_j}\n')
-                        else:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_pos} {node_neg} '
-                                    f'{gain_vccs_b_j}\n')
-
-                        # prepare nodes for next impedance
-                        n_current += 1
-                        node_pos = f'n_{i + 1}_{n_current}'
-                        n_nodes_remaining = n_nodes_total - n_current
-                        if n_nodes_remaining == 1:
-                            node_neg = '0'
-                        else:
-                            node_neg = f'n_{i + 1}_{n_current + 1}'
-
-                    # L for proportional term
-                    if e != 0.0:
-                        # calculated inductance can be negative, but implementation must use positive values
-                        # L = |e|
-                        f.write(f'L{j + 1}_{i + 1} {node_pos} {node_neg} {np.abs(e)}\n')
-
-                        # correction of the sign inversion by flipping the polarity of the control voltage for the VCCS
-                        # transferring the voltage across L to port j
-                        if e < 0:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_neg} {node_pos} '
-                                    f'{gain_vccs_b_j}\n')
-                        else:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_pos} {node_neg} '
-                                    f'{gain_vccs_b_j}\n')
-
-                        # prepare nodes for next impedance
-                        n_current += 1
-                        node_pos = f'n_{i + 1}_{n_current}'
-                        n_nodes_remaining = n_nodes_total - n_current
-                        if n_nodes_remaining == 1:
-                            node_neg = '0'
-                        else:
-                            node_neg = f'n_{i + 1}_{n_current + 1}'
-
-                    # Transfer impedances represented by poles and residues
+                    # each residue rk_i_j at port i is multiplied by its respective state signal xk_j
                     for k in range(len(self.poles)):
                         pole = self.poles[k]
-                        residue = self.residues[idx_S_j_i, k]
+                        residue = self.residues[idx_S_i_j, k]
 
-                        # calculated component values can be negative, but implementation must use positive values.
-                        # the sign of the residue can be inverted, but then the inversion must be compensated by
-                        # flipping the polarity of the VCCS control voltage for transfer of U_j_i_k to port j.
-                        if np.real(residue) < 0.0:
-                            # residue multiplication with -1 required
-                            residue = -1 * residue
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_neg} {node_pos} '
-                                    f'{gain_vccs_b_j}\n')
-                        else:
-                            f.write(f'Gb{j + 1}_{i + 1}_{n_current} {node_ref_j} s{j + 1} {node_pos} {node_neg} '
-                                    f'{gain_vccs_b_j}\n')
-
-                        # impedance representing S_j_i_k
                         if np.imag(pole) == 0.0:
-                            # Real pole; Add parallel RC network via `rc_passive`
-                            c = 1 / np.real(residue)
-                            r = -1 * np.real(residue) / np.real(pole)
-                            f.write(f'X{j + 1}_{i + 1}_{n_current} {node_pos} {node_neg} rc_passive res={r} cap={c}\n')
+                            # Real pole/residue pair; represented by one state
+                            f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_{j + 1} 0 {np.real(residue)}\n')
                         else:
-                            # Complex pole of a conjugate pair; Add active or passive RCL network via `rcl_active`
-                            x1 = np.real(residue) * np.real(pole)
-                            x2 = np.imag(residue) * np.imag(pole)
-                            c = 1 / (2 * np.real(residue))
-                            l = 2 * np.real(residue) / ((np.imag(pole)) ** 2 + (x2 / np.real(residue)) ** 2)
-                            r1 = -2 * (x1 + x2) / ((np.imag(pole)) ** 2 + (x2 / np.real(residue)) ** 2)
-                            r2 = (2 * np.real(residue)) ** 2 / (-2 * (x1 - x2))
-                            if r1 < 0:
-                                # calculated r1 is negative; this gets compensated with the transconductance gt1
-                                gt1 = 2 / np.abs(r1)
-                            else:
-                                # transconductance gt1 not required
-                                gt1 = 0.0
-                            if r2 < 0:
-                                # calculated r2 is negative; this gets compensated with the transconductance gt2
-                                gt2 = 2 / np.abs(r2)
-                            else:
-                                # transconductance gt2 not required
-                                gt2 = 0.0
-                            f.write(f'X{j + 1}_{i + 1}_{n_current} {node_pos} {node_neg} rcl_active '
-                                    f'cap={c} ind={l} res1={np.abs(r1)} res2={np.abs(r2)} gt1={gt1} gt2={gt2}\n')
-
-                        # prepare nodes for next impedance
-                        n_current += 1
-                        node_pos = f'n_{i + 1}_{n_current}'
-                        n_nodes_remaining = n_nodes_total - n_current
-                        if n_nodes_remaining == 1:
-                            node_neg = '0'
-                        else:
-                            node_neg = f'n_{i + 1}_{n_current + 1}'
+                            # Complex-conjugate pole/residue pair; represented by two states
+                            # real part at x_{k + 1}_re_{i + 1}
+                            # imaginary part at x_{k + 1}_im_{i + 1}
+                            f.write(f'Gr_{k + 1}_re_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_re_{j + 1} 0 {np.real(residue)}\n')
+                            f.write(f'Gr_{k + 1}_im_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_im_{j + 1} 0 {np.imag(residue)}\n')
 
             f.write(f'.ENDS {fitted_model_name}\n')
-            f.write('*\n')
-
-            # Subcircuit for an RCL equivalent impedance of a complex-conjugate pole-residue pair
-            f.write('.SUBCKT rcl_active 1 2 cap=1e-9 ind=100e-12 res1=1e3 res2=1e3 gt1=2e-3 gt2=2e-3\n')
-            f.write('L1 1 3 {ind}\n')
-            f.write('R1 3 2 {res1}\n')
-            f.write('G1 2 3 3 2 {gt1}\n')
-            f.write('C1 1 2 {cap}\n')
-            f.write('R2 1 2 {res2}\n')
-            f.write('G2 2 1 1 2 {gt2}\n')
-            f.write('.ENDS rcl_active\n')
-
-            f.write('*\n')
-
-            # Subcircuit for an RC equivalent impedance of a real pole-residue pair
-            f.write('.SUBCKT rc_passive 1 2 res=1e3 cap=1e-9\n')
-            f.write('C1 1 2 {cap}\n')
-            f.write('R1 1 2 {res}\n')
-            f.write('.ENDS rc_passive\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2528,7 +2528,8 @@ class VectorFitting:
                         f.write(f'C{k + 1}_{i + 1} {xki} 0 1.0\n')
                         f.write(f'Ga_{k + 1}_{i + 1} 0 {xki} p{i + 1} {node_ref_i} {1 * gain_vccs_a_i}\n')
                         f.write(f'Fa_{k + 1}_{i + 1} 0 {xki} V{i + 1} {1 * gain_cccs_a_i}\n')
-                        f.write(f'Gp_{k + 1}_{i + 1} 0 {xki} {xki} 0 {gp}\n')
+                        # f.write(f'Gp_{k + 1}_{i + 1} 0 {xki} {xki} 0 {gp}\n')  # problem for LTspice
+                        f.write(f'Rp_{k + 1}_{i + 1} 0 {xki} {1 / gp}\n')   # dc path to gnd for LTspice
                     else:
                         # Complex pole of a conjugate pair; represented by two states
                         # real part at x_{k + 1}_re_{i + 1}, input a_i is scaled by b = 2
@@ -2539,13 +2540,15 @@ class VectorFitting:
                         f.write(f'C{k + 1}_re_{i + 1} {xk_re_i} 0 1.0\n')
                         f.write(f'Ga_{k + 1}_re_{i + 1} 0 {xk_re_i} p{i + 1} {node_ref_i} {2 * gain_vccs_a_i}\n')
                         f.write(f'Fa_{k + 1}_re_{i + 1} 0 {xk_re_i} V{i + 1} {2 * gain_cccs_a_i}\n')
-                        f.write(f'Gp_{k + 1}_re_re_{i + 1} 0 {xk_re_i} {xk_re_i} 0 {gp_re}\n')
+                        # f.write(f'Gp_{k + 1}_re_re_{i + 1} 0 {xk_re_i} {xk_re_i} 0 {gp_re}\n')  # problem for LTspice
+                        f.write(f'Rp_{k + 1}_re_re_{i + 1} 0 {xk_re_i} {1 / gp_re}\n')  # dc path to gnd for LTspice
                         f.write(f'Gp_{k + 1}_re_im_{i + 1} 0 {xk_re_i} {xk_im_i} 0 {gp_im}\n')
 
                         # imaginary part at x_{k + 1}_im_{i + 1}, input a_i is inactive (b = 0)
                         f.write(f'C{k + 1}_im_{i + 1} {xk_im_i} 0 1.0\n')
                         f.write(f'Gp_{k + 1}_im_re_{i + 1} 0 {xk_im_i} {xk_re_i} 0 {-1 * gp_im}\n')
-                        f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 {xk_im_i} {xk_im_i} 0 {gp_re}\n')
+                        # f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 {xk_im_i} {xk_im_i} 0 {gp_re}\n')  # problem for LTspice
+                        f.write(f'Rp_{k + 1}_im_im_{i + 1} 0 {xk_im_i} {1 / gp_re}\n')  # dc path to gnd for LTspice
 
                 # transfer of states and inputs from port j to port i
                 for j in range(self.network.nports):

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2415,7 +2415,7 @@ class VectorFitting:
     def write_spice_subcircuit_s(self, file: str, fitted_model_name: str = "s_equivalent",
                                      create_reference_pins: bool = False, g_min: float = 1e-12) -> None:
         """
-        Creates an equivalent N-port subcircuit based on its vector fitted S parameter responses
+        Creates an equivalent N-port subcircuit based on its vector fitted scattering (S) parameter responses
         in spice simulator netlist syntax (compatible with LTspice, ngspice, Xyce, ...). The circuit synthesis is based
         on a direct implementation of the state-space representation of the vector fitted model [#vf-book]_.
 
@@ -2462,6 +2462,11 @@ class VectorFitting:
             doi: https://doi.org/10.1002/9781119140931
 
         """
+
+        if np.any(self.proportional_coeff):
+            raise NotImplementedError('The SPICE equivalent circuit synthesis currently only works models without the '
+                                      'proportional terms. For scattering parameters, it is usually best not to use '
+                                      'them in the vector fit (specify `vector_fit(..., fit_proportional=False)`).')
 
         with open(file, 'w') as f:
             # write title line

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2523,23 +2523,29 @@ class VectorFitting:
                     # Transfer of input (a_i) to state networks (node xk_i)
                     if np.imag(pole) == 0.0:
                         # Real pole; represented by one state, input a_i is scaled by b = 1
-                        f.write(f'C{k + 1}_{i + 1} x{k + 1}_{i + 1} 0 1.0\n')
-                        f.write(f'Ga_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} p{i + 1} {node_ref_i} {1 * gain_vccs_a_i}\n')
-                        f.write(f'Fa_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} V{i + 1} {1 * gain_cccs_a_i}\n')
-                        f.write(f'Gp_{k + 1}_{i + 1} 0 x{k + 1}_{i + 1} x{k + 1}_{i + 1} 0 {np.real(pole)}\n')
+                        xki = f'x{k + 1}_{i + 1}'
+                        gp = np.real(pole)
+                        f.write(f'C{k + 1}_{i + 1} {xki} 0 1.0\n')
+                        f.write(f'Ga_{k + 1}_{i + 1} 0 {xki} p{i + 1} {node_ref_i} {1 * gain_vccs_a_i}\n')
+                        f.write(f'Fa_{k + 1}_{i + 1} 0 {xki} V{i + 1} {1 * gain_cccs_a_i}\n')
+                        f.write(f'Gp_{k + 1}_{i + 1} 0 {xki} x{k + 1}_{i + 1} 0 {gp}\n')
                     else:
                         # Complex pole of a conjugate pair; represented by two states
                         # real part at x_{k + 1}_re_{i + 1}, input a_i is scaled by b = 2
-                        f.write(f'C{k + 1}_re_{i + 1} x{k + 1}_re_{i + 1} 0 1.0\n')
-                        f.write(f'Ga_{k + 1}_re_{i + 1} 0 x{k + 1}_re_{i + 1} p{i + 1} {node_ref_i} {2 * gain_vccs_a_i}\n')
-                        f.write(f'Fa_{k + 1}_re_{i + 1} 0 x{k + 1}_re_{i + 1} V{i + 1} {2 * gain_cccs_a_i}\n')
-                        f.write(f'Gp_{k + 1}_re_re_{i + 1} 0 x{k + 1}_re_{i + 1} x{k + 1}_re_{i + 1} 0 {np.real(pole)}\n')
-                        f.write(f'Gp_{k + 1}_re_im_{i + 1} 0 x{k + 1}_re_{i + 1} x{k + 1}_im_{i + 1} 0 {np.imag(pole)}\n')
+                        xk_re_i = f'x{k + 1}_re_{i + 1}'
+                        gp_re = np.real(pole)
+                        gp_im = np.imag(pole)
+                        f.write(f'C{k + 1}_re_{i + 1} {xk_re_i} 0 1.0\n')
+                        f.write(f'Ga_{k + 1}_re_{i + 1} 0 {xk_re_i} p{i + 1} {node_ref_i} {2 * gain_vccs_a_i}\n')
+                        f.write(f'Fa_{k + 1}_re_{i + 1} 0 {xk_re_i} V{i + 1} {2 * gain_cccs_a_i}\n')
+                        f.write(f'Gp_{k + 1}_re_re_{i + 1} 0 {xk_re_i} {xk_re_i} 0 {gp_re}\n')
+                        f.write(f'Gp_{k + 1}_re_im_{i + 1} 0 {xk_re_i} {xk_im_i} 0 {gp_im}\n')
 
                         # imaginary part at x_{k + 1}_im_{i + 1}, input a_i is inactive (b = 0)
-                        f.write(f'C{k + 1}_im_{i + 1} x{k + 1}_im_{i + 1} 0 1.0\n')
-                        f.write(f'Gp_{k + 1}_im_re_{i + 1} 0 x{k + 1}_im_{i + 1} x{k + 1}_re_{i + 1} 0 {-1 * np.imag(pole)}\n')
-                        f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 x{k + 1}_im_{i + 1} x{k + 1}_im_{i + 1} 0 {np.real(pole)}\n')
+                        xk_im_i = f'x{k + 1}_im_{i + 1}'
+                        f.write(f'C{k + 1}_im_{i + 1} {xk_im_i} 0 1.0\n')
+                        f.write(f'Gp_{k + 1}_im_re_{i + 1} 0 {xk_im_i} {xk_re_i} 0 {-1 * gp_im}\n')
+                        f.write(f'Gp_{k + 1}_im_im_{i + 1} 0 {xk_im_i} {xk_im_i} 0 {gp_re}\n')
 
                 # transfer of states and inputs from port j to port i
                 for j in range(self.network.nports):
@@ -2566,8 +2572,10 @@ class VectorFitting:
                     gain_cccs_a_j = np.sqrt(z0_j) / 2
 
                     # input a_j is scaled by constant term d_i_j and by current gain for b_i
-                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {gain_b_i * d * gain_vccs_a_j}\n')
-                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {gain_b_i * d * gain_cccs_a_j}\n')
+                    g = gain_b_i * d * gain_vccs_a_j
+                    f = gain_b_i * d * gain_cccs_a_j
+                    f.write(f'Ga{i + 1}_{j + 1} {node_ref_i} s{i + 1} p{j + 1} {node_ref_j} {g}\n')
+                    f.write(f'Fa{i + 1}_{j + 1} {node_ref_i} s{i + 1} V{j + 1} {f}\n')
 
                     # each residue rk_i_j at port i is multiplied by its respective state signal xk_j
                     for k in range(len(self.poles)):
@@ -2576,12 +2584,18 @@ class VectorFitting:
 
                         if np.imag(pole) == 0.0:
                             # Real pole/residue pair; represented by one state
-                            f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_{j + 1} 0 {gain_b_i * np.real(residue)}\n')
+                            xkj = f'x{k + 1}_{j + 1}'
+                            g = gain_b_i * np.real(residue)
+                            f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} {xkj} 0 {g}\n')
                         else:
                             # Complex-conjugate pole/residue pair; represented by two states
                             # real part at x_{k + 1}_re_{i + 1}
                             # imaginary part at x_{k + 1}_im_{i + 1}
-                            f.write(f'Gr_{k + 1}_re_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_re_{j + 1} 0 {gain_b_i * np.real(residue)}\n')
-                            f.write(f'Gr_{k + 1}_im_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_im_{j + 1} 0 {gain_b_i * np.imag(residue)}\n')
+                            xk_re_j = f'x{k + 1}_re_{j + 1}'
+                            xk_im_j = f'x{k + 1}_im_{j + 1}'
+                            g_re = gain_b_i * np.real(residue)
+                            g_im = gain_b_i * np.imag(residue)
+                            f.write(f'Gr_{k + 1}_re_{i + 1}_{j + 1} {node_ref_i} s{i + 1} {xk_re_j} 0 {g_re}\n')
+                            f.write(f'Gr_{k + 1}_im_{i + 1}_{j + 1} {node_ref_i} s{i + 1} {xk_im_j} 0 {g_im}\n')
 
             f.write(f'.ENDS {fitted_model_name}\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2576,12 +2576,12 @@ class VectorFitting:
 
                         if np.imag(pole) == 0.0:
                             # Real pole/residue pair; represented by one state
-                            f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_{j + 1} 0 {np.real(residue)}\n')
+                            f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_{j + 1} 0 {gain_b_i * np.real(residue)}\n')
                         else:
                             # Complex-conjugate pole/residue pair; represented by two states
                             # real part at x_{k + 1}_re_{i + 1}
                             # imaginary part at x_{k + 1}_im_{i + 1}
-                            f.write(f'Gr_{k + 1}_re_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_re_{j + 1} 0 {np.real(residue)}\n')
-                            f.write(f'Gr_{k + 1}_im_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_im_{j + 1} 0 {np.imag(residue)}\n')
+                            f.write(f'Gr_{k + 1}_re_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_re_{j + 1} 0 {gain_b_i * np.real(residue)}\n')
+                            f.write(f'Gr_{k + 1}_im_{i + 1}_{j + 1} {node_ref_i} s{i + 1} x{k + 1}_im_{j + 1} 0 {gain_b_i * np.imag(residue)}\n')
 
             f.write(f'.ENDS {fitted_model_name}\n')

--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -2528,7 +2528,7 @@ class VectorFitting:
                         f.write(f'C{k + 1}_{i + 1} {xki} 0 1.0\n')
                         f.write(f'Ga_{k + 1}_{i + 1} 0 {xki} p{i + 1} {node_ref_i} {1 * gain_vccs_a_i}\n')
                         f.write(f'Fa_{k + 1}_{i + 1} 0 {xki} V{i + 1} {1 * gain_cccs_a_i}\n')
-                        f.write(f'Gp_{k + 1}_{i + 1} 0 {xki} x{k + 1}_{i + 1} 0 {gp}\n')
+                        f.write(f'Gp_{k + 1}_{i + 1} 0 {xki} {xki} 0 {gp}\n')
                     else:
                         # Complex pole of a conjugate pair; represented by two states
                         # real part at x_{k + 1}_re_{i + 1}, input a_i is scaled by b = 2
@@ -2565,7 +2565,7 @@ class VectorFitting:
                     # H(s) = d + s * e  model
                     # Z(s) = R + s * L  equivalent impedance
                     d = self.constant_coeff[idx_S_i_j]
-                    e = self.proportional_coeff[idx_S_i_j]
+                    # e = self.proportional_coeff[idx_S_i_j]
 
                     # VCCS and CCCS adding their currents to represent the incident wave a_j
                     gain_vccs_a_j = 1 / 2 / np.sqrt(z0_j)
@@ -2589,8 +2589,8 @@ class VectorFitting:
                             f.write(f'Gr_{k + 1}_{i + 1}_{j + 1} {node_ref_i} s{i + 1} {xkj} 0 {g}\n')
                         else:
                             # Complex-conjugate pole/residue pair; represented by two states
-                            # real part at x_{k + 1}_re_{i + 1}
-                            # imaginary part at x_{k + 1}_im_{i + 1}
+                            # real part at x_{k + 1}_re_{j + 1}
+                            # imaginary part at x_{k + 1}_im_{j + 1}
                             xk_re_j = f'x{k + 1}_re_{j + 1}'
                             xk_im_j = f'x{k + 1}_im_{j + 1}'
                             g_re = gain_b_i * np.real(residue)


### PR DESCRIPTION
This PR implements another equivalent circuit topology for vector-fitted networks in scattering representation. In contrast to the previous admittance-based and impedance-based topologies, this one is a direct implementation of the state-space equations. While it still involves many controlled source (mostly VCCS, not so bad), the resulting network is much smaller in terms of node count, i.e. number of unknowns to solve for. LTspice is still not impressed, but ngspice and Xyce run much faster with the state-space circuits.

I will add some documentation later in another PR, once this one is discussed, finalized and merged.

Here are some runtime comparisons for small and large networks with small and large models:

**`4port_reduced`, 4-port network, model order 105:**
- ngspice (admittance variant): 788.640 s
- ngspice (impedance variant): 0.390 s
- ngspice (state-space variant): 0.105 s
- Xyce (admittance variant): 21.033 s
- Xyce (impedance variant): 4.84399 s
- Xyce (state-space variant): 0.765833 s
- LTspice (admittance variant): 0.249 s
- LTspice (impedance variant): 0.233 s
- LTspice (state-space variant): 0.154 s

**`Backplane`, 8-port network, model order 385:**
- ngspice (admittance variant): did not finish in reasonable time
- ngspice (impedance variant): 97.564 s
- ngspice (state-space variant): 70.181 s
- Xyce (admittance variant): did not finish in reasonable time
- Xyce (impedance variant): 133.325 s
- Xyce (state-space variant): 18.8203 s
- LTspice (admittance variant): 8.119 s
- LTspice (impedance variant): 8.763 s
- LTspice (state-space variant): 8.661 s

**`Via_array`, 18-port network, model order 13:**
- ngspice (admittance variant): did not finish in reasonable time
- ngspice (impedance variant): did not finish in reasonable time
- ngspice (state-space variant): did not finish in reasonable time
- Xyce (admittance variant): did not finish in reasonable time
- Xyce (impedance variant): 53.4626 s
- Xyce (state-space variant): 5.91896 s
- LTspice (admittance variant): 0.251 s
- LTspice (impedance variant): 0.237 s
- LTspice (state-space variant): 0.787 s