### PR TITLE
Vector fitting: Ensure complex calculations for square-root of eigenvalues

### DIFF
--- a/skrf/vectorFitting.py
+++ b/skrf/vectorFitting.py
@@ -1400,7 +1400,7 @@ class VectorFitting:
 
         # purely imaginary square roots of eigenvalues identify frequencies (2*pi*f) of borders of passivity violations
         freqs_violation = []
-        for sqrt_eigenval in np.sqrt(P_eigs):
+        for sqrt_eigenval in np.sqrt(P_eigs, dtype=complex):
             if np.real(sqrt_eigenval) == 0.0:
                 freqs_violation.append(np.imag(sqrt_eigenval) / 2 / np.pi)
 


### PR DESCRIPTION
This hopefully fixes issue #1300

Usually, `numpy.sqrt()` fails for negative real numbers, but it works if `dtype=complex` is specified:

``` python
import numpy as np
np.sqrt(-1, dtype=complex)
Out[3]: 1j

np.sqrt(-1)
<ipython-input-4-597592b72a04>:1: RuntimeWarning: invalid value encountered in sqrt
  np.sqrt(-1)
Out[4]: nan
```