### PR TITLE
Update reference to nfmin in nf_circle 'see also' section

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4782,7 +4782,8 @@ class Network:
         stability_circle
         gain_circle
         g_opt: The optimum source reflection coefficient to minimize noise.
-        nf_min : The minimum noise figure of the network.
+        nfmin : The minimum noise figure of the network.
+        nfmin_db : The minimum noise figure for the network in dB.
         rn : The equivalent noise resistance of the network.
 
         """


### PR DESCRIPTION
Just noticed that the [docs](https://scikit-rf.readthedocs.io/en/latest/api/generated/skrf.network.Network.nf_circle.html#skrf.network.Network.nf_circle) link to a non-existent property `nf_min`, this corrects that to `nfmin` and also adds a reference to `nfmin_db` (since it took me a minute to realise `nfmin` wasn't already in dB).