### PR TITLE
Fix time_gate documentation

### DIFF
--- a/skrf/time.py
+++ b/skrf/time.py
@@ -324,7 +324,7 @@ def time_gate(ntwk: Network, start: float = None, stop: float = None, center: fl
             * 's': seconds (default)
             * 'ms': milliseconds
             * 'µs' or 'us': microseconds
-            * 'ns': nanoseconds 
+            * 'ns': nanoseconds
             * 'ps': picoseconds
 
 


### PR DESCRIPTION
The documentation for time_gate seems to indicate that both sec and nsec are the default. PR fixes this.