### PR TITLE
v2.0.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-rf" %}
-{% set version = "1.13.0" %}
+{% set version = "2.0.0" %}
 {% set hash_val = "8223204281599ba14b685d7e28b7e361" %}
 
 package:

--- a/skrf/__init__.py
+++ b/skrf/__init__.py
@@ -3,7 +3,7 @@ skrf is an object-oriented approach to microwave engineering,
 implemented in Python.
 """
 
-__version__ = '1.13.0'
+__version__ = '2.0.0'
 # Import all  module names for coherent reference of name-space
 import os as _os
 from typing import Any as _Any


### PR DESCRIPTION
This release mainly merges #1372, which moves most module level imports of scipy, matplotlib and pandas into functions, to reduce import time and proper module imports. Major version release, since it breaks several things:
- `skrf.stylely` always points to plotting.stylely even if plotting is not available (was None in this case before)
- removed `skrf.plotting_available` (was always None)
- removed `skrf.setup_pylab()`
- moved `plotting_available()`, `figure()`,` subplot(),` `axes_kwarg()` from `util` to `plotting` module
