### PR TITLE
fix port_names connect issues when the second network has no port names

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5086,7 +5086,6 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
         if ntwkA.port_names is not None:
             ntwkB.port_names = [str(x) for x in range(ntwkB.nports)]
 
-
     have_complex_ports = (ntwkA.z0.imag != 0).any() or (ntwkB.z0.imag != 0).any()
 
     # If definitions aren't identical and there are complex ports renormalize first

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5081,6 +5081,12 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     if (l + num - 1 > ntwkB.nports - 1):
         raise IndexError('Port `l` out of range')
 
+    # create port_names if required
+    if ntwkB.port_names is None:
+        if ntwkA.port_names is not None:
+            ntwkB.port_names = [str(x) for x in range(ntwkB.nports)]
+
+
     have_complex_ports = (ntwkA.z0.imag != 0).any() or (ntwkB.z0.imag != 0).any()
 
     # If definitions aren't identical and there are complex ports renormalize first
@@ -5134,9 +5140,12 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     # call s-matrix connection function
     ntwkC.s = connect_s(ntwkC.s if not z0_equal else ntwkA.s, k, ntwkB.s, l, num)
 
-    # combine z0 arrays and remove ports which were `connected`
+    # combine z0 and port_names arrays and remove ports which were `connected`
     ntwkC.z0 = np.hstack(
         (np.delete(ntwkA.z0, range(k, k + 1), 1), np.delete(ntwkB.z0, range(l, l + 1), 1)))
+    if ntwkA.port_names is not None:
+        ntwkC.port_names = np.concatenate(
+            (np.delete(ntwkA.port_names, k), np.delete(ntwkB.port_names, l)))
 
     # if we're connecting more than one port, call innerconnect recursively
     # until all connections are made to finish the job
@@ -5519,6 +5528,8 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
     z0_equal = (ntwkC.z0[:, k] == ntwkC.z0[:, l]).all()
 
     if not z0_equal:
+        if ntwkC.port_names is not None:
+            port_names = ntwkC.port_names.copy()
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
         mismatch = impedance_mismatch(ntwkA.z0[:, k], ntwkA.z0[:, l], ntwkA.s_def)
@@ -5529,12 +5540,16 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
         ntwkC.z0[:, k:] = np.hstack((ntwkC.z0[:, k + 1:], ntwkC.z0[:, [l]]))
         ntwkC.renumber(from_ports=[ntwkC.nports - 1] + list(range(k, ntwkC.nports - 1)),
                        to_ports=list(range(k, ntwkC.nports)))
+        if ntwkC.port_names is not None:
+            ntwkC.port_names = port_names
 
     # call s-matrix connection function
     ntwkC.s = innerconnect_s(ntwkC.s if not z0_equal else ntwkA.s, k, l)
 
-    # update the characteristic impedance matrix
+    # update the characteristic impedance matrix and port_names
     ntwkC.z0 = np.delete(ntwkC.z0, list(range(k, k + 1)) + list(range(l, l + 1)), 1)
+    if ntwkC.port_names is not None:
+        ntwkC.port_names = np.delete(ntwkC.port_names, [k] + [l]).tolist()
 
     # recur if we're connecting more than one port
     if num > 1:

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5083,6 +5083,7 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     # create port_names if required
     if ntwkB.port_names is None:
         if ntwkA.port_names is not None:
+            ntwkB = ntwkB.copy()
             ntwkB.port_names = [str(x) for x in range(ntwkB.nports)]
 
     have_complex_ports = (ntwkA.z0.imag != 0).any() or (ntwkB.z0.imag != 0).any()

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -721,7 +721,6 @@ class NetworkTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(ntwk2.z0[0], [1, 2, 30])
         self.assertTrue(ntwk2.port_names is None)
 
-
     def test_interconnect_complex_ports(self):
         """ Test that connecting two complex ports in a network
         gives the same S-parameters with all s_def when the rest of

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -714,7 +714,7 @@ class NetworkTestCase(unittest.TestCase):
 
         # this keeps port_names from splitter and provides port_names for thru
         np.testing.assert_almost_equal(ntwk1.z0[0], [10, 3, 4])
-        self.assertTrue(ntwk1.port_names == ["a", "3", "4"])
+        self.assertTrue(ntwk1.port_names == ["a", "2", "3"])
 
         # this removes port_names from splitter
         ntwk2 = rf.connect(self.thru, 2, self.splitter, 0, 2)

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 from scipy import signal
-from scipy.constants import  c
 
 import skrf as rf
 from skrf import setup_pylab

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -12,12 +12,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 from scipy import signal
+from scipy.constants import  c
 
 import skrf as rf
 from skrf import setup_pylab
 from skrf.constants import S_DEF_HFSS_DEFAULT, S_DEFINITIONS
 from skrf.frequency import Frequency, InvalidFrequencyWarning
-from skrf.media import CPW, DistributedCircuit
+from skrf.media import CPW, DefinedGammaZ0, DistributedCircuit
 from skrf.networkSet import tuner_constellation
 
 try:
@@ -63,8 +64,8 @@ class NetworkTestCase(unittest.TestCase):
         l2 = self.cpw.line(0.07, 'm', z0=50)
         l3 = self.cpw.line(0.47, 'm', z0=50)
         self.l2 = l2
-        freq = rf.Frequency(0, 2, 3, 'GHz')
-        m50 = rf.media.DefinedGammaZ0(frequency = freq, z0_port = 50, z0 = 50)
+        freq = Frequency(0, 9, 10, 'GHz')
+        m50 = DefinedGammaZ0(frequency = freq, z0_port = 50, z0 = 50)
         self.o1 = m50.open()
         self.splitter = m50.splitter(nports = 3, z0 = [10, 20, 30])
         self.splitter.port_names = ["a", "b", "c"]


### PR DESCRIPTION
Fix the error when connecting more than 1 port of two networks using `Network.connect` if the first network has `port_names `and the second network has not.
If the first network has no `port_names`, there is no problem because the results has no `port_names`.