### PR TITLE
Version 1.9.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-rf" %}
-{% set version = "1.8.0" %}
+{% set version = "1.9.0" %}
 {% set hash_val = "8223204281599ba14b685d7e28b7e361" %}
 
 package:

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python.
 """
 
-__version__ = '1.8.0'
+__version__ = '1.9.0'
 ## Import all  module names for coherent reference of name-space
 #import io
 


### PR DESCRIPTION
## What's Changed
* Fix Coaxial media shunt conductance expression by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1298
* Allow IEEEP370_FD_QM.check_causality() for One-Port Networks, with additional docstring tweaks by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1303
* Allow `skrf.Network` to input touchstone 2.0 file without `*.ts` extension by @SHF101202021 in https://github.com/scikit-rf/scikit-rf/pull/1304
* Vector fitting: Ensure complex calculations for square-root of eigenvalues by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/1305
* media.py: reword misleading z0 documentation, close #1310. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1312
* calibration.py: fix incorrect UnknownThru and MRC calibration by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1318
* media.py: fix incorrect modification in media.mode(), close #1319. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1320
* Documentation improvements by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1323
* doc/SOLT Calibration Standards Creation: Complete Rewrite by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1306
* Add API to set/get the global numpy RNG, close #1314. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1330
* doc/SOLT Calibration Standards Creation: language and formatting fixes. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1335
* calibration.py: raise ValueError if 2-port inputs are used, close #1321. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1332
* Adding Python 3.14 to CI by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1337
* io/touchstone.py: strip leading spaces, close #1339. by @biergaizi in https://github.com/scikit-rf/scikit-rf/pull/1340
* Allows printing Iterable type RLCGs in DistributedCircuit by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1336
* Vector Fitting: Documentation Update by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/1343
* Add some functions to the docstring by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1350
* Hp8510c single point by @jamiestepanian in https://github.com/scikit-rf/scikit-rf/pull/1351
* fix docstring for from_z by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1355
* Adding missing undocumented function by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1356

## New Contributors
* @jamiestepanian made their first contribution in https://github.com/scikit-rf/scikit-rf/pull/1351

**Full Changelog**: https://github.com/scikit-rf/scikit-rf/compare/v1.8.0...v1.9.0