### PR TITLE
Fix time gate level shift caused by a periodic window

### DIFF
--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -167,10 +167,70 @@ class NetworkTestCase(unittest.TestCase):
         for window in ["hamming", ('kaiser', 6)]:
             gated1 = self.ntwk1.s11.time_gate(0,.2, t_unit='ns', window=window, fft_window=window)
 
-            get_window = partial(signal.get_window, window)
+            # the time-domain gate is symmetric, the frequency-domain window is periodic
+            gate_window = partial(signal.get_window, window, fftbins=False)
+            fft_window = partial(signal.get_window, window)
 
-            gated2 = self.ntwk1.s11.time_gate(0,.2, t_unit='ns', window=get_window, fft_window=get_window)
+            gated2 = self.ntwk1.s11.time_gate(0,.2, t_unit='ns', window=gate_window, fft_window=fft_window)
             assert gated1 == gated2
+
+    def test_time_gate_preserves_flat_response(self):
+        """A flat response gated around t=0 must come back unchanged.
+
+        The gate is a symmetric window whose peak sample sits on t = 0, so the zero-lag term
+        of the frequency-domain kernel is exactly one and a constant reflection coefficient is
+        passed through untouched. A periodic window is symmetric about sample `window_width / 2`
+        instead, which puts the peak half a sample late and scales the gated data by a constant
+        slightly below one.
+        """
+        s0 = 0.9 - 0.3j
+
+        # Sweep an even and an odd number of frequency points and an even and an odd
+        # half-width k. The resulting gate width 2 * k + 1 is always odd, which is
+        # intended: only an odd window has a single center sample on which
+        # gate(t = 0) = 1 can be imposed, so the invariant does not apply to even widths.
+        for npoints in (256, 257):
+            freq = Frequency(67, 110, npoints, unit='GHz')
+            ntwk = rf.Network(frequency=freq, s=np.full(npoints, s0))
+            dt = 1 / (npoints * freq.step)
+
+            for k in (20, 21):
+                # gate edges placed exactly on time samples, so that the gate covers
+                # the 2 * k + 1 samples centered on t = 0 without any rounding ambiguity
+                for method, kwargs in (('convolution', {'conv_mode': 'wrap'}),
+                                       ('convolution', {'conv_mode': 'reflect'}),
+                                       ('fft', {'fft_window': None})):
+                    gated = ntwk.time_gate(center=0, span=2 * k * dt, t_unit='s',
+                                           window=('kaiser', 10), method=method, **kwargs)
+                    np.testing.assert_allclose(
+                        gated.s.flatten(), s0, rtol=1e-12, atol=1e-12,
+                        err_msg=f'npoints={npoints}, k={k}, method={method}, {kwargs}')
+
+    def test_time_gate_spans_closed_interval(self):
+        """The gate covers the closed sample interval [start, stop], both edges included."""
+        npoints = 128
+        freq = Frequency(1, npoints, npoints, unit='GHz')
+        dt = 1 / (npoints * freq.step)
+        center_idx = npoints // 2
+        k = 10
+
+        # impulses on the two gate edge samples and on the first sample outside the gate
+        t_domain = np.zeros(npoints, dtype=complex)
+        t_domain[[center_idx - k, center_idx + k, center_idx + k + 1]] = 1
+        ntwk = rf.Network(frequency=freq, s=np.fft.fft(np.fft.ifftshift(t_domain)))
+
+        t_expected = t_domain.copy()
+        t_expected[center_idx + k + 1] = 0
+        expected = np.fft.fft(np.fft.ifftshift(t_expected))
+
+        # a boxcar gate keeps the samples it covers untouched, so this pins the gate
+        # support without depending on the shape of the window
+        for method, kwargs in (('fft', {'fft_window': None}),
+                               ('convolution', {'conv_mode': 'wrap'})):
+            gated = ntwk.time_gate(center=0, span=2 * k * dt, t_unit='s',
+                                   window='boxcar', method=method, **kwargs)
+            np.testing.assert_allclose(gated.s.flatten(), expected, rtol=1e-12, atol=1e-12,
+                                       err_msg=f'method={method}, {kwargs}')
 
     def test_time_gate_raises(self):
         ntwk = self.ntwk1

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -227,7 +227,7 @@ def detect_span(ntwk: Network, t_unit: str = "") -> float:
 
     return span / time_lookup_dict[t_unit]
 
-def get_window(window: str | tuple | Callable, Nx: int, **kwargs) -> np.ndarray:
+def get_window(window: str | tuple | Callable, Nx: int, fftbins: bool = True, **kwargs) -> np.ndarray:
     """Calls a custom window function or `scipy.signal.get_window()` depending on the window argument.
 
     Parameters
@@ -237,6 +237,12 @@ def get_window(window: str | tuple | Callable, Nx: int, **kwargs) -> np.ndarray:
         for `scipy.signal.get_window()`.
     Nx : int
         Number of samples
+    fftbins : bool
+        If True (default), create a periodic window, which is symmetric about sample `Nx / 2`.
+        If False, create a symmetric window, which is symmetric about sample `(Nx - 1) / 2`.
+        Only used for string or tuple window specifications, which are passed on to
+        `scipy.signal.get_window()`. Callable windows are called as `window(Nx)` and do not
+        receive this argument.
 
     Returns
     -------
@@ -247,7 +253,7 @@ def get_window(window: str | tuple | Callable, Nx: int, **kwargs) -> np.ndarray:
     if callable(window):
         return window(Nx, **kwargs)
     else:
-        return scipy.signal.get_window(window, Nx=Nx, **kwargs)
+        return scipy.signal.get_window(window, Nx=Nx, fftbins=fftbins, **kwargs)
 
 def time_gate(ntwk: Network, start: float = None, stop: float = None, center: float = None, span: float = None,
               mode: str = 'bandpass', window=('kaiser', 6),
@@ -285,7 +291,11 @@ def time_gate(ntwk: Network, start: float = None, stop: float = None, center: fl
     mode : ['bandpass', 'bandstop']
         mode of gate
     window : string, float, or tuple
-        passed to `window` arg of `scipy.signal.get_window()` or callable function
+        passed to `window` arg of `scipy.signal.get_window()` or callable function.
+        String and tuple specifications are requested with `fftbins=False`, so that the
+        time-domain gate is symmetric about its center sample. Callable windows are called
+        as `window(window_width)` and are themselves responsible for returning a symmetric
+        window.
     method : str
         Gating method. There are 3 option: 'convolution', 'fft', 'rfft'.
 
@@ -433,7 +443,11 @@ def time_gate(ntwk: Network, start: float = None, stop: float = None, center: fl
 
     # create gating window
     window_width = abs(stop_idx - start_idx) + 1
-    window = get_window(window, window_width)
+    # The gate multiplies a time vector that is centered on t = 0, so the window has to be symmetric
+    # about its own center sample. A periodic window (the scipy default) is symmetric about sample
+    # `window_width / 2` instead of `(window_width - 1) / 2`, which shifts the gate by half a sample
+    # and lowers its peak below unity.
+    window = get_window(window, window_width, fftbins=False)
 
     # create the gate by padding the window with zeros
     gate = np.zeros_like(t)


### PR DESCRIPTION
## Summary

- Build the discrete time-domain gate from a symmetric SciPy window.
- Keep the inclusive gate support introduced in #900.
- Add regression coverage for level preservation and closed gate support.

## Context

`scipy.signal.get_window()` creates a periodic window by default. For an odd
window length, that window is centered about `Nx / 2` rather than
`(Nx - 1) / 2`.

`time_gate()` places the window on a discrete time grid containing a center
sample at `t = 0`. The periodic window is therefore shifted by half a sample,
and its value at the center remains below unity.

The zero-lag value of the frequency-domain convolution kernel equals the gate
value at `t = 0`. A flat frequency response is consequently scaled by this
value. On the dataset attached to #1399, the current implementation produces
a level shift of approximately -0.0172 dB. The effect becomes larger for
narrower gates.

Before #900, a half-open slice happened to compensate for the periodic
window's offset, but its support was asymmetric and one sample too short.
This change keeps the inclusive support and instead builds the gate from a
symmetric window.

## Implementation

`get_window()` now accepts an explicit `fftbins` argument.

String and tuple window specifications pass this option to SciPy. Callable
windows keep their existing contract and are still called with only the
requested window length. This is why the option is consumed by the helper
rather than passed through `**kwargs` at the `time_gate()` call site.

Only the time-domain gate uses `fftbins=False`. Frequency-domain tapering and
`Network.windowed()` retain their existing behavior.

## Verification

- `pytest -v -c "" skrf/tests/test_network.py -k "time_gate"`
- `pytest -v -c "" skrf/tests/test_network.py`
- `ruff check skrf/time.py skrf/tests/test_network.py`
- `git diff --check`

The full test suite previously completed with 1665 passed, 53 skipped,
4 xfailed, and one Windows-specific `NamedTemporaryFile` permission failure in
`test_networkSet.py::test_to_mdif`. The same failure was reproduced on the
unmodified `upstream/master` branch.

FFT and circular-convolution gating remain equivalent within floating-point
precision.

## Scope

This change does not modify:

- the inclusive gate width;
- `fft_window`;
- `Network.windowed()`;
- convolution boundary handling;
- the convolution kernel definition.

## Limits

The requested span remains quantized to the available time grid. Callable
windows remain responsible for returning an appropriately symmetric window.

Fixes #1399.
