### PR TITLE
Raise out-of-bound error when interpolating network parameters

### DIFF
--- a/skrf/networkSet.py
+++ b/skrf/networkSet.py
@@ -1398,7 +1398,7 @@ class NetworkSet:
             raise ValueError(f'Parameter {param} is not found in the NetworkSet params.')
         if isinstance(x, Number):
             if not (min(self.coords[param]) < x < max(self.coords[param])):
-                ValueError(f'Out of bound values: {x} is not inside {self.coords[param]}. Cannot interpolate.')
+                raise ValueError(f'Out of bound values: {x} is not inside {self.coords[param]}. Cannot interpolate.')
         else:
             raise ValueError('Cannot interpolate between string-based parameters.')
 


### PR DESCRIPTION
## PR Summary
This small PR fixes an issue where out-of-bound values during network parameter interpolation would create an exception object but fail to properly raise it. Currently it rises other exception that comes later.
Here is a small example to reproduce it:
```python
import skrf as rf
import numpy as np

freq = rf.Frequency(1, 1, 1, unit='GHz')
networks = [
    rf.Network(frequency=freq, s=np.array([[0.1]]), name='ntwk1', params={'param': 1}),
    rf.Network(frequency=freq, s=np.array([[0.2]]), name='ntwk2', params={'param': 2}),
    rf.Network(frequency=freq, s=np.array([[0.3]]), name='ntwk3', params={'param': 3})
]
ns = rf.NetworkSet(networks)
result = ns.interpolate_from_params('param', 0)
```

Please note that the existing tests in `test_networkSet.py` already cover this use-case as they just catch `ValueError` without checking their kind. The relevant test case is [`test_interpolate_from_params`](https://github.com/scikit-rf/scikit-rf/blob/527d515cf15e0e222be0c9dfe39a1f34833d2be3/skrf/tests/test_networkSet.py#L342C9-L342C37).