### PR TITLE
Update se2gmm example for N=3

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3925,7 +3925,7 @@ class Network:
 
         >>> ntwk.renumber([0,1,2], [2,1,0])
         >>> ntwk.se2gmm(p=1)
-        >>> ntwk.renumber([2,1,0], [0,1,2])
+        >>> ntwk.renumber([0,1,2], [1,2,0])
 
         In the resulting network, port 0 is single-ended, port 1 is
         differential mode, and port 2 is common mode.


### PR DESCRIPTION
Associated with issue #1358.

By redoing the ordering in the example:

```
import numpy as np
import skrf as rf

# fake 3-port
ntwk = rf.Network(
    f=[1],
    s=np.zeros((1, 3, 3), dtype=complex),
)
print(f"initial {ntwk.z0=}")

# do the reordering/conversion in the *new* example
ntwk.renumber([0, 1, 2], [2, 1, 0])
ntwk.se2gmm(p=1)
ntwk.renumber([0, 1, 2], [1, 2, 0])

print(f"final {ntwk.z0=}")
```
We see the differential port is correctly placed into port 1, as written in the description:
```
initial ntwk.z0=array([[50.+0.j, 50.+0.j, 50.+0.j]])
final ntwk.z0=array([[ 50.+0.j, 100.+0.j,  25.+0.j]])
```