### PR TITLE
Add Touchstone 2.1 write support

### DIFF
--- a/skrf/io/tests/test_ts_spec.py
+++ b/skrf/io/tests/test_ts_spec.py
@@ -1,4 +1,5 @@
 import io
+import zipfile
 from pathlib import Path
 
 import numpy as np
@@ -22,6 +23,19 @@ def test_ex_2():
                      )
     assert ts == ref
 
+
+def test_ex_2_version_2_1():
+    data = (test_data / "ex_2.ts").read_text().replace("[Version] 2.0", "[Version] 2.1")
+    ts = rf.Network.from_string(data)
+    ref = rf.Network(
+        f=np.arange(1, 6),
+        z=(np.arange(5) + 11) * np.exp(1j * np.arange(10, 60, 10) * np.pi / 180),
+        f_unit="mhz",
+    )
+
+    assert ts == ref
+
+
 def test_ex_2_write():
     ts = rf.Network(test_data / "ex_2.ts")
 
@@ -30,6 +44,34 @@ def test_ex_2_write():
     ts_read_back = rf.Network(stream)
 
     assert ts == ts_read_back
+
+
+@pytest.mark.parametrize("version", ["2.0", "2.1"])
+def test_ex_2_write_v2(version):
+    ts = rf.Network(test_data / "ex_2.ts")
+
+    output = ts.write_touchstone(return_string=True, form="ma", parameter="Z", version=version)
+    ts_read_back = rf.Network.from_string(output)
+
+    assert f"[Version] {version}" in output
+    assert "[Number of Ports] 1" in output
+    assert "[Number of Frequencies] 5" in output
+    assert "[Network Data]" in output
+    assert output.rstrip().endswith("[End]")
+    assert ts == ts_read_back
+
+
+@pytest.mark.parametrize("parameter", ["Y", "Z", "G", "H"])
+def test_write_v2_non_s_parameters_are_unnormalized(parameter):
+    ts = rf.Network(test_data / "ex_12.ts")
+    ts.renormalize([45 + 2j, 60 + 3j])
+
+    output = ts.write_touchstone(return_string=True, form="ri", parameter=parameter, version="2.1")
+    ts_read_back = rf.Network.from_string(output)
+
+    assert "[Reference]" not in output
+    np.testing.assert_allclose(getattr(ts, parameter.lower()), getattr(ts_read_back, parameter.lower()))
+
 
 def test_ex_3():
     ts = rf.Network(test_data / "ex_3.ts")
@@ -55,6 +97,164 @@ def test_ex_4():
         f_unit="ghz"
      )
     assert ts == ref
+
+
+@pytest.mark.parametrize("version", ["2.0", "2.1"])
+def test_ex_4_write_v2(version):
+    ts = rf.Network(test_data / "ex_4.ts")
+
+    output = ts.write_touchstone(return_string=True, form="ma", version=version)
+    ts_read_back = rf.Network.from_string(output)
+
+    assert f"[Version] {version}" in output
+    assert "[Reference] 50.0 75.0 0.01 0.01" in output
+    assert ts == ts_read_back
+
+
+def test_write_v2_renormalizes_frequency_dependent_z0():
+    ts = rf.Network(
+        f=[1, 2],
+        f_unit="ghz",
+        s=np.zeros((2, 2, 2), dtype=complex),
+        z0=[[50, 75], [55, 80]],
+        name="frequency_dependent_z0",
+    )
+
+    with pytest.raises(ValueError, match="vary with frequency"):
+        ts.write_touchstone(return_string=True, version="2.1")
+
+    output = ts.write_touchstone(return_string=True, version="2.1", r_ref=50)
+    ts_read_back = rf.Network.from_string(output)
+    expected = ts.copy()
+    expected.renormalize(50)
+
+    np.testing.assert_allclose(expected.s, ts_read_back.s)
+    np.testing.assert_allclose(expected.z0, ts_read_back.z0)
+
+
+def test_write_v2_with_hfss_port_impedance_comments():
+    ts = rf.Network(
+        f=[1, 2],
+        f_unit="ghz",
+        s=np.zeros((2, 2, 2), dtype=complex),
+        z0=[[50 + 1j, 75 + 2j], [55 + 3j, 80 + 4j]],
+        name="complex_z0",
+        s_def="traveling",
+    )
+
+    output = ts.write_touchstone(return_string=True, version="2.1", write_z0=True)
+    ts_read_back = rf.Network.from_string(output)
+
+    assert "! Port Impedance" in output
+    np.testing.assert_allclose(ts.s, ts_read_back.s)
+    np.testing.assert_allclose(ts.z0, ts_read_back.z0)
+
+
+def test_write_v2_rejects_invalid_inputs():
+    ts = rf.Network(f=[1], s=[[[0]]], name="invalid")
+
+    with pytest.raises(ValueError, match="version"):
+        ts.write_touchstone(return_string=True, version="3.0")
+    with pytest.raises(ValueError, match="positive"):
+        ts.copy().write_touchstone(return_string=True, version="2.1", r_ref=-50)
+    with pytest.raises(ValueError, match="at least one frequency"):
+        rf.Network(name="empty").write_touchstone(return_string=True, version="2.1")
+
+    mixed_mode = ts.copy()
+    mixed_mode.port_modes = np.array(["D"])
+    with pytest.raises(NotImplementedError, match="mixed-mode"):
+        mixed_mode.write_touchstone(return_string=True, version="2.1")
+
+
+@pytest.mark.parametrize(
+    ("encoding", "encoded_comment"),
+    [
+        ("ISO-8859-1", b"\xb5"),
+        ("UTF-8", b"\xc2\xb5"),
+    ],
+)
+def test_write_v2_file_encoding(tmp_path, encoding, encoded_comment):
+    ts = rf.Network(test_data / "ex_4.ts")
+    ts.name = "encoded"
+    ts.comments = "micro sign: µ"
+    filename = tmp_path / ts.name
+
+    ts.write_touchstone(filename, version="2.1", encoding=encoding)
+
+    output_file = filename.with_suffix(".ts")
+    output_bytes = output_file.read_bytes()
+    explicit_encoding = rf.Network(output_file, encoding=encoding)
+    detected_encoding = rf.Network(output_file)
+
+    assert encoded_comment in output_bytes
+    assert "micro sign: µ" in explicit_encoding.comments
+    assert "micro sign: µ" in detected_encoding.comments
+    assert ts == explicit_encoding
+    assert ts == detected_encoding
+
+
+def test_write_touchstone_defaults_to_iso_8859_1(tmp_path):
+    ts = rf.Network(test_data / "ex_4.ts")
+    ts.comments = "micro sign: µ"
+    filename = tmp_path / "default_encoding"
+
+    ts.write_touchstone(filename, version="2.1")
+
+    output_bytes = filename.with_suffix(".ts").read_bytes()
+    assert b"\xb5" in output_bytes
+    assert b"\xc2\xb5" not in output_bytes
+
+
+def test_read_touchstone_honors_explicit_encoding(tmp_path):
+    ts = rf.Network(test_data / "ex_4.ts")
+    ts.comments = "micro sign: µ"
+    filename = tmp_path / "latin1"
+    ts.write_touchstone(filename, version="2.1")
+
+    with pytest.raises(UnicodeDecodeError):
+        rf.Network(filename.with_suffix(".ts"), encoding="UTF-8")
+
+
+@pytest.mark.parametrize(
+    ("encoding", "encoded_comment"),
+    [
+        ("ISO-8859-1", b"\xb5"),
+        ("UTF-8", b"\xc2\xb5"),
+    ],
+)
+def test_write_v2_zip_encoding(tmp_path, encoding, encoded_comment):
+    ts = rf.Network(test_data / "ex_4.ts")
+    ts.name = "encoded"
+    ts.comments = "micro sign: µ"
+    archive_path = tmp_path / "touchstones.zip"
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        ts.write_touchstone("encoded.ts", to_archive=archive, version="2.1", encoding=encoding)
+        archive.writestr("reports", "not a Touchstone file")
+
+    with zipfile.ZipFile(archive_path) as archive:
+        output_bytes = archive.read("encoded.ts")
+        explicit_encoding = rf.Network.zipped_touchstone("encoded.ts", archive, encoding=encoding)
+        detected_encoding = rf.Network.zipped_touchstone("encoded.ts", archive)
+        discovered_networks = rf.io.read_zipped_touchstones(archive, encoding=encoding)
+        auto_discovered_networks = rf.io.read_zipped_touchstones(archive)
+
+    assert encoded_comment in output_bytes
+    assert "micro sign: µ" in explicit_encoding.comments
+    assert "micro sign: µ" in detected_encoding.comments
+    assert ts == explicit_encoding
+    assert ts == detected_encoding
+    assert discovered_networks == {"encoded": detected_encoding}
+    assert auto_discovered_networks == {"encoded": detected_encoding}
+
+
+@pytest.mark.parametrize("encoding", ["UTF-16", "ASCII", "not-a-codec"])
+def test_write_touchstone_rejects_unsupported_encoding(encoding):
+    ts = rf.Network(test_data / "ex_4.ts")
+
+    with pytest.raises(ValueError, match="encoding"):
+        ts.write_touchstone(return_string=True, version="2.1", encoding=encoding)
+
 
 s_mag = np.array(
         [[[0.6 , 0.4 , 0.42, 0.53],
@@ -232,6 +432,35 @@ def test_ts_example_17():
     snp = rf.Network(test_data / "ex_18.s2p")
     assert ts == snp
     assert np.allclose(ts.noise, snp.noise)
+
+
+@pytest.mark.parametrize("version", ["2.0", "2.1"])
+def test_ts_example_17_write_v2(version):
+    ts = rf.Network(test_data / "ex_17.ts")
+
+    output = ts.write_touchstone(return_string=True, form="ma", version=version)
+    ts_read_back = rf.Network.from_string(output)
+
+    assert "[Two-Port Data Order] 21_12" in output
+    assert "[Number of Noise Frequencies] 2" in output
+    assert "[Reference] 50.0 25.0" in output
+    assert "[Noise Data]" in output
+    noise_block = output.partition("[Noise Data]\n")[2].partition("[End]")[0]
+    noise_resistances = [
+        float(line.split()[-1])
+        for line in noise_block.splitlines()
+        if line and not line.startswith("!")
+    ]
+    np.testing.assert_allclose(noise_resistances, [19, 20])
+    np.testing.assert_allclose(ts.s, ts_read_back.s)
+    np.testing.assert_allclose(ts.z0, ts_read_back.z0)
+    expected_noise = ts.copy()
+    expected_noise.resample(ts.f_noise)
+    ts_read_back.resample(ts_read_back.f_noise)
+    np.testing.assert_allclose(expected_noise.nfmin_db, ts_read_back.nfmin_db)
+    np.testing.assert_allclose(expected_noise.g_opt, ts_read_back.g_opt)
+    np.testing.assert_allclose(expected_noise.rn, ts_read_back.rn)
+
 
 def test_ts_example_16():
     ts = rf.Network(test_data / "ex_16.ts")

--- a/skrf/io/touchstone.py
+++ b/skrf/io/touchstone.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..media import DefinedGammaZ0
 
+import io
 import os
 import re
 import typing
@@ -187,12 +188,14 @@ class Touchstone:
 
     The reference for writing this class is the draft of the
     Touchstone(R) File Format Specification Rev 2.0 [#]_ and
-    Touchstone(R) File Format Specification Version 2.0 [#]_
+    Touchstone(R) File Format Specification Version 2.0 [#]_ and
+    Touchstone(R) File Format Specification Version 2.1 [#]_
 
     References
     ----------
     .. [#] https://ibis.org/interconnect_wip/touchstone_spec2_draft.pdf
     .. [#] https://ibis.org/touchstone_ver2.0/touchstone_ver2_0.pdf
+    .. [#] https://ibis.org/touchstone_ver2.1/touchstone_ver2_1.pdf
     """
 
     def __init__(self, file: str | Path | typing.TextIO, encoding: str | None = None):
@@ -266,38 +269,24 @@ class Touchstone:
         self.s_def = None
         self.port_modes = np.array([])
 
-        # open the file depending on encoding
-        # Guessing the encoding by trial-and-error, unless specified encoding
+        if isinstance(file, str | Path):
+            file_path = Path(file)
+            if encoding is None:
+                try:
+                    file_contents = file_path.read_text(encoding="utf-8-sig")
+                except UnicodeDecodeError:
+                    file_contents = file_path.read_text(encoding="ISO-8859-1")
+            else:
+                file_contents = file_path.read_text(encoding=encoding)
+
+            fid = io.StringIO(file_contents)
+            fid.name = str(file_path)
+        else:
+            fid = get_fid(file)
+
         try:
-            try:
-                if encoding is not None:
-                    fid = get_fid(file, encoding=encoding)
-                    self.filename = fid.name
-                    self.load_file(fid)
-                else:
-                    # Assume default encoding
-                    fid = get_fid(file)
-                    self.filename = fid.name
-                    self.load_file(fid)
-            except Exception as e:
-                fid.close()
-                raise e
-
-        except UnicodeDecodeError:
-            # Unicode fails -> Force Latin-1
-            fid = get_fid(file, encoding="ISO-8859-1")
             self.filename = fid.name
             self.load_file(fid)
-
-        except ValueError:
-            # Assume Microsoft UTF-8 variant encoding with BOM
-            fid = get_fid(file, encoding="utf-8-sig")
-            self.filename = fid.name
-            self.load_file(fid)
-
-        except Exception as e:
-            raise ValueError("Something went wrong by the file opening") from e
-
         finally:
             fid.close()
 
@@ -355,7 +344,7 @@ class Touchstone:
     @version.setter
     def version(self, x: str) -> None:
         self._version = x
-        if x == "2.0":
+        if x in {"2.0", "2.1"}:
             self._parse_dict.update(self._parse_dict_v2)
 
     def _parse_port(self, fid: typing.TextIO) -> list[str]:
@@ -932,7 +921,11 @@ def hfss_touchstone_2_network(filename: str) -> Network:
     return my_network
 
 
-def read_zipped_touchstones(ziparchive: zipfile.ZipFile, dir: str = "") -> dict[str, Network]:
+def read_zipped_touchstones(
+    ziparchive: zipfile.ZipFile,
+    dir: str = "",
+    encoding: str | None = None,
+) -> dict[str, Network]:
     """
     similar to skrf.io.read_all_networks, which works for directories but only for Touchstones in ziparchives.
 
@@ -942,6 +935,9 @@ def read_zipped_touchstones(ziparchive: zipfile.ZipFile, dir: str = "") -> dict[
         an zip archive file, containing Touchstone files and open for reading
     dir : str
         the directory of the ziparchive to read networks from, default is "" which reads only the root directory
+    encoding : str, optional
+        File encoding. Supported encodings are ISO-8859-1 and UTF-8.
+        If omitted, encoding is detected for each file.
 
     Returns
     -------
@@ -952,7 +948,7 @@ def read_zipped_touchstones(ziparchive: zipfile.ZipFile, dir: str = "") -> dict[
     networks = dict()
     for fname in ziparchive.namelist():  # type: str
         directory = os.path.split(fname)[0]
-        if dir == directory and  re.search(r"s\d+p$", fname.lower()):
-            network = Network.zipped_touchstone(fname, ziparchive)
+        if dir == directory and re.search(r"\.(?:s\d+p|ts)$", fname.lower()):
+            network = Network.zipped_touchstone(fname, ziparchive, encoding=encoding)
             networks[network.name] = network
     return networks

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -190,6 +190,7 @@ if TYPE_CHECKING:
 
     from .plotting import Axes
 
+import codecs
 import io
 import os
 import re
@@ -231,6 +232,19 @@ from .frequency import Frequency
 from .plotting import axes_kwarg
 from .time import get_window, time_gate
 from .util import copy_doc, find_nearest_index, get_extn, get_fid, partial_with_docs
+
+
+def _normalize_touchstone_encoding(encoding: str) -> str:
+    """Return a supported Python codec name for a Touchstone file."""
+    try:
+        normalized_encoding = codecs.lookup(encoding).name
+    except LookupError as err:
+        raise ValueError(f"Unknown Touchstone encoding {encoding!r}") from err
+
+    if normalized_encoding not in {"iso8859-1", "utf-8"}:
+        raise ValueError("Touchstone encoding must be either ISO-8859-1 or UTF-8")
+
+    return normalized_encoding
 
 
 class Network:
@@ -2465,7 +2479,12 @@ class Network:
                 self.name = os.path.basename(os.path.splitext(touchstoneFile.filename)[0])
 
     @classmethod
-    def zipped_touchstone(cls, filename: str | Path, archive: zipfile.ZipFile) -> Network:
+    def zipped_touchstone(
+        cls,
+        filename: str | Path,
+        archive: zipfile.ZipFile,
+        encoding: str | None = None,
+    ) -> Network:
         """
         Read a Network from a Touchstone file in a ziparchive.
 
@@ -2475,6 +2494,9 @@ class Network:
             the full path filename of the touchstone file
         archive : zipfile.ZipFile
             the opened zip archive
+        encoding : str, optional
+            File encoding. Supported encodings are ISO-8859-1 and UTF-8.
+            If omitted, UTF-8 is attempted before ISO-8859-1.
 
         Returns
         -------
@@ -2486,10 +2508,19 @@ class Network:
         # Convert a path filename to a string
         filename = str(filename.resolve()) if isinstance(filename, Path) else filename
 
+        raw_data = archive.open(filename).read()
+        if encoding is None:
+            try:
+                data = raw_data.decode("utf-8-sig")
+            except UnicodeDecodeError:
+                data = raw_data.decode("iso8859-1")
+        else:
+            data = raw_data.decode(_normalize_touchstone_encoding(encoding))
+
         # Touchstone requires file objects to be seekable (for get_gamma_z0_from_fid)
         # A ZipExtFile object is not seekable prior to Python 3.7, so use StringIO
         # and manually add a name attribute
-        fileobj = io.StringIO(archive.open(filename).read().decode('UTF-8'))
+        fileobj = io.StringIO(data)
         fileobj.name = filename
         ntwk = Network(fileobj)
         return ntwk
@@ -2502,7 +2533,9 @@ class Network:
                          format_spec_nf_freq: str = '{}', format_spec_nf_min: str = '{}',
                          format_spec_g_opt_mag: str = '{}', format_spec_g_opt_phase: str = '{}',
                          format_spec_rn: str = '{}', write_noise: bool = True,
-                         parameter: Literal["S", "Y", "Z", "G", "H"] = "S") -> str | None:
+                         parameter: Literal["S", "Y", "Z", "G", "H"] = "S",
+                         version: Literal["1.0", "2.0", "2.1"] = "1.0",
+                         encoding: str = "ISO-8859-1") -> str | None:
 
         """
         Write a contents of the :class:`Network` to a touchstone file.
@@ -2572,6 +2605,11 @@ class Network:
         parameter : string
             Specify the network parameter ("S", "Y", "Z", "G", "H") to write, defaults to "S".
             "G" and "H" is only available for 2-port Networks.
+        version : string
+            Touchstone file format version. Supported versions are "1.0", "2.0", and "2.1".
+            Version "1.0" preserves the legacy output format.
+        encoding : string
+            File encoding. Supported encodings are ISO-8859-1 and UTF-8.
 
         Note
         ----
@@ -2585,32 +2623,63 @@ class Network:
         :class:`~skrf.io.touchstone.Touchstone` class.
 
         """
-        # according to Touchstone 2.0 spec
-        # [no tab, max. 4 coeffs per line, etc.]
+        if version not in {"1.0", "2.0", "2.1"}:
+            raise ValueError("`version` must be either '1.0', '2.0', or '2.1'")
+
+        normalized_encoding = _normalize_touchstone_encoding(encoding)
+        is_version_2 = version in {"2.0", "2.1"}
+
+        if is_version_2 and len(self.f) == 0:
+            raise ValueError("Touchstone 2.x requires at least one frequency point")
+        if is_version_2 and self.port_modes.size and np.any(self.port_modes != "S"):
+            raise NotImplementedError("Writing mixed-mode Touchstone 2.x data is not supported")
 
         have_complex_ports = np.any(self.z0.imag != 0)
         equal_z0 = np.all(self.z0 == self.z0[0, 0])
+        frequency_invariant_z0 = np.all(self.z0 == self.z0[0])
 
         ntwk = self.copy()
+        reference_impedances = None
 
-        if r_ref is None and not write_z0:
-            if not equal_z0:
-                raise ValueError(
-                    "Network has unequal port impedances but reference impedance for renormalization"
-                    " 'r_ref' is not specified."
-                    )
+        if is_version_2 and parameter != "S" and r_ref is None and not write_z0:
+            r_ref = 50
+        elif r_ref is None and not write_z0:
             if have_complex_ports:
                 raise ValueError(
                     "Network port impedances are complex but reference impedance for renormalization"
                      " 'r_ref' is not specified."
                     )
-            r_ref = ntwk.z0[0, 0]
+            if is_version_2:
+                if not frequency_invariant_z0:
+                    raise ValueError(
+                        "Network port impedances vary with frequency but Touchstone 2.x [Reference]"
+                        " impedances must be frequency invariant. Specify 'r_ref' to renormalize the network."
+                    )
+                reference_impedances = ntwk.z0[0].real
+                r_ref = reference_impedances[0]
+            else:
+                if not equal_z0:
+                    raise ValueError(
+                        "Network has unequal port impedances but reference impedance for renormalization"
+                        " 'r_ref' is not specified."
+                        )
+                r_ref = ntwk.z0[0, 0]
         elif r_ref is not None:
             if not np.isscalar(r_ref):
                 raise ValueError('r_ref must be scalar')
             if r_ref.imag != 0:
                 raise ValueError('r_ref must be real')
+            if is_version_2 and r_ref.real <= 0:
+                raise ValueError("Touchstone 2.x [Reference] impedances must be positive")
             ntwk.renormalize(r_ref)
+            if is_version_2:
+                reference_impedances = ntwk.z0[0].real
+        elif is_version_2 and frequency_invariant_z0 and not have_complex_ports:
+            reference_impedances = ntwk.z0[0].real
+            r_ref = reference_impedances[0]
+
+        if is_version_2 and reference_impedances is not None and np.any(reference_impedances <= 0):
+            raise ValueError("Touchstone 2.x [Reference] impedances must be positive")
 
         if filename is None:
             if ntwk.name is not None:
@@ -2628,13 +2697,17 @@ class Network:
 
         pdata = ntwk.s
         if parameter != "S":
-            pdata = globals()[f"s2{parameter.lower()}"](pdata, 1)
+            if is_version_2:
+                pdata = getattr(ntwk, parameter.lower())
+            else:
+                pdata = globals()[f"s2{parameter.lower()}"](pdata, 1)
 
         if get_extn(filename) is None:
             if isinstance(filename, Path):
                 filename = str(filename.resolve())
 
-            filename = f"{filename}.{parameter.lower()}{ntwk.nports}p"
+            extension = "ts" if is_version_2 else f"{parameter.lower()}{ntwk.nports}p"
+            filename = f"{filename}.{extension}"
 
         if dir is not None:
             filename = os.path.join(dir, filename)
@@ -2686,7 +2759,7 @@ class Network:
                 from .io.general import StringBuffer  # avoid circular import
                 buf = StringBuffer()
             else:
-                buf = open(filename, "w")
+                buf = open(filename, "w", encoding=normalized_encoding)
             return buf
 
         with get_buffer() as output:
@@ -2703,6 +2776,9 @@ class Network:
 
             output.write(commented_header)
 
+            if is_version_2:
+                output.write(f'[Version] {version}\n')
+
             # write header file.
             # the '#'  line is NOT a comment it is essential and it must be
             # exactly this format, to work
@@ -2710,7 +2786,11 @@ class Network:
             if write_z0:
                 output.write('! Data is not renormalized\n')
                 output.write(f'! S-parameter uses the {self.s_def} definition\n')
-                output.write(f'# {ntwk.frequency.unit} {parameter} {form.upper()} R\n')
+                if is_version_2:
+                    option_resistance = r_ref.real if r_ref is not None else 50
+                    output.write(f'# {ntwk.frequency.unit} {parameter} {form.upper()} R {option_resistance}\n')
+                else:
+                    output.write(f'# {ntwk.frequency.unit} {parameter} {form.upper()} R\n')
             else:
                 # Write "r_ref.real" instead of "r_ref", so we get a real number "a" instead
                 # of a complex number "(a+0j)", which is unsupported by the standard Touchstone
@@ -2721,6 +2801,17 @@ class Network:
                                         "should never happen in scikit-rf."
                 output.write(f'# {ntwk.frequency.unit} {parameter} {form.upper()} R {r_ref.real} \n')
 
+            if is_version_2:
+                output.write(f'[Number of Ports] {ntwk.number_of_ports}\n')
+                if ntwk.number_of_ports == 2:
+                    output.write('[Two-Port Data Order] 21_12\n')
+                output.write(f'[Number of Frequencies] {len(ntwk.f)}\n')
+                if ntwk.number_of_ports == 2 and ntwk.noisy and write_noise:
+                    output.write(f'[Number of Noise Frequencies] {ntwk.noise_freq.npoints}\n')
+                if parameter == "S" and reference_impedances is not None:
+                    references = " ".join(str(reference) for reference in reference_impedances)
+                    output.write(f'[Reference] {references}\n')
+
             # write ports
             try:
                 if ntwk.port_names and len(ntwk.port_names) == ntwk.number_of_ports:
@@ -2730,6 +2821,9 @@ class Network:
                     output.write(ports)
             except AttributeError:
                 pass
+
+            if is_version_2:
+                output.write('[Network Data]\n')
 
             if ntwk.number_of_ports == 2:
                 # 2-port is a special case with
@@ -2773,28 +2867,36 @@ class Network:
                 if ntwk.noisy and write_noise:
                     self._write_noisedata(output, format_spec_nf_freq, format_spec_nf_min,
                                           format_spec_g_opt_mag, format_spec_g_opt_phase,
-                                          format_spec_rn)
+                                          format_spec_rn, version)
+
+            if is_version_2:
+                output.write('[End]\n')
 
             if type(to_archive) is zipfile.ZipFile:
-                to_archive.writestr(filename, output.getvalue())
+                to_archive.writestr(filename, output.getvalue().encode(normalized_encoding))
             elif return_string is True:
                 return output.getvalue()
             return None
 
     def _write_noisedata(self, output, format_spec_nf_freq: str = '{}', format_spec_nf_min: str = '{}',
                          format_spec_g_opt_mag: str = '{}', format_spec_g_opt_phase: str = '{}',
-                         format_spec_rn: str = '{}'):
+                         format_spec_rn: str = '{}', version: str = "1.0"):
         ntwk = self.copy()
 
-        output.write("! Noise Data\n! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
+        if version in {"2.0", "2.1"}:
+            output.write("[Noise Data]\n")
+        else:
+            output.write("! Noise Data\n")
+        output.write("! freq\tnf_min_db\tmagGOpt\tdegGOpt\tRn_eff\n")
         new = ntwk.copy()
         new.resample(ntwk.f_noise) # only write data from original noise freqs
         for f, nf, g_opt, rn, z0 in zip(new.f_noise.f_scaled, new.nfmin_db, new.g_opt, new.rn, new.z0):
+            effective_rn = rn if version in {"2.0", "2.1"} else rn/z0[0].real
             output.write(format_spec_nf_freq.format(f) + ' ' \
                     + format_spec_nf_min.format(nf) + ' ' \
                     + format_spec_g_opt_mag.format(mf.complex_2_magnitude(g_opt)) + ' ' \
                     + format_spec_g_opt_phase.format(mf.complex_2_degree(g_opt)) + ' ' \
-                    + format_spec_rn.format(rn/z0[0].real) + ' ' "\n")
+                    + format_spec_rn.format(effective_rn) + ' ' "\n")
 
 
     def write(self, file: str | Path = None, *args, **kwargs) -> None:


### PR DESCRIPTION
- Adding support for writing Touchstone 2.1 files.
- Ensuring correct functionality with Unit Tests
- updating link to spec file

> [!note]
> Only reading of v2.1 files was implemented