### PR TITLE
Document Circuit helper topologies

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -599,6 +599,14 @@ class Circuit:
         """
         Return a 2-port network of a shunt admittance.
 
+        The network topology is::
+
+            (Port 1)-----(Port 2)
+                      |
+                     [Y]
+                      |
+                     Gnd
+
         Passing the frequency and name is mandatory.
 
         Parameters

--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -520,6 +520,10 @@ class Circuit:
         """
         Return a 1-port Network to be used as a Circuit port.
 
+        The network topology is::
+
+            (Port)
+
         Parameters
         ----------
         frequency : :class:`~skrf.frequency.Frequency`
@@ -555,6 +559,10 @@ class Circuit:
     def SeriesImpedance(cls, frequency: Frequency, Z: NumberLike, name: str, z0: float = 50) -> Network:
         """
         Return a 2-port network of a series impedance.
+
+        The network topology is::
+
+            (Port 1)-----[Z]-----(Port 2)
 
         Passing the frequency and name is mandatory.
 
@@ -650,6 +658,10 @@ class Circuit:
         """
         Return a 1-port network of a grounded link.
 
+        The network topology is::
+
+            (Port)-----Gnd
+
         Passing the frequency and a name is mandatory.
 
         The ground link is implemented by media.short object.
@@ -689,6 +701,10 @@ class Circuit:
     def Open(cls, frequency: Frequency, name: str, z0: float = 50) -> Network:
         """
         Return a 1-port network of an open link.
+
+        The network topology is::
+
+            (Port)-----Open
 
         Passing the frequency and name is mandatory.
 


### PR DESCRIPTION
## Summary

- add simple topology diagrams to the five `Circuit` network helpers: `Port`,
  `SeriesImpedance`, `ShuntAdmittance`, `Ground`, and `Open`
- render each diagram as a reStructuredText literal block so its alignment is
  preserved in the API documentation

Addresses #1395.

## Validation

- compiled `skrf/circuit.py` from source and parsed it with the standard-library
  AST parser
- asserted that all five helper docstrings contain the topology marker and their
  exact diagram text
- `git diff --check`

The original `ShuntAdmittance` fragment was built with Sphinx 9.1.0 and its
rendered alignment was verified. Sphinx, Ruff, and the project runtime
dependencies were unavailable when validating the follow-up diagrams locally,
so those checks were not rerun for the expanded patch; the new literal blocks
use the same syntax as the rendered fragment.

## AI assistance

OpenAI Codex was used to investigate the issue, add the documentation blocks,
and run local validation. The final diff and validation evidence were reviewed
before submission.
