### PR TITLE
calibration.py: raise ValueError if 2-port inputs are used, close #1321.

### DIFF
--- a/skrf/calibration/calibration.py
+++ b/skrf/calibration/calibration.py
@@ -1133,6 +1133,12 @@ class OnePort(Calibration):
         Calibration.__init__(self, measured, ideals,
                              *args, **kwargs)
 
+    def _check_input(self):
+        if not all([n.number_of_ports==1 for n in self.ideals]):
+            raise ValueError(f'ideals for {self.family} should be 1-port Networks')
+        if not all([n.number_of_ports==1 for n in self.measured]):
+            raise ValueError(f'measured networks for {self.family} should be 1-port Networks')
+
     def run(self):
         """ Run the calibration algorithm.
         """
@@ -1142,10 +1148,7 @@ class OnePort(Calibration):
         mList = [self.measured[k].s.reshape((-1,1)) for k in range(numStds)]
         iList = [self.ideals[k].s.reshape((-1,1)) for k in range(numStds)]
 
-        if not all([n.number_of_ports==1 for n in self.ideals]):
-            raise RuntimeError(f'ideals for {self.family} should be 1-port Networks')
-        if not all([n.number_of_ports==1 for n in self.measured]):
-            raise RuntimeError(f'measured networks for {self.family} should be 1-port Networks')
+        self._check_input()
 
         # ASSERT: mList and aList are now kx1x1 matrices, where k in frequency
         fLength = len(mList[0])
@@ -1309,6 +1312,8 @@ class SDDLWeikle(OnePort):
                              ideals =ideals, **kwargs)
 
     def run(self):
+        self._check_input()
+
         #measured reflection coefficients
         w_s = self.measured[0].s.flatten() # short
         w_1 = self.measured[1].s.flatten() # delay short 1
@@ -1451,6 +1456,7 @@ class SDDL(OnePort):
 
 
     def run(self):
+        self._check_input()
 
         #measured impedances
         d = s2z(self.measured[0].s,1) # short
@@ -1532,6 +1538,7 @@ class PHN(OnePort):
 
 
     def run(self):
+        self._check_input()
 
         # ideals (in impedance)
         a = s2z(self.ideals[0].s,1).flatten() # half known

--- a/skrf/calibration/tests/test_calibration.py
+++ b/skrf/calibration/tests/test_calibration.py
@@ -295,7 +295,7 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
 
     def test_input_networks_1port(self):
         # test users do not enter 2-port networks by accident
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             wg = self.wg
             ideals = [
                     two_port_reflect(wg.short( name='short'), wg.short( name='short')),
@@ -304,7 +304,9 @@ class OnePortTest(unittest.TestCase, CalibrationTest):
                     wg.match( name='load'),
                     ]
             measured = [self.measure(k) for k in ideals]
-            cal = rf.OnePort(
+            # create another calibration instance of the same class
+            cal_class = type(self.cal)
+            cal = cal_class(
                is_reciprocal = True,
                ideals = ideals,
                measured = measured,


### PR DESCRIPTION
In the current calibration code, `OnePort` class checks whether users accidentally use 2-port input networks for 1-port calibration, and raises a `RuntimeError` if so. But there's no check for `SDDL`, `SDDLWeikle`, and `PHN` calibrations. As a result, they all threw different errors in the middle of a calibration run, sometimes it's `IndexError`, sometimes it's `ValueError`.

This commit adds a class-wide `self._check_input()` methods for all one-port calibration classes, which is called in `self.run()`. For consistency, we use `ValueError` instead of the original `RuntimeError`.