### PR TITLE
Fix string parsing bug in n_twoports_2_nport (Closes #1217)

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6452,9 +6452,21 @@ def n_twoports_2_nport(ntwk_list: Sequence[Network], nports: int,
     for subntwk in ntwk_list:
         for m, n in nport.port_tuples:
             if m != n and m > n:
-                if f"{m + offby}{port_sep}{n + offby}" in subntwk.name:
+                if port_sep == "":
+                    # If we have no separator, assume the first two digits we find are the port numbers
+                    re_digits = re.findall(r'\d', subntwk.name)
+                    p1 = int(re_digits[0])
+                    p2 = int(re_digits[1])
+                else:
+                    # If we have a separator, use split/regex match
+                    # This ensures there is no string ambiguity for networks with > 10 ports
+                    split_name = subntwk.name.split(port_sep)
+                    p1 = int(re.search(r'\d+', split_name[0]).group(0))
+                    p2 = int(re.search(r'\d+', split_name[1]).group(0))
+
+                if (p1 == m + offby) and (p2 == n + offby):
                     pass
-                elif f"{n + offby}{port_sep}{m + offby}" in subntwk.name:
+                elif (p1 == n + offby) and (p2 == m + offby):
                     subntwk = subntwk.flipped()
                 else:
                     continue

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1,4 +1,5 @@
 import io
+import itertools
 import os
 import pickle
 import sys
@@ -2120,6 +2121,25 @@ class NetworkTestCase(unittest.TestCase):
         ntw_list = [tee12, tee23, tee13]
         tee2 = n_twoports_2_nport(ntw_list, nports=3)
         self.assertTrue(tee2 == tee)
+
+    def test_n_twoports_2_nport_large_network(self):
+        """
+        Test that n_twoports_2_nport() can combine large networks with > 10 ports (Issue #1217)
+        Import an .s32p, split it into 2 port networks, then recombine
+        """
+        ntwk = rf.Network(os.path.join(self.test_dir,'ntwk.s32p'))
+
+        subnetwork_ports = list(itertools.combinations(list(range(ntwk.nports)), 2))
+        subnetworks = []
+
+        for pair in subnetwork_ports:
+            subnetworks.append(ntwk.subnetwork(pair))
+            subnetworks[-1].name = f"p{pair[0]+1}_{pair[1]+1}"
+
+        combined_ntwk = n_twoports_2_nport(subnetworks, ntwk.nports, port_sep="_")
+
+        self.assertTrue(np.allclose(ntwk.s, combined_ntwk.s))
+        self.assertTrue(np.allclose(ntwk.z0, combined_ntwk.z0))
 
     def test_subnetwork_port_names(self):
         """ Test that subnetwork keeps port_names property. Issue #429 """


### PR DESCRIPTION
Currently, `n_twoports_2_nport()` will fail to return a correct s-parameter matrix for networks with 11 or more ports due to an ambiguity in how the function handles network name strings. See: https://github.com/scikit-rf/scikit-rf/issues/1217 for details.

This PR fixes this behavior by using the python `re` module to explicitly search for integers in the network name string when a port separator is used. It also adds a unit test to add regression coverage for `n_twoports_2_nport()` when using networks with a large number of ports.