### PR TITLE
use smaller diff_step in least_squares to be compatible with scipy 1.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 dependencies = [
     "numpy >=1.21",
-    "scipy >=1.7,<1.16",
+    "scipy >=1.7",
     "pandas >=1.1",
     "typing-extensions"
 ]

--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -4668,7 +4668,7 @@ class LRRM(EightTerm):
             if init_guess[li] < np.mean(min_l(l0)**2):
                 l0 = best_guess
 
-            sol = least_squares(min_l, l0, method='lm')
+            sol = least_squares(min_l, l0, method="lm", diff_step=np.sqrt(np.finfo(np.float64).resolution))
             match_l = sol.x * np.ones(match_l.shape)
             match_c = zeros
 


### PR DESCRIPTION
Fixes #1288 