### PR TITLE
test_calibration_ng.py: Next-generation calibration test suite

### DIFF
--- a/skrf/calibration/tests/test_calibration_ng.py
+++ b/skrf/calibration/tests/test_calibration_ng.py
@@ -527,8 +527,8 @@ class AbstractIncompleteCalTest:
         else:
             return True
 
-    #def assertEqualNtwk(self, network1, network2, tolerance=ZERO):
-    def assertEqualNtwk(self, network1, network2, tolerance=1e-2):
+    def assertEqualNtwk(self, network1, network2, tolerance=ZERO):
+    #def assertEqualNtwk(self, network1, network2, tolerance=1e-2):
         self.assertTrue(
             self._compare_ntwk(network1, network2, tolerance)
         )
@@ -1934,13 +1934,13 @@ class LRRMTest(EightTermTest):
     @classmethod
     def setup_std_for_testgroup(cls, medium, vna, testgroup):
         if (medium.z0_port > 5).all():
-            parasitic_l = np.random.default_rng().uniform(1e-12, 20e-12)
-            parasitic_c = np.random.default_rng().uniform(1e-15, 20e-15)
+            parasitic_l = 1e-12 #np.random.default_rng().uniform(1e-12, 20e-12)
+            parasitic_c = 1e-15 #np.random.default_rng().uniform(1e-15, 20e-15)
         else:
             # When the reference impedance is low, the phase shift will
             # increase. It must be kept within 90 degrees of 180 degrees.
-            parasitic_l = np.random.default_rng().uniform(0.1e-12, 1e-12)
-            parasitic_c = np.random.default_rng().uniform(0.1e-15, 1e-15)
+            parasitic_l = 1e-12 # np.random.default_rng().uniform(0.1e-12, 1e-12)
+            parasitic_c = 1e-15 # np.random.default_rng().uniform(0.1e-15, 1e-15)
         testgroup["parasitic_l"] = parasitic_l
 
         imperfect_short = (


### PR DESCRIPTION
This commit introduces the next-generation calibration test suite.

Its features include:

1. Instead of testing at a simple reference impedance or a single waveguide, now multiple mediums (`MEDIUM`) and reference impedances (`Z0_REF`) are tested.

2. The new concept of a `testgroup` is introduced the base class. Each `testgroup` is a complete set of measurement, constructed by combining all possible mediums and all possible impedances.

3. All error simulations are implemented using a virtual 2-port `UncalibratedNetworkAnalyzer`, this allows reusing same error simulation code instead of cascading ad-hoc error boxes in each calibration test, reducing lines of code in each test significantly.

4. Define two abstract base classes for all common tests encountered in 1-port and 2-port calibrations. So each the test for each algorithm no longer needs to reimplement the same code repeatedly. Only the calibration standard inputs need to be defined, reducing lines of code in each test significantly.

5. Instead of defining a class member function for each error coefficient, we collect all error coefficients and their calculations (as `lambda` functions) into a single list. During a test, only a single class member function is required. Each coefficient test failure remains distinguishable and labeled in the logs by utilizing the the "subTest` feature in `unittest`.

6. Introducing a valid_frequency property for all calibration classes, narrowband calibrations are automatically excluded from unsuitable wideband tests.

The new test code provides a more comprehensive and more readable and maintainable framework. Not all tests have been converted from `test_calibration.py` to `test_calibration_ng.py` yet because of the high number of tests. Both test suite will coexist for now.

As an extra bonus, because we no longer have a member function for each calibration coefficient, we no longer have repeated creation of the calibration class, reducing the number of calibration runs. The original test suite only tests 1 frequency point due to performance issue, but the new implementation can easily test 100 frequency points.