### PR TITLE
Fix plot z time response numerical singularities

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4869,8 +4869,8 @@ class Network:
 
             if attribute[0].lower() == "z":
                 y_label = "Z (Ohm)"
-                y[x ==  1.] =  1. + 1e-12  # solve numerical singularity
-                y[x == -1.] = -1. + 1e-12  # solve numerical singularity
+                y[y ==  1.] =  1. + 1e-12  # solve numerical singularity
+                y[y == -1.] = -1. - 1e-12  # solve numerical singularity
                 y = self.z0[0].real * (1+y) / (1-y)
 
         for m in M:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4869,8 +4869,7 @@ class Network:
 
             if attribute[0].lower() == "z":
                 y_label = "Z (Ohm)"
-                y[y ==  1.] =  1. + 1e-12  # solve numerical singularity
-                y[y == -1.] = -1. - 1e-12  # solve numerical singularity
+                y[y ==  1.] =  1. - 1e-12  # solve numerical singularity
                 y = self.z0[0].real * (1+y) / (1-y)
 
         for m in M:

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -63,6 +63,9 @@ class NetworkTestCase(unittest.TestCase):
         l2 = self.cpw.line(0.07, 'm', z0=50)
         l3 = self.cpw.line(0.47, 'm', z0=50)
         self.l2 = l2
+        freq = rf.Frequency(0, 2, 3, 'GHz')
+        m50 = rf.media.DefinedGammaZ0(frequency = freq, z0_port = 50, z0 = 50)
+        self.o1 = m50.open()
         self.Fix = rf.concat_ports([l1, l1, l1, l1])
         self.DUT = rf.concat_ports([l2, l2, l2, l2])
         self.Meas = rf.concat_ports([l3, l3, l3, l3])
@@ -1059,6 +1062,11 @@ class NetworkTestCase(unittest.TestCase):
     @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
     def test_plot_two_port_smith(self):
         self.ntwk1.plot_s_smith()
+
+    @pytest.mark.skipif("matplotlib" not in sys.modules, reason="Requires matplotlib in sys.modules.")
+    def test_plot_z_responses_singularities(self):
+        with np.errstate(divide='raise'):
+            self.o1.plot_z_time_impulse(window = None)
 
     def test_zy_singularities(self):
         networks = [


### PR DESCRIPTION
Fix `Network.plot_z_time_step` and `Network.plot_z_time_step` singularities when

$Z = Z_0 \frac{\Gamma + 1}{\Gamma - 1}$ with $\Gamma=1$

Fix #1254 