### PR TITLE
Port name fixes

### DIFF
--- a/skrf/circuit.py
+++ b/skrf/circuit.py
@@ -1276,6 +1276,27 @@ class Circuit:
                 port_indexes.append(idx_cnx)
         return port_indexes
 
+    @property
+    def port_names(self) -> list[str]:
+        """
+        Return the names of the "external" ports.
+
+        The names are given in the same order as the ports of the Network
+        returned by :func:`network`, ie. in the order the port Networks appear
+        in the connection list.
+
+        Returns
+        -------
+        port_names : list of str
+
+        See Also
+        --------
+        port_indexes
+        network
+        """
+        return [ntw.name for (ntw, _) in chain.from_iterable(self.connections)
+                if Circuit._is_port(ntw)]
+
     def _cnx_z0(self, cnx_k: list[tuple]) -> np.ndarray:
         """
         Return the characteristic impedances of a specific connections.
@@ -1389,9 +1410,16 @@ class Circuit:
         -------
         ntw : :class:`~skrf.network.Network`
             Network associated to external ports
+
+        See Also
+        --------
+        port_names
         """
-        return Network(frequency = self.frequency, z0 = self.port_z0,
+        ntw = Network(frequency = self.frequency, z0 = self.port_z0,
                       s = self.s_external, name = self.name)
+        # the external ports are named, keep track of which port is where
+        ntw.port_names = self.port_names
+        return ntw
 
     def s_active(self, a: NumberLike) -> np.ndarray:
         r"""

--- a/skrf/io/general.py
+++ b/skrf/io/general.py
@@ -873,9 +873,12 @@ def from_json_string(obj_string):
     ntwk.variables = obj['variables']
     ntwk.name = obj['name']
     ntwk.comments = obj['comments']
-    ntwk.port_names = obj['port_names']
     ntwk.z0 = np.array(obj['_z0'])[..., 0] + np.array(obj['_z0'])[..., 1] * 1j  # recreate complex numbers
     ntwk.s = np.array(obj['_s'])[..., 0] + np.array(obj['_s'])[..., 1] * 1j
+    # after the s-parameters, the number of ports has to be known to be able to
+    # check that there is a name for every port. 'port_names' is the key used
+    # before port_names became a property, accept it as well.
+    ntwk.port_names = obj.get('_port_names', obj.get('port_names'))
     ntwk.frequency = Frequency.from_f(np.array(obj['_frequency']['flist']),
                                          unit=obj['_frequency']['funit'])
     return ntwk

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -394,6 +394,8 @@ class Network:
         \*\*kwargs :
             key word arguments can be used to assign properties of the
             Network, such as `s`, `f` and `z0`.
+            keyword `port_names` can be used to name the ports, list with one
+                     name per port.
             keyword `encoding` can be used to define the Touchstone file encoding.
             keyword `noise_interp_kind` used to change the default interpolation
                      method for noisy networks. Options are 'linear', 'nearest',
@@ -447,7 +449,7 @@ class Network:
         self.name = name
         self.params = params
         self.comments = comments
-        self.port_names = None
+        self._port_names = None
         self.encoding = kwargs.pop('encoding', None)
 
         self.deembed = None
@@ -527,6 +529,11 @@ class Network:
         for attr in list(PRIMARY_PROPERTIES) + ['frequency', 'noise', 'noise_freq']:
             if attr in kwargs:
                 self.__setattr__(attr, kwargs[attr])
+
+        # Assign port_names after S-parameters so that the number of ports can
+        # be checked.
+        if 'port_names' in kwargs:
+            self.port_names = kwargs['port_names']
 
     @classmethod
     def from_z(cls, z: np.ndarray, *args, **kw) -> Network:
@@ -987,6 +994,13 @@ class Network:
 
         return ret + s_properties
 
+    def __setstate__(self, state: dict) -> None:
+        # port_names used to be a plain attribute, it is a property now and
+        # unpickling an old Network would leave it shadowed and lost
+        if 'port_names' in state:
+            state['_port_names'] = state.pop('port_names')
+        self.__dict__.update(state)
+
     def attribute(self, prop_name: PrimaryPropertiesT, conversion: ComponentFuncT) -> np.ndarray:
         prop = getattr(self, prop_name)
         return self.COMPONENT_FUNC_DICT[conversion](prop)
@@ -1043,6 +1057,11 @@ class Network:
 
         if len(self.port_modes) != self.nports:
             self.port_modes = np.array(["S"] * self.nports)
+
+        # the ports are not the same ones anymore, whoever changed the number
+        # of ports has to set the names of the new ports
+        if self._port_names is not None and len(self._port_names) != self.nports:
+            self._port_names = None
 
     @property
     def s_traveling(self) -> np.ndarray:
@@ -1699,6 +1718,44 @@ class Network:
         self._port_modes = port_modes
 
     @property
+    def port_names(self) -> list[str] | None:
+        """
+        Names of the ports, or None if the ports are not named.
+
+        Named ports can be indexed by name. The names are read from and written
+        to touchstone files.
+
+        Length of the port_names list should match the number of ports in the
+        network, this is checked on assigment. The names are dropped when an
+        operation changes the number of ports without being able to tell what
+        the new ports are.
+
+        Returns
+        -------
+        port_names : list of str, or None
+                names of the ports
+
+        Examples
+        --------
+        >>> ntwk = rf.Network(f=[1], s=np.zeros((1, 2, 2)), port_names=['in', 'out'])
+        >>> ntwk['in', 'out']  # same as ntwk.s21
+
+        """
+        return self._port_names
+
+    @port_names.setter
+    def port_names(self, port_names: Sequence[str] | None) -> None:
+        if port_names is None:
+            self._port_names = None
+            return
+        port_names = list(port_names)
+        if len(port_names) != self.nports:
+            raise ValueError(
+                f'Number of port names ({len(port_names)}) does not match the '
+                f'number of ports ({self.nports})')
+        self._port_names = port_names
+
+    @property
     def port_tuples(self) -> list[tuple[int, int]]:
         """
         Returns a list of tuples, for each port index pair.
@@ -2197,7 +2254,8 @@ class Network:
         >>> b = rf.N('my_file.s2p')
         >>> a.copy_from (b)
         """
-        for attr in ['_s', 'frequency', '_z0', 'name']:
+        # assigment order matters here since there are checks in some setters
+        for attr in ['_s', 'frequency', '_z0', 'name', 'port_names']:
             setattr(self, attr, copy(getattr(other, attr)))
 
     def copy_subset(self, key: np.ndarray) -> Network:
@@ -2423,9 +2481,10 @@ class Network:
 
         self.variables = touchstoneFile.get_comment_variables()
 
-        self.port_names = touchstoneFile.port_names
-
         f, self.s = touchstoneFile.get_sparameter_arrays()  # note: freq in Hz
+        # after the s-parameters, the number of ports has to be known to be
+        # able to check that there is a name for every port
+        self.port_names = touchstoneFile.port_names
         self.frequency = Frequency.from_f(f, unit='hz')
         self.frequency.unit = touchstoneFile.frequency_unit
 
@@ -6167,6 +6226,8 @@ def one_port_2_two_port(ntwk: Network) -> Network:
         the resultant two-port Network
     """
     result = ntwk.copy()
+    # setting s drops the port name of the one-port, the second port of the
+    # result is synthesized and there is no name to give to either of them
     result.s = np.zeros((result.frequency.npoints, 2, 2), dtype=complex)
     s11 = ntwk.s[:, 0, 0]
     result.s[:, 0, 0] = s11

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5906,6 +5906,8 @@ def stitch(ntwkA: Network, ntwkB: Network, **kwargs) -> Network:
         **kwargs
     )
     C.frequency.unit = A.frequency.unit
+    # the ports are the same ones, only the frequency axis is stitched
+    C.port_names = A.port_names
     return C
 
 
@@ -8640,6 +8642,9 @@ def two_port_reflect(ntwk1: Network, ntwk2: Network | None = None, name : str | 
          [s21, s22]]). \
         transpose().reshape(-1, 2, 2)
     result.z0 = np.hstack([ntwk1.z0, ntwk2.z0])
+    # port_names was copied from ntwk1 and would be too short for a two-port
+    if ntwk1.port_names is not None or ntwk2.port_names is not None:
+        result.port_names = list(ntwk1.port_names or ['0']) + list(ntwk2.port_names or ['1'])
 
     if name is None:
         try:
@@ -8848,4 +8853,9 @@ def twoport_to_nport(ntwk: Network, port1: int, port2: int, nports: int, **kwarg
     nport.s[:,port2,port2] = ntwk.s[:,1,1]
     nport.z0[:,port1] = ntwk.z0[:,0]
     nport.z0[:,port2] = ntwk.z0[:,1]
+    # keep track of where the two-port's ports ended up, the added ports are new
+    if ntwk.port_names is not None:
+        port_names = [str(x) for x in range(nports)]
+        port_names[port1], port_names[port2] = ntwk.port_names
+        nport.port_names = port_names
     return nport

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5230,11 +5230,14 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     if (l + num - 1 > ntwkB.nports - 1):
         raise IndexError('Port `l` out of range')
 
-    # create port_names if required
-    if ntwkB.port_names is None:
-        if ntwkA.port_names is not None:
-            ntwkB = ntwkB.copy()
-            ntwkB.port_names = [str(x) for x in range(ntwkB.nports)]
+    # port names of the result, created for the network which doesn't have them
+    # when only one of the two networks is named
+    port_names_a, port_names_b = ntwkA.port_names, ntwkB.port_names
+    if port_names_a is not None or port_names_b is not None:
+        if port_names_a is None:
+            port_names_a = [str(x) for x in range(ntwkA.nports)]
+        if port_names_b is None:
+            port_names_b = [str(x) for x in range(ntwkB.nports)]
 
     have_complex_ports = (ntwkA.z0.imag != 0).any() or (ntwkB.z0.imag != 0).any()
 
@@ -5292,9 +5295,9 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     # combine z0 and port_names arrays and remove ports which were `connected`
     ntwkC.z0 = np.hstack(
         (np.delete(ntwkA.z0, range(k, k + 1), 1), np.delete(ntwkB.z0, range(l, l + 1), 1)))
-    if ntwkA.port_names is not None:
+    if port_names_a is not None:
         ntwkC.port_names = np.concatenate(
-            (np.delete(ntwkA.port_names, k), np.delete(ntwkB.port_names, l))).tolist()
+            (np.delete(port_names_a, k), np.delete(port_names_b, l))).tolist()
 
     # if we're connecting more than one port, call innerconnect recursively
     # until all connections are made to finish the job
@@ -6015,6 +6018,14 @@ def concat_ports(ntwk_list: Sequence[Network], port_order: Literal["first", "sec
     ntwkC.s = C
     ntwkC.z0 = np.hstack([ntwkA.z0, ntwkB.z0])
     ntwkC.port_modes = np.hstack([ntwkA.port_modes, ntwkB.port_modes])
+    # port_names was copied from ntwkA and would be too short for ntwkC.
+    # Create names for the network which doesn't have them, like connect() does.
+    if ntwkA.port_names is not None or ntwkB.port_names is not None:
+        names_a = ntwkA.port_names if ntwkA.port_names is not None \
+                else [str(x) for x in range(nA)]
+        names_b = ntwkB.port_names if ntwkB.port_names is not None \
+                else [str(x) for x in range(nB)]
+        ntwkC.port_names = list(names_a) + list(names_b)
     if port_order == 'second':
         old_order = list(range(nC))
         new_order = list(range(0, nC, 2)) + list(range(1, nC, 2))

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -912,10 +912,14 @@ class Network:
                     except ValueError as err:
                         raise KeyError(f"Unknown port {p2_name}") from err
                 ntwk = self.copy()
+                # setting s drops the port names, the result is a one-port
                 ntwk.s = self.s[:, p1_index, p2_index]
                 ntwk.z0 = self.z0[:, p1_index]
                 ntwk.name = f"{self.name}({p1_name}, {p2_name})"
-                ntwk.port_names = None
+                # a reflection coefficient is the port it is measured at, a
+                # transmission one is not any single port of this network
+                ntwk.port_names = [self.port_names[p1_index]] \
+                        if p1_index == p2_index and self.port_names is not None else None
                 return ntwk
             else:
                 raise ValueError(f"Don't understand index: {key}")
@@ -981,8 +985,13 @@ class Network:
             t0 = int(m.group(1)) - 1
             t1 = int(m.group(2)) - 1
             ntwk = self.copy()
+            # setting s drops the port names, the result is a one-port
             ntwk.s = self.s[:, t0, t1]
             ntwk.z0 = self.z0[:, t0]
+            # a reflection coefficient is the port it is measured at, a
+            # transmission one is not any single port of this network
+            if t0 == t1 and self.port_names is not None:
+                ntwk.port_names = [self.port_names[t0]]
             return ntwk
         raise AttributeError(f'object does not have attribute {name}')
 
@@ -1508,6 +1517,12 @@ class Network:
         port_pairs: int = self.nports // 2
         out.z0[:, :port_pairs] = self.z0[:, port_pairs:]
         out.z0[:, port_pairs:] = self.z0[:, :port_pairs]
+        # flip the port names the same way
+        if self.port_names is not None:
+            port_names = self.port_names.copy()
+            port_names[:port_pairs] = self.port_names[port_pairs:]
+            port_names[port_pairs:] = self.port_names[:port_pairs]
+            out.port_names = port_names
         out.deembed = True
         return out
 
@@ -5783,9 +5798,12 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
 
     z0_equal = (ntwkC.z0[:, k] == ntwkC.z0[:, l]).all()
 
+    # port names of the result, the connected ports are removed from them at
+    # the end. The mismatch below shuffles the ports around without changing
+    # which port is where, and setting `s` drops the names.
+    port_names = ntwkC.port_names
+
     if not z0_equal:
-        if ntwkC.port_names is not None:
-            port_names = ntwkC.port_names.copy()
         # connect a impedance mismatch, which will takes into account the
         # effect of differing port impedances
         mismatch = impedance_mismatch(ntwkA.z0[:, k], ntwkA.z0[:, l], ntwkA.s_def)
@@ -5796,16 +5814,14 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
         ntwkC.z0[:, k:] = np.hstack((ntwkC.z0[:, k + 1:], ntwkC.z0[:, [l]]))
         ntwkC.renumber(from_ports=[ntwkC.nports - 1] + list(range(k, ntwkC.nports - 1)),
                        to_ports=list(range(k, ntwkC.nports)))
-        if ntwkC.port_names is not None:
-            ntwkC.port_names = port_names
 
     # call s-matrix connection function
     ntwkC.s = innerconnect_s(ntwkC.s if not z0_equal else ntwkA.s, k, l)
 
     # update the characteristic impedance matrix and port_names
     ntwkC.z0 = np.delete(ntwkC.z0, list(range(k, k + 1)) + list(range(l, l + 1)), 1)
-    if ntwkC.port_names is not None:
-        ntwkC.port_names = np.delete(ntwkC.port_names, [k] + [l]).tolist()
+    if port_names is not None:
+        ntwkC.port_names = np.delete(port_names, [k] + [l]).tolist()
 
     # recur if we're connecting more than one port
     if num > 1:
@@ -5966,7 +5982,7 @@ def stitch(ntwkA: Network, ntwkB: Network, **kwargs) -> Network:
     )
     C.frequency.unit = A.frequency.unit
     # the ports are the same ones, only the frequency axis is stitched
-    C.port_names = A.port_names
+    C.port_names = list(A.port_names) if A.port_names is not None else None
     return C
 
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4085,6 +4085,8 @@ class Network:
 
         self.port_modes[:p] = "D"
         self.port_modes[p:2 * p] = "C"
+        # the single ended names don't describe the mixed mode ports anymore
+        self.port_names = _mixed_mode_port_names(self.port_names, p)
         if s_def is None:
             s_def = self.s_def
         if s_def != self.s_def:
@@ -4219,6 +4221,8 @@ class Network:
             raise ValueError('Invalid number of differential ports')
 
         self.port_modes[:2*p] = "S"
+        # restore the single ended names, if se2gmm created the mixed mode ones
+        self.port_names = _single_ended_port_names(self.port_names, p)
         if s_def is None:
             s_def = self.s_def
         if s_def != self.s_def:
@@ -5157,6 +5161,45 @@ PRIMARY_PROPERTIES = Network.PRIMARY_PROPERTIES
 Y_LABEL_DICT = Network.Y_LABEL_DICT
 
 ## Functions operating on Network[s]
+def _mixed_mode_port_names(port_names: list[str] | None, p: int) -> list[str] | None:
+    """
+    Port names of a network converted to mixed mode with :func:`Network.se2gmm`.
+
+    The differential and common mode ports of a pair are named after the two
+    single ended ports they are made of, which keeps the names unique and lets
+    :func:`Network.gmm2se` restore the original ones.
+
+    Returns None if there is nothing to convert.
+    """
+    if port_names is None or len(port_names) < 2 * p:
+        return None
+    pairs = [f'({port_names[2 * i]},{port_names[2 * i + 1]})' for i in range(p)]
+    return [f'd{pair}' for pair in pairs] + [f'c{pair}' for pair in pairs] \
+            + list(port_names[2 * p:])
+
+
+def _single_ended_port_names(port_names: list[str] | None, p: int) -> list[str] | None:
+    """
+    Inverse of :func:`_mixed_mode_port_names`, used by :func:`Network.gmm2se`.
+
+    Returns None if the names were not created by :func:`_mixed_mode_port_names`,
+    in which case the names of the single ended ports are unknown.
+    """
+    if port_names is None or len(port_names) < 2 * p:
+        return None
+    se_names = []
+    for i in range(p):
+        diff, comm = port_names[i], port_names[p + i]
+        if not (diff.startswith('d(') and comm.startswith('c(')
+                and diff.endswith(')') and diff[1:] == comm[1:]):
+            return None
+        pair = diff[2:-1].split(',')
+        if len(pair) != 2:
+            return None
+        se_names += pair
+    return se_names + list(port_names[2 * p:])
+
+
 def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Network:
     """
     Connect two n-port networks together.

--- a/skrf/tests/test_circuit.py
+++ b/skrf/tests/test_circuit.py
@@ -250,6 +250,31 @@ class CircuitClassMethods(unittest.TestCase):
             self.media.short(nports=2).s
             )
 
+    def test_port_names(self):
+        """The ports of a Circuit are named, the resulting Network keeps them.
+
+        The ports come out in the order the port Networks appear in the
+        connection list, which is not necessarily the order they were created in.
+        """
+        tee = self.media.tee(name='tee')
+        line = self.media.line(1, 'm', name='line')
+        p_in = Circuit.Port(self.freq, 'input', z0=50)
+        p_thru = Circuit.Port(self.freq, 'thru', z0=50)
+        p_coupled = Circuit.Port(self.freq, 'coupled', z0=75)
+
+        cir = Circuit([[(p_coupled, 0), (tee, 2)],
+                       [(p_in, 0), (tee, 0)],
+                       [(tee, 1), (line, 0)],
+                       [(line, 1), (p_thru, 0)]])
+        ntwk = cir.network
+
+        self.assertEqual(cir.port_names, ['coupled', 'input', 'thru'])
+        self.assertEqual(ntwk.port_names, cir.port_names)
+        # the names must describe the ports of the network: the 75 ohm port is
+        # the one named 'coupled'
+        self.assertEqual(ntwk.z0[0, ntwk.port_names.index('coupled')].real, 75)
+        ntwk['input', 'thru']  # name based indexing works on the result
+
 class CircuitTestWilkinson(unittest.TestCase):
     """
     Create a Wilkinson power divider Circuit [#]_ and test the results

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -579,6 +579,38 @@ class NetworkTestCase(unittest.TestCase):
             self.assertTrue(np.allclose(self.DUT2.z0[:, i:j], self.l2.z0)) # check z0
         self.assertTrue(np.all(self.DUT2.port_modes == np.array(['S']*8))) # check port mode
 
+    def test_concat_ports_port_names(self):
+        """port_names must cover all ports of the concatenated network.
+
+        They used to be copied from the first network only, which raised an
+        IndexError for port_order='second' and gave a too short list otherwise.
+        """
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+
+        def two_port(prefix, named=True):
+            ntwk = rf.Network(frequency=freq, s=self.rng.random((1, 2, 2)), name=prefix)
+            if named:
+                ntwk.port_names = [f'{prefix}0', f'{prefix}1']
+            return ntwk
+
+        a, b = two_port('a'), two_port('b')
+        # 'first' is front-to-back, 'second' left-to-right, see the diagrams in
+        # concat_ports. The names must follow the s-parameters either way.
+        self.assertEqual(concat_ports([a, b], port_order='first').port_names,
+                         ['a0', 'a1', 'b0', 'b1'])
+        self.assertEqual(concat_ports([a, b], port_order='second').port_names,
+                         ['a0', 'b0', 'a1', 'b1'])
+        self.assertEqual(concat_ports([a, b, two_port('c'), two_port('d')],
+                                      port_order='first').port_names,
+                         ['a0', 'a1', 'b0', 'b1', 'c0', 'c1', 'd0', 'd1'])
+
+        # names are created for the network which doesn't have them
+        self.assertEqual(concat_ports([a, two_port('b', named=False)],
+                                      port_order='first').port_names,
+                         ['a0', 'a1', '0', '1'])
+        self.assertIsNone(concat_ports([two_port('a', named=False),
+                                        two_port('b', named=False)]).port_names)
+
     def test_connect(self):
         self.assertEqual(connect(self.ntwk1, 1, self.ntwk2, 0) , \
             self.ntwk3)
@@ -831,10 +863,11 @@ class NetworkTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(ntwk1.z0[0], [10, 3, 4])
         self.assertTrue(ntwk1.port_names == ["a", "2", "3"])
 
-        # this removes port_names from splitter
+        # the other way around keeps port_names from splitter as well and
+        # provides port_names for thru
         ntwk2 = connect(self.thru, 2, self.splitter, 0, 2)
         np.testing.assert_almost_equal(ntwk2.z0[0], [1, 2, 30])
-        self.assertTrue(ntwk2.port_names is None)
+        self.assertTrue(ntwk2.port_names == ["0", "1", "c"])
 
     def test_interconnect_complex_ports(self):
         """ Test that connecting two complex ports in a network

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -29,6 +29,7 @@ from skrf.network import (
     fix_z0_shape,
     h2s,
     n_twoports_2_nport,
+    one_port_2_two_port,
     parallelconnect,
     renormalize_s,
     s2a,
@@ -779,6 +780,102 @@ class NetworkTestCase(unittest.TestCase):
         np.testing.assert_allclose(nport.z0[:, 1], dut.z0[:, 1])
         self.assertIsNone(twoport_to_nport(ntwk(2, 'u', port_names=False),
                                            0, 1, nports=3).port_names)
+
+    def test_port_names_length_is_checked(self):
+        """There must be a name for every port, or no names at all."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+        two_port = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
+
+        # the constructor names the ports as well
+        named = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)),
+                           port_names=['in', 'out'])
+        self.assertEqual(named.port_names, ['in', 'out'])
+        with self.assertRaises(ValueError):
+            rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)),
+                       port_names=['in'])
+
+        with self.assertRaises(ValueError):
+            two_port.port_names = ['only_one']
+        with self.assertRaises(ValueError):
+            two_port.port_names = ['a', 'b', 'c']
+        self.assertIsNone(two_port.port_names)
+
+        # names are dropped when the ports they describe are gone
+        named.s = self.rng.random((5, 3, 3))
+        self.assertIsNone(named.port_names)
+
+        # copy_from sets the s-parameters directly, the names must follow the
+        # ports it copies instead of being left over from the previous ones
+        three_port = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 3, 3)),
+                                port_names=['a', 'b', 'c'])
+        target = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)),
+                            port_names=['in', 'out'])
+        target.copy_from(three_port)
+        self.assertEqual(target.port_names, ['a', 'b', 'c'])
+        target.copy_from(rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2))))
+        self.assertIsNone(target.port_names)
+
+    def test_port_names_pickle_roundtrip(self):
+        """Reading a pickled Network must keep the names of its ports."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+        ntwk = rf.Network(frequency=freq, name='p', z0=50,
+                          s=self.rng.random((5, 2, 2)), port_names=['in', 'out'])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'p.ntwk')
+            ntwk.write(path)
+            # rf.Network(file) goes through copy_from, which used to drop them
+            self.assertEqual(rf.Network(path).port_names, ['in', 'out'])
+
+    def test_port_names_are_dropped(self):
+        """Operations which leave different ports must not keep their names."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+        two_port = rf.Network(frequency=freq, name='a', z0=[10, 20],
+                              s=self.rng.random((5, 2, 2)), port_names=['in', 'out'])
+
+        # a transmission coefficient is a one-port which is neither of the
+        # ports it is measured between
+        self.assertIsNone(two_port.s21.port_names)
+        self.assertIsNone(two_port.s2_1.port_names)
+        self.assertIsNone(two_port.nonreciprocity(1, 2).port_names)
+        self.assertIsNone(two_port['in', 'out'].port_names)
+
+        # a reflection coefficient is the port it is measured at, it keeps
+        # the name of that port
+        self.assertEqual(two_port.s11.port_names, ['in'])
+        self.assertEqual(two_port.s22.port_names, ['out'])
+        self.assertEqual(two_port.s2_2.port_names, ['out'])
+        self.assertEqual(two_port['in', 'in'].port_names, ['in'])
+        # the name follows the port, ie. its z0
+        np.testing.assert_allclose(two_port.s22.z0[:, 0], two_port.z0[:, 1])
+        # a network without names stays without names
+        unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
+        self.assertIsNone(unnamed.s11.port_names)
+
+        # one_port_2_two_port synthesizes a second port there is no name for
+        one_port = rf.Network(frequency=freq, name='o', z0=50,
+                              s=self.rng.random((5, 1, 1)), port_names=['refl'])
+        self.assertIsNone(one_port_2_two_port(one_port).port_names)
+
+    def test_inv_port_names(self):
+        """inv flips the ports, the names must follow like z0 does."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+        two_port = rf.Network(frequency=freq, name='a', z0=[10, 20],
+                              s=self.rng.random((5, 2, 2)), port_names=['in', 'out'])
+
+        inverse = two_port.inv
+        self.assertEqual(inverse.port_names, ['out', 'in'])
+        # the names describe the same ports as z0 does
+        np.testing.assert_allclose(inverse.z0[:, 0], two_port.z0[:, 1])
+        np.testing.assert_allclose(inverse.z0[:, 1], two_port.z0[:, 0])
+
+        four_port = rf.Network(frequency=freq, name='b', z0=[10, 20, 30, 40],
+                               s=self.rng.random((5, 4, 4)),
+                               port_names=['a', 'b', 'c', 'd'])
+        self.assertEqual(four_port.inv.port_names, ['c', 'd', 'a', 'b'])
+
+        unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
+        self.assertIsNone(unnamed.inv.port_names)
 
     def test_connect_no_frequency(self):
         """ Connecting 2 networks defined without frequency returns Error

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -39,6 +39,7 @@ from skrf.network import (
     s2vswr_active,
     s2y,
     s2z,
+    stitch,
     subnetwork,
     t2s,
     two_port_reflect,
@@ -733,6 +734,51 @@ class NetworkTestCase(unittest.TestCase):
             expected = [f'a{i}' for i in range(4)]
             expected[port] = 'b1'
             self.assertEqual(ntwk_c.port_names, expected)
+
+    def test_port_names_are_kept(self):
+        """Operations which don't change the ports must keep their names."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+
+        def ntwk(nports, prefix, port_names=True, frequency=freq):
+            n = rf.Network(frequency=frequency, name=prefix, z0=50,
+                           s=self.rng.random((frequency.npoints, nports, nports)))
+            if port_names:
+                n.port_names = [f'{prefix}{i}' for i in range(nports)]
+            return n
+
+        # stitch only concatenates the frequency axis, the ports stay the same
+        two_port = ntwk(2, 'a')
+        stitched = stitch(two_port, ntwk(2, 'a', frequency=rf.Frequency(4, 6, 5, unit='GHz')))
+        self.assertEqual(stitched.port_names, ['a0', 'a1'])
+        self.assertIsNone(stitch(ntwk(2, 'u', port_names=False),
+                                 ntwk(2, 'v', port_names=False,
+                                      frequency=rf.Frequency(4, 6, 5, unit='GHz'))).port_names)
+
+        # two_port_reflect used to keep the single name of the first one-port,
+        # which left a two-port with one port name
+        short, open_ = ntwk(1, 'short'), ntwk(1, 'open')
+        reflect = two_port_reflect(short, open_)
+        self.assertEqual(reflect.port_names, ['short0', 'open0'])
+        reflect['short0', 'open0']  # name based indexing must work
+        # a name is created for the one-port which doesn't have one
+        self.assertEqual(two_port_reflect(short, ntwk(1, 'x', port_names=False)).port_names,
+                         ['short0', '1'])
+        self.assertEqual(two_port_reflect(ntwk(1, 'x', port_names=False), open_).port_names,
+                         ['0', 'open0'])
+        self.assertIsNone(two_port_reflect(ntwk(1, 'x', port_names=False),
+                                           ntwk(1, 'y', port_names=False)).port_names)
+
+        # twoport_to_nport keeps track of where the two-port's ports ended up
+        dut = rf.Network(frequency=freq, name='dut', z0=[10, 20],
+                         s=self.rng.random((freq.npoints, 2, 2)))
+        dut.port_names = ['in', 'out']
+        nport = twoport_to_nport(dut, 3, 1, nports=4)
+        self.assertEqual(nport.port_names, ['0', 'out', '2', 'in'])
+        # the names follow the ports, ie. the z0 of the two-port
+        np.testing.assert_allclose(nport.z0[:, 3], dut.z0[:, 0])
+        np.testing.assert_allclose(nport.z0[:, 1], dut.z0[:, 1])
+        self.assertIsNone(twoport_to_nport(ntwk(2, 'u', port_names=False),
+                                           0, 1, nports=3).port_names)
 
     def test_connect_no_frequency(self):
         """ Connecting 2 networks defined without frequency returns Error

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -2037,6 +2037,47 @@ class NetworkTestCase(unittest.TestCase):
             self.assertTrue(np.allclose(ntwk4.s, ntwk4t.s))
             self.assertTrue(np.allclose(ntwk4.z0, ntwk4t.z0))
 
+    def test_se2gmm2se_port_names(self):
+        """The mixed mode ports are named after the pair they are made of.
+
+        The single ended names do not describe the mixed mode ports, so se2gmm
+        renames them, keeping them unique, and gmm2se restores the original ones.
+        """
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+
+        def ntwk(nports, port_names):
+            n = rf.Network(frequency=freq, s=self.rng.random((1, nports, nports)))
+            n.port_names = port_names
+            return n
+
+        # 2 differential pairs
+        n = ntwk(4, ['in_p', 'in_n', 'out_p', 'out_n'])
+        n.se2gmm(p=2)
+        self.assertEqual(n.port_names, ['d(in_p,in_n)', 'd(out_p,out_n)',
+                                        'c(in_p,in_n)', 'c(out_p,out_n)'])
+        n['d(in_p,in_n)', 'c(out_p,out_n)']  # names stay unique and usable
+        n.gmm2se(p=2)
+        self.assertEqual(n.port_names, ['in_p', 'in_n', 'out_p', 'out_n'])
+
+        # ports which stay single ended keep their name
+        n = ntwk(5, ['a_p', 'a_n', 'b_p', 'b_n', 'gnd'])
+        n.se2gmm(p=2)
+        self.assertEqual(n.port_names, ['d(a_p,a_n)', 'd(b_p,b_n)',
+                                        'c(a_p,a_n)', 'c(b_p,b_n)', 'gnd'])
+        n.gmm2se(p=2)
+        self.assertEqual(n.port_names, ['a_p', 'a_n', 'b_p', 'b_n', 'gnd'])
+
+        # a network without names stays without names
+        n = rf.Network(frequency=freq, s=self.rng.random((1, 4, 4)))
+        n.se2gmm(p=2)
+        self.assertIsNone(n.port_names)
+
+        # names which cannot be restored are dropped instead of being wrong
+        n = ntwk(4, ['a,b', 'c', 'd', 'e'])
+        n.se2gmm(p=2)
+        n.gmm2se(p=2)
+        self.assertIsNone(n.port_names)
+
     def test_se2gmm(self):
         # Test mixed mode conversion of two parallel thrus
         se = np.zeros((1,4,4), dtype=complex)


### PR DESCRIPTION
Fixes #1241.

Fix many bugs with `port_names` handling:
* `port_names` is now a property with some basic error checking on assignment.
* Circuit now has `port_names` in generated Networks.
* `port_names` can be gives in `Network` constructor.
* `connect`, `copy_from`, `stitch`, `inv`, `concat_ports`, `twoport_reflect`, `one_port_2_two_port` functions now handle `port_names`.
* `se2gmm` will automatically generate name for ports and it can undo the automatically generated names when transforming in the opposite direction.

I have few more changes, for example accepting port names in connect, but I split them into separate PR.