### PR TITLE
Temporary fix of continuous integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest >=7.0",
+    "pytest <9.0",
     "pytest-mock >= 3.10",
     "pytest-xdist >= 3.5.0",
     "coverage >=6.0",


### PR DESCRIPTION
Following changes introduces in pytest version 9, force pytest <9 (see [here](https://github.com/pytest-dev/pytest/pull/13963)), this PR forces the CI setup to use pytest <9, to pass all tests.
