### PR TITLE
media.py: fix incorrect modification in media.mode(), close #1319.

### DIFF
--- a/skrf/media/media.py
+++ b/skrf/media/media.py
@@ -124,7 +124,7 @@ class Media(ABC):
         """
         out = copy(self)
         for k in kw:
-            setattr(self, k, kw[k])
+            setattr(out, k, kw[k])
         return out
 
     def copy(self) -> Media:

--- a/skrf/media/tests/test_all_construction.py
+++ b/skrf/media/tests/test_all_construction.py
@@ -20,6 +20,13 @@ class MediaTestCase:
     def test_z0_value(self):
         self.media.z0
 
+    def test_mode_original_not_modified(self):
+        # https://github.com/scikit-rf/scikit-rf/issues/1319
+        network1 = self.media.delay_short(30, unit='deg')
+        newmedia = self.media.mode(z0_port=1)  # unused newmedia
+        network2 = self.media.delay_short(30, unit='deg')
+        self.assertEqual(network1, network2)
+
     def test_match(self):
         self.media.match()
 


### PR DESCRIPTION
Due to a typo, the `media.mode()` method accidentally modifies the original instance rather than the copied new media instance, causing unexpectedly modifications.

This Pull Request fixes the original issue, and adds a unit test to replicate the problem and to prevent the problem from reoccurring again.
