### PR TITLE
v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ multiline-trl # Run the multiline-trl application
 
 ## Questions or comments? Ask the Community
 
-[![Slack](https://img.shields.io/badge/Slack-join%20chat-blueviolet?style=flat&logo=slack)](https://join.slack.com/t/scikit-rf/shared_invite/zt-d82b62wg-0bdSJjZVhHBKf6687V80Jg)
 [![Matrix](https://img.shields.io/badge/Matrix-join%20chat-blueviolet?style=flat&logo=matrix)](https://app.element.io/#/room/#scikit-rf:matrix.org)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn_scikit_rf_group-orange?style=flat)](https://www.linkedin.com/groups/12462155/)
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-rf" %}
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}
 {% set hash_val = "8223204281599ba14b685d7e28b7e361" %}
 
 package:

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python.
 """
 
-__version__ = '1.9.0'
+__version__ = '1.10.0'
 ## Import all  module names for coherent reference of name-space
 #import io
 


### PR DESCRIPTION
Last minor version before a major version (2.0), as #1365 changes previous version namespace config.

## What's Changed
* Temporary fix of continuous integration by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1357
* Vector fitting tutorial: minor correction by @Vinc0110 in https://github.com/scikit-rf/scikit-rf/pull/1360
* Update se2gmm example for N=3 by @AlecVercruysse in https://github.com/scikit-rf/scikit-rf/pull/1359
* Fix input parameters type. by @Asachoo in https://github.com/scikit-rf/scikit-rf/pull/1361
* Remove Python versions 3.8/3.9 and fix Continuous Integration  by @jhillairet in https://github.com/scikit-rf/scikit-rf/pull/1364
* Simplify and improve write_touchstone by @luar123 in https://github.com/scikit-rf/scikit-rf/pull/1363
* Add virtual instrument support for Rohde & Schwarz ZNA by @mxxmxn in https://github.com/scikit-rf/scikit-rf/pull/1362
* Remove slack channel, to only promote an open-source alternative (Element).

## New Contributors
* @AlecVercruysse made their first contribution in https://github.com/scikit-rf/scikit-rf/pull/1359

**Full Changelog**: https://github.com/scikit-rf/scikit-rf/compare/v1.9.0...v1.10.0
