### PR TITLE
More port name fixes

### DIFF
--- a/doc/source/tutorials/Networks.ipynb
+++ b/doc/source/tutorials/Networks.ipynb
@@ -737,6 +737,284 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Port names\n",
+    "\n",
+    "The ports of a [Network](../api/network.rst) can be given names with `Network.port_names`. A named port can then be used anywhere a port index is accepted, and the names follow the ports they describe through operations which reorder, drop or combine ports.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    Version note\n",
+    "\n",
+    "    Port names can only be used this way in versions after 2.0.1. In\n",
+    "    version 2.0.1 and earlier, Network.port_names is a plain attribute\n",
+    "    which most operations do not keep up to date, and it cannot be used to\n",
+    "    address a port.\n",
+    "</div>\n",
+    "\n",
+    "Names are given either when the [Network](../api/network.rst) is created, or by assigning to the property afterwards. There has to be a name for every port."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "freq = rf.Frequency(1, 10, 11, unit='GHz')\n",
+    "media = rf.media.DefinedGammaZ0(frequency=freq, z0_port=50)\n",
+    "\n",
+    "amp = media.attenuator(-10, name='amp')\n",
+    "amp.port_names = ['in', 'out']\n",
+    "amp.port_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = np.zeros((freq.npoints, 2, 2), dtype=complex)\n",
+    "s[:, 0, 1] = s[:, 1, 0] = 10 ** (-3 / 20)\n",
+    "\n",
+    "pad = rf.Network(frequency=freq, s=s, name='pad', port_names=['rf_in', 'rf_out'])\n",
+    "pad.port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A [Network](../api/network.rst) without named ports has `port_names` set to `None`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(media.attenuator(-3).port_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connecting by name\n",
+    "\n",
+    "`connect()` takes a port name in place of a port index and the output `Network` keeps the names of the ports which are left over."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cascade = rf.network.connect(amp, 'out', pad, 'rf_in')\n",
+    "cascade.port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the same connection as the one made by indices, names are just another way of selecting a port."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cascade == rf.network.connect(amp, 1, pad, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`innerconnect()`, `parallelconnect()`, `subnetwork()` and `renumber()` accept names the same way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tee = rf.data.tee.copy()\n",
+    "tee.port_names = ['sum', 'a', 'b']\n",
+    "\n",
+    "tee.subnetwork(['a', 'sum']).port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In `renumber()` a name refers to the port which currently carries it, so the call below swaps the ports named `sum` and `b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tee.renumbered(['sum', 'b'], ['b', 'sum']).port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Names follow the ports\n",
+    "\n",
+    "A one-port taken out of a network is either a reflection coefficient, which is one of the ports and keeps its name, or a transmission coefficient, which is not any single port of the network and therefore has no name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(amp.s11.port_names) # port 'in'\n",
+    "print(amp.s22.port_names) # port 'out'\n",
+    "print(amp.s21.port_names) # neither port"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same one-ports can be picked out by name instead of by number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "amp['in', 'in'].port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mixed mode\n",
+    "\n",
+    "`se2gmm()` replaces pairs of single ended ports with a differential and a common mode port. Each new port is named after the pair it is made of, so the names stay unique and say where the port came from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line_p = media.line(50, 'deg', name='p')\n",
+    "line_n = media.line(70, 'deg', name='n')\n",
+    "\n",
+    "pair = rf.network.concat_ports([line_p, line_n], port_order='second')\n",
+    "pair.port_names = ['in+', 'in-', 'out+', 'out-']\n",
+    "pair.port_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mm = pair.copy()\n",
+    "mm.se2gmm(p=2)\n",
+    "mm.port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The differential insertion loss is then addressable by name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mm['d(in+,in-)', 'd(out+,out-)'].s_db[:, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`gmm2se()` reverses the conversion and restores the single ended names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mm.gmm2se(p=2)\n",
+    "mm.port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Duplicate names\n",
+    "\n",
+    "Several ports may share a name, which happens for instance when a Touchstone file names them that way, or when `connect()` joins two networks which both have a port called `in`. Such a name cannot be used to address a port, since it does not identify one, and those ports have to be given by index instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "amp2 = amp.copy()\n",
+    "amp2.name = 'amp2'\n",
+    "\n",
+    "# the two ports named 'out' are the ones consumed, both 'in' ports are left\n",
+    "back_to_back = rf.network.connect(amp, 'out', amp2, 'out')\n",
+    "back_to_back.port_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Asking for a port by an ambiguous name raises rather than silently returning the first match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    back_to_back['in', 'in']\n",
+    "except ValueError as err:\n",
+    "    print(err)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\t\n",
     "## Interpolation and Concatenation\n",
     "\n",
@@ -982,7 +1260,7 @@
   "anaconda-cloud": {},
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3.9.5 ('.venv': venv)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -996,7 +1274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {
@@ -1005,5 +1283,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5337,6 +5337,45 @@ PRIMARY_PROPERTIES = Network.PRIMARY_PROPERTIES
 Y_LABEL_DICT = Network.Y_LABEL_DICT
 
 ## Functions operating on Network[s]
+def _port_index(ntwk: Network, port: int | str) -> int:
+    """
+    Index of a port given either as an index or as a port name.
+
+    Port indices are returned unchanged, names are looked up in
+    `ntwk.port_names`.
+
+    Parameters
+    ----------
+    ntwk : :class:`Network`
+        network the port belongs to
+    port : int or str
+        port index, or port name if the network has named ports
+
+    Returns
+    -------
+    index : int
+        index of the port
+
+    Raises
+    ------
+    ValueError
+        If the network has no port names, or the name is unknown or ambiguous.
+    """
+    if not isinstance(port, str):
+        return port
+    if ntwk.port_names is None:
+        raise ValueError(
+            f"Network '{ntwk.name}' has no port names, port '{port}' can't be resolved")
+    if ntwk.port_names.count(port) > 1:
+        raise ValueError(
+            f"Port name '{port}' is ambiguous, network has ports {ntwk.port_names}")
+    try:
+        return ntwk.port_names.index(port)
+    except ValueError:
+        raise ValueError(
+            f"Unknown port '{port}', network has ports {ntwk.port_names}") from None
+
+
 def _mixed_mode_port_names(port_names: list[str] | None, p: int) -> list[str] | None:
     """
     Port names of a network converted to mixed mode with :func:`Network.se2gmm`.
@@ -5376,14 +5415,16 @@ def _single_ended_port_names(port_names: list[str] | None, p: int) -> list[str] 
     return se_names + list(port_names[2 * p:])
 
 
-def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Network:
+def connect(ntwkA: Network, k: int | str, ntwkB: Network, l: int | str, num: int = 1) -> Network:
     """
     Connect two n-port networks together.
 
     Connect ports `k` thru `k+num-1` on `ntwkA` to ports
     `l` thru `l+num-1` on `ntwkB`. The resultant network has
     (ntwkA.nports+ntwkB.nports-2*num) ports. The port indices ('k','l')
-    start from 0. Port impedances **are** taken into account.
+    start from 0. Ports of networks which have named ports
+    (:attr:`Network.port_names`) can be given by name instead of by index.
+    Port impedances **are** taken into account.
     When the two networks have overlapping frequencies, the resulting
     network will contain only the overlapping frequencies.
 
@@ -5400,12 +5441,14 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     ----------
     ntwkA : :class:`Network`
             network 'A'
-    k : int
-            starting port index on `ntwkA` ( port indices start from 0 )
+    k : int or str
+            starting port index on `ntwkA` ( port indices start from 0 ),
+            or port name if `ntwkA` has named ports
     ntwkB : :class:`Network`
             network 'B'
-    l : int
-            starting port index on `ntwkB`
+    l : int or str
+            starting port index on `ntwkB`, or port name if `ntwkB` has
+            named ports
     num : int
             number of consecutive ports to connect (default 1)
 
@@ -5431,6 +5474,12 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
     >>> ntwkB = rf.Network('ntwkB.s2p')
     >>> ntwkC = rf.connect(ntwkA, 1, ntwkB,0)
 
+    Ports of networks with named ports can be given by name
+
+    >>> ntwkA.port_names
+    ['in', 'out']
+    >>> ntwkC = rf.connect(ntwkA, 'out', ntwkB, 0)
+
     """
     # some checking
     try:
@@ -5443,6 +5492,9 @@ def connect(ntwkA: Network, k: int, ntwkB: Network, l: int, num: int = 1) -> Net
             ntwkA = ntwkA[common_freq[1]]
             ntwkB = ntwkB[common_freq[2]]
             warnings.warn("Using a frequency subset:\n" + str(ntwkA.frequency), stacklevel=2)
+
+    k = _port_index(ntwkA, k)
+    l = _port_index(ntwkB, l)
 
     if (k + num - 1 > ntwkA.nports - 1):
         raise IndexError('Port `k` out of range')
@@ -5665,11 +5717,13 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
     ----------
     ntwks : :Sequence[`Network`] | `Network`
             A sequence of multi-port networks or a single network to be connected in parallel.
-    ports : Sequence[int  |  Sequence[int]]
+    ports : Sequence[int | str | Sequence[int | str]]
             A sequence of port indices, where each entry can be an int or a sequence of ints
             corresponding to the ports of the respective network. The length of `ports` should
             match the length of `networks`. Each specified port index is connect to the
             concatenated intersection, implying they are electrically common.
+            Ports of networks which have named ports (:attr:`Network.port_names`)
+            can be given by name instead of by index.
     name : str, optional
             define the connected network's name. Default is None.
 
@@ -5778,6 +5832,9 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
     dim, off = sum(ntw.nports for ntw in ntwks), 0
     inter_indices, exter_indices =  [], []
     z0_in, z0_ext = [], []
+    # names of the ports which stay external, if any network has port names
+    named = any(ntw.port_names is not None for ntw in ntwks)
+    port_names_ext = [] if named else None
 
     # Assign the global scattering matrix [X] and concatenated intersection matrix [C]
     X = np.zeros((ntwks[0].frequency.npoints, dim, dim), dtype='complex')
@@ -5788,7 +5845,10 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
         nports: int = ntw.nports
 
         # Convert the int port to list
-        port = [port] if isinstance(port, int) else port
+        port = [port] if isinstance(port, (int, str)) else port
+
+        # Resolve the ports given by name
+        port = [_port_index(ntw, p) for p in port]
 
         # Che the port indices valid or not
         if len(port) != len(set(port)):
@@ -5799,6 +5859,10 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
         # Check the frequency equal or not
         check_frequency_equal(ntw, ntwks[0])
 
+        # Names of this network's ports, created if it doesn't have any
+        names = ntw.port_names if ntw.port_names is not None \
+                else [str(x) for x in range(nports)]
+
         # Append the port index with offset to indices list
         for p in range(nports):
             if p in port:
@@ -5807,6 +5871,8 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
             else:
                 exter_indices.append(p + off)
                 z0_ext.append(ntw.z0[:, p])
+                if named:
+                    port_names_ext.append(names[p])
 
         # Assign the scattering matrix of each network to the global scattering matrix
         X[:, off:off+nports, off:off+nports] = ntw.s_traveling
@@ -5832,18 +5898,21 @@ def parallelconnect(ntwks: Sequence[Network] | Network,
     # Get the global scattering matrix
     s = X @ np.linalg.inv(np.identity(dim) - C @ X)
 
-    return Network(frequency = ntwks[0].frequency,
-                   s = s[:, out_ind[0], out_ind[1]],
-                   z0 = np.array(z0_ext).T,
-                   name = name)
+    connected = Network(frequency = ntwks[0].frequency,
+                        s = s[:, out_ind[0], out_ind[1]],
+                        z0 = np.array(z0_ext).T,
+                        name = name)
+    connected.port_names = port_names_ext
+    return connected
 
 
-def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
+def innerconnect(ntwkA: Network, k: int | str, l: int | str, num: int = 1) -> Network:
     """
     Connect ports of a single n-port network.
 
     this results in a (n-2)-port network. remember port indices start
-    from 0.
+    from 0. Ports of a network which has named ports
+    (:attr:`Network.port_names`) can be given by name instead of by index.
 
 
     Note
@@ -5856,8 +5925,9 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
     ----------
     ntwkA : :class:`Network`
         network 'A'
-    k,l : int
-        starting port indices on ntwkA ( port indices start from 0 )
+    k,l : int or str
+        starting port indices on ntwkA ( port indices start from 0 ),
+        or port names if `ntwkA` has named ports
     num : int
         number of consecutive ports to connect
 
@@ -5881,6 +5951,8 @@ def innerconnect(ntwkA: Network, k: int, l: int, num: int = 1) -> Network:
     >>> ntwkC = rf.innerconnect(ntwkA, 0,1)
 
     """
+    k = _port_index(ntwkA, k)
+    l = _port_index(ntwkA, l)
 
     if (k + num - 1 > ntwkA.nports - 1):
         raise IndexError('Port `k` out of range')

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -915,16 +915,10 @@ class Network:
                     p1_index = p1_name - 1
                     p2_index = p2_name - 1
                 else:
-                    if self.port_names is None:
-                        raise ValueError("Can't index without named ports")
-                    try:
-                        p1_index = self.port_names.index(p1_name)
-                    except ValueError as err:
-                        raise KeyError(f"Unknown port {p1_name}") from err
-                    try:
-                        p2_index = self.port_names.index(p2_name)
-                    except ValueError as err:
-                        raise KeyError(f"Unknown port {p2_name}") from err
+                    # a name shared by several ports can't be resolved, those
+                    # ports have to be indexed by their number
+                    p1_index = _port_index(self, p1_name)
+                    p2_index = _port_index(self, p2_name)
                 ntwk = self.copy()
                 # setting s drops the port names, the result is a one-port
                 ntwk.s = self.s[:, p1_index, p2_index]
@@ -5366,8 +5360,12 @@ def _port_index(ntwk: Network, port: int | str) -> int:
 
     Raises
     ------
+    KeyError
+        If the port name is unknown.
     ValueError
-        If the network has no port names, or the name is unknown or ambiguous.
+        If the network has no port names, or several ports share the name.
+        Duplicated port names are allowed, but a port can then only be
+        addressed by its index.
     """
     if not isinstance(port, str):
         return port
@@ -5376,11 +5374,12 @@ def _port_index(ntwk: Network, port: int | str) -> int:
             f"Network '{ntwk.name}' has no port names, port '{port}' can't be resolved")
     if ntwk.port_names.count(port) > 1:
         raise ValueError(
-            f"Port name '{port}' is ambiguous, network has ports {ntwk.port_names}")
+            f"Port name '{port}' is ambiguous, network has ports {ntwk.port_names}. "
+            "Use the port index instead")
     try:
         return ntwk.port_names.index(port)
     except ValueError:
-        raise ValueError(
+        raise KeyError(
             f"Unknown port '{port}', network has ports {ntwk.port_names}") from None
 
 

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3846,7 +3846,7 @@ class Network:
 
         self.s = self.s * np.exp(-1j*theta)
 
-    def delay(self, d: float, unit: str = 'deg', port: int = 0, media: Any = None, **kw) -> Network:
+    def delay(self, d: float, unit: str = 'deg', port: int | str = 0, media: Any = None, **kw) -> Network:
         """
         Add phase delay to a given port.
 
@@ -3860,8 +3860,10 @@ class Network:
             The angle/length/delay of the transmission line (see `unit` argument)
         unit : ['deg','rad','m','cm','um','in','mil','s','us','ns','ps']
             The units of d.  See :func:`Media.to_meters`, for details
-        port : int
-            Port to add the delay to.
+        port : int or str
+            Port to add the delay to, given by index or by name if the Network
+            has named ports (:attr:`Network.port_names`). The delayed port keeps
+            its name.
         media: skrf.media.Media
             Media object to use for generating the delay. If None, this will
             default to freespace.
@@ -3872,6 +3874,7 @@ class Network:
             A delayed copy of the `Network`.
 
         """
+        port = _port_index(self, port)
         if d ==0:
             return self
         d=d/2.
@@ -3881,6 +3884,9 @@ class Network:
                               z0_override = self.z0[:,port])
 
         l =media.line(d=d, unit=unit,**kw)
+        # the delayed port is still the same port of this network
+        if self.port_names is not None:
+            l.port_names = [self.port_names[port]] * 2
         return connect(self, port, l, 0)
 
     def windowed(self, window: str | float | tuple[str, float] | Callable =('kaiser', 6),

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -3447,7 +3447,7 @@ class Network:
         return result
 
 
-    def subnetwork(self, ports: Sequence[int], offby: int = 1) -> Network:
+    def subnetwork(self, ports: Sequence[int | str], offby: int = 1) -> Network:
         """
         Return a subnetwork of a the Network from a list of port numbers.
 
@@ -3461,8 +3461,9 @@ class Network:
 
         Parameters
         ----------
-        ports : list of int
-            List of ports to keep in the resultant Network.
+        ports : list of int or str
+            List of ports to keep in the resultant Network. Ports can be given
+            by name if the Network has named ports (:attr:`Network.port_names`).
             Indices are the Python indices (starts at 0)
         offby : int
             starting value for s-parameters indexes in the sub-Network name parameter.
@@ -3673,7 +3674,8 @@ class Network:
         self.s_def = s_def
         self.z0 = z_new
 
-    def renumber(self, from_ports: Sequence[int], to_ports: Sequence[int], only_z0: bool = False) -> None:
+    def renumber(self, from_ports: Sequence[int | str], to_ports: Sequence[int | str],
+                 only_z0: bool = False) -> None:
         """
         Renumber ports of a Network (inplace).
 
@@ -3681,8 +3683,12 @@ class Network:
         ----------
         from_ports : list-like
             List of port indices to change. Size between 1 and N_ports.
+            Ports can be given by name if the Network has named ports
+            (:attr:`Network.port_names`).
         to_ports : list-like
             List of desired port indices. Size between 1 and N_ports.
+            A port name refers to the port which currently has that name, so
+            renumber(['a', 'b'], ['b', 'a']) swaps the ports named 'a' and 'b'.
         only_z0 : bool
             If true only z0 is renumbered, s-parameters are not affected.
             This should only be used after executing the "connect_s" method
@@ -3790,8 +3796,8 @@ class Network:
         flipped
 
         """
-        from_ports = np.array(from_ports)
-        to_ports = np.array(to_ports)
+        from_ports = np.array([_port_index(self, port) for port in from_ports])
+        to_ports = np.array([_port_index(self, port) for port in to_ports])
         if len(np.unique(from_ports)) != len(from_ports):
             raise ValueError('an index can appear at most once in from_ports or to_ports')
         if any(np.unique(from_ports) != np.unique(to_ports)):
@@ -3806,7 +3812,7 @@ class Network:
             _port_names[to_ports] = _port_names[from_ports]
             self.port_names = _port_names.tolist()
 
-    def renumbered(self, from_ports: Sequence[int], to_ports: Sequence[int]) -> Network:
+    def renumbered(self, from_ports: Sequence[int | str], to_ports: Sequence[int | str]) -> Network:
         """
         Return a renumbered Network, leave self alone.
 
@@ -3814,6 +3820,8 @@ class Network:
         ----------
         from_ports : list-like
             List of port indices to change. Size between 1 and N_ports.
+            Ports can be given by name if the Network has named ports
+            (:attr:`Network.port_names`).
         to_ports : list-like
             List of desired port indices. Size between 1 and N_ports.
 
@@ -6543,7 +6551,7 @@ def evenodd2delta(n: Network, z0: NumberLike = 50, renormalize: bool = True,
     return n_delta
 
 
-def subnetwork(ntwk: Network, ports: Sequence[int], offby:int = 1) -> Network:
+def subnetwork(ntwk: Network, ports: Sequence[int | str], offby:int = 1) -> Network:
     """
     Return a subnetwork of a given Network from a list of port numbers.
 
@@ -6559,8 +6567,9 @@ def subnetwork(ntwk: Network, ports: Sequence[int], offby:int = 1) -> Network:
     ----------
     ntwk : :class:`Network` object
         Network to split into a subnetwork
-    ports : list of int
-        List of ports to keep in the resultant Network.
+    ports : list of int or str
+        List of ports to keep in the resultant Network. Ports can be given by
+        name if the Network has named ports (:attr:`Network.port_names`).
         Indices are the Python indices (starts at 0)
     offby : int
         starting value for s-parameters indexes in the sub-Network name parameter.
@@ -6584,6 +6593,7 @@ def subnetwork(ntwk: Network, ports: Sequence[int], offby:int = 1) -> Network:
     >>> tee13 = rf.subnetwork(tee, [0, 2])  # 2 port Network from ports 1 & 3, port 2 matched
 
     """
+    ports = [_port_index(ntwk, port) for port in ports]
     # forging subnetwork name
     subntwk_name = (ntwk.name or 'p') + ''.join([str(index+offby) for index in ports])
     # create a dummy Network with same frequency and z0 from the original

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -4095,7 +4095,7 @@ class Network:
                           for k in range(len(p))]]
         return ntwkB
 
-    def nonreciprocity(self, m: int, n: int, normalize: bool = False) -> Network:
+    def nonreciprocity(self, m: int | str, n: int | str, normalize: bool = False) -> Network:
         r"""
         Normalized non-reciprocity metric.
 
@@ -4108,10 +4108,14 @@ class Network:
 
         Parameters
         ----------
-        m : int
-            m index
-        n : int
-            n index
+        m : int or str
+            m index, or port name if the Network has named ports
+            (:attr:`Network.port_names`). Note that the indices are one-based,
+            like the :attr:`s` matrix element they name, and unlike the
+            zero-based port indices taken by :func:`connect` or
+            :func:`Network.renumber`. Port names are unaffected by this.
+        n : int or str
+            n index, one-based, or port name
         normalize : bool
             Normalize the result. Default is False.
 
@@ -4121,6 +4125,12 @@ class Network:
             Resulting renumbered Network
 
         """
+        # the s{m}_{n} attributes are one-based, port indices are not
+        if isinstance(m, str):
+            m = _port_index(self, m) + 1
+        if isinstance(n, str):
+            n = _port_index(self, n) + 1
+
         forward = getattr(self, f"s{m}_{n}")
         reverse = getattr(self, f"s{n}_{m}")
         if normalize:
@@ -5720,7 +5730,7 @@ def connect_fast(ntwkA: Network, k: int, ntwkB: Network, l: int) -> Network:
 
 
 def parallelconnect(ntwks: Sequence[Network] | Network,
-                    ports: Sequence[int | Sequence[int]],
+                    ports: Sequence[int | str | Sequence[int | str]],
                     name: str | None = None) -> Network:
     """
     Connects a series of multi-port networks in parallel, ensuring that the specified port

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -878,6 +878,45 @@ class NetworkTestCase(unittest.TestCase):
         unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
         self.assertIsNone(unnamed.inv.port_names)
 
+    def test_delay_port_names(self):
+        """delay() extends a port, it stays the same port and keeps its name.
+        """
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+
+        def nport(nports):
+            z0 = [10 * (i + 1) for i in range(nports)]
+            return rf.Network(frequency=freq, name='a', z0=z0,
+                              s=self.rng.random((5, nports, nports)),
+                              port_names=[f'p{i}' for i in range(nports)])
+
+        # delaying any port of a network leaves the ports as they were
+        four_port = nport(4)
+        for port in range(4):
+            delayed = four_port.delay(1, 'ns', port=port)
+            self.assertEqual(delayed.port_names, ['p0', 'p1', 'p2', 'p3'])
+            np.testing.assert_allclose(delayed.z0, four_port.z0)
+
+        # a name may be used instead of the index, and picks the same port
+        self.assertEqual(four_port.delay(1, 'ns', port='p2'),
+                         four_port.delay(1, 'ns', port=2))
+        with self.assertRaises(KeyError):
+            four_port.delay(1, 'ns', port='nope')
+
+        # whichever way delay() orders the ports of a two-port, the names have
+        # to describe the same ports z0 does
+        two_port = nport(2)
+        for port in range(2):
+            delayed = two_port.delay(90, 'deg', port=port)
+            self.assertEqual([dict(zip(two_port.z0[0].real, two_port.port_names))[z]
+                              for z in delayed.z0[0].real],
+                             delayed.port_names)
+
+        # a network without names stays without names
+        unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
+        self.assertIsNone(unnamed.delay(1, 'ns').port_names)
+        # d == 0 is a no-op which returns the network itself
+        self.assertIs(two_port.delay(0, 'ns'), two_port)
+
     def test_duplicate_port_names(self):
         """Duplicated port names are allowed, but can't be used to address a port.
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -948,6 +948,41 @@ class NetworkTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             parallelconnect([ntwk_a, ntwk_b], ['nope', 0])
 
+    def test_subnetwork_renumber_by_port_name(self):
+        """subnetwork and renumber take port names too."""
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+
+        base = rf.Network(frequency=freq, name='n', z0=[1, 2, 3, 4],
+                          s=self.rng.random((1, 4, 4)))
+        base.port_names = ['in', 'out', 'cpl', 'iso']
+
+        def nport():
+            return base.copy()
+
+        ntwk = nport()
+        self.assertEqual(ntwk.subnetwork(['cpl', 'in']), ntwk.subnetwork([2, 0]))
+        self.assertEqual(ntwk.subnetwork(['cpl', 'in']).port_names, ['cpl', 'in'])
+        self.assertEqual(ntwk.subnetwork(['cpl', 0]).port_names, ['cpl', 'in'])  # mixed
+        np.testing.assert_allclose(ntwk.subnetwork(['cpl', 'in']).z0, [[3, 1]])
+
+        # a name in to_ports refers to the port which currently has that name,
+        # so this swaps the two ports
+        by_name, by_index = nport(), nport()
+        by_name.renumber(['in', 'out'], ['out', 'in'])
+        by_index.renumber([0, 1], [1, 0])
+        self.assertEqual(by_name, by_index)
+        self.assertEqual(by_name.port_names, by_index.port_names)
+        self.assertEqual(by_name.port_names, ['out', 'in', 'cpl', 'iso'])
+        np.testing.assert_allclose(by_name.z0, [[2, 1, 3, 4]])
+
+        self.assertEqual(nport().renumbered(['iso', 'in'], ['in', 'iso']).port_names,
+                         nport().renumbered([3, 0], [0, 3]).port_names)
+
+        with self.assertRaises(ValueError):
+            nport().renumber(['in', 'nope'], [1, 0])
+        with self.assertRaises(ValueError):
+            nport().subnetwork(['nope'])
+
     def test_connect_no_frequency(self):
         """ Connecting 2 networks defined without frequency returns Error
         """

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -917,6 +917,29 @@ class NetworkTestCase(unittest.TestCase):
         # d == 0 is a no-op which returns the network itself
         self.assertIs(two_port.delay(0, 'ns'), two_port)
 
+    def test_nonreciprocity_by_port_name(self):
+        """nonreciprocity picks a pair of ports, which can be given by name."""
+        freq = rf.Frequency(1, 3, 5, unit='GHz')
+        three_port = rf.Network(frequency=freq, name='a', z0=[10, 20, 30],
+                                s=self.rng.random((5, 3, 3)),
+                                port_names=['in', 'out', 'iso'])
+
+        # the s{m}_{n} attributes are one-based, a name means the same port
+        self.assertEqual(three_port.nonreciprocity('in', 'out'),
+                         three_port.nonreciprocity(1, 2))
+        self.assertEqual(three_port.nonreciprocity('out', 'iso'),
+                         three_port.nonreciprocity(2, 3))
+        self.assertEqual(three_port.nonreciprocity('in', 'iso', normalize=True),
+                         three_port.nonreciprocity(1, 3, normalize=True))
+        # the result is a pair of ports, not any single one of them
+        self.assertIsNone(three_port.nonreciprocity('in', 'out').port_names)
+
+        with self.assertRaises(KeyError):
+            three_port.nonreciprocity('nope', 'out')
+        unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
+        with self.assertRaises(ValueError):
+            unnamed.nonreciprocity('a', 'b')
+
     def test_duplicate_port_names(self):
         """Duplicated port names are allowed, but can't be used to address a port.
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -878,6 +878,44 @@ class NetworkTestCase(unittest.TestCase):
         unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
         self.assertIsNone(unnamed.inv.port_names)
 
+    def test_duplicate_port_names(self):
+        """Duplicated port names are allowed, but can't be used to address a port.
+
+        Touchstone files may name several ports the same, and connect() creates
+        duplicates when it concatenates the names of two networks. Everything
+        which works on port indices must keep working, while looking a port up
+        by an ambiguous name raises instead of silently returning the first one.
+        """
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+        ntwk = rf.Network(frequency=freq, name='n', z0=[1, 2, 3],
+                          s=self.rng.random((1, 3, 3)))
+        ntwk.port_names = ['a', 'b', 'a']
+
+        # index based operations are unaffected
+        self.assertEqual(ntwk.subnetwork([2, 1]).port_names, ['a', 'b'])
+        self.assertEqual(ntwk.renumbered([0, 2], [2, 0]).port_names, ['a', 'b', 'a'])
+        np.testing.assert_allclose(ntwk[1, 3].s[:, 0, 0], ntwk.s[:, 0, 2])
+
+        # an unambiguous name still resolves
+        np.testing.assert_allclose(ntwk['b', 'b'].s[:, 0, 0], ntwk.s[:, 1, 1])
+
+        # an ambiguous one used to silently resolve to the first match
+        with self.assertRaises(ValueError):
+            ntwk['a', 'b']
+        with self.assertRaises(ValueError):
+            connect(ntwk, 'a', ntwk.copy(), 'b')
+        with self.assertRaises(ValueError):
+            ntwk.subnetwork(['a'])
+
+        # connect creates duplicates out of networks which have unique names
+        def two_port(name):
+            n = rf.Network(frequency=freq, name=name, z0=50,
+                           s=self.rng.random((1, 2, 2)))
+            n.port_names = ['in', 'out']
+            return n
+        self.assertEqual(connect(two_port('a'), 1, two_port('b'), 1).port_names,
+                         ['in', 'in'])
+
     def test_connect_by_port_name(self):
         """Ports can be given by name instead of by index."""
         freq = rf.Frequency(1, 1, 1, unit='GHz')
@@ -907,7 +945,7 @@ class NetworkTestCase(unittest.TestCase):
                          connect(ntwk_a, 1, ntwk_b, 0, num=2))
         self.assertEqual(innerconnect(ntwk_a, 'a0', 'a3').port_names, ['a1', 'a2'])
 
-        with self.assertRaises(ValueError):  # unknown name
+        with self.assertRaises(KeyError):  # unknown name
             connect(ntwk_a, 'nope', ntwk_b, 0)
         with self.assertRaises(ValueError):  # network without port names
             connect(rf.Network(frequency=freq, s=self.rng.random((1, 2, 2))), 'x', ntwk_b, 0)
@@ -945,7 +983,7 @@ class NetworkTestCase(unittest.TestCase):
         self.assertIsNone(parallelconnect([nport(2, 'a', named=False),
                                            nport(2, 'b', named=False)], [1, 0]).port_names)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             parallelconnect([ntwk_a, ntwk_b], ['nope', 0])
 
     def test_subnetwork_renumber_by_port_name(self):
@@ -978,9 +1016,9 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(nport().renumbered(['iso', 'in'], ['in', 'iso']).port_names,
                          nport().renumbered([3, 0], [0, 3]).port_names)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             nport().renumber(['in', 'nope'], [1, 0])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             nport().subnetwork(['nope'])
 
     def test_connect_no_frequency(self):

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -28,6 +28,7 @@ from skrf.network import (
     connect,
     fix_z0_shape,
     h2s,
+    innerconnect,
     n_twoports_2_nport,
     one_port_2_two_port,
     parallelconnect,
@@ -876,6 +877,76 @@ class NetworkTestCase(unittest.TestCase):
 
         unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
         self.assertIsNone(unnamed.inv.port_names)
+
+    def test_connect_by_port_name(self):
+        """Ports can be given by name instead of by index."""
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+
+        def nport(nports, prefix):
+            ntwk = rf.Network(frequency=freq, name=prefix,
+                              z0=np.arange(start=1, stop=nports + 1),
+                              s=self.rng.random((1, nports, nports)))
+            ntwk.port_names = [f'{prefix}{i}' for i in range(nports)]
+            return ntwk
+
+        ntwk_a, ntwk_b = nport(4, 'a'), nport(3, 'b')
+
+        # a name is equivalent to the index of that port, for every port and
+        # not just the first one. Names and indices can be mixed.
+        for k in range(ntwk_a.nports):
+            for l in range(ntwk_b.nports):
+                by_index = connect(ntwk_a, k, ntwk_b, l)
+                for by_name in (connect(ntwk_a, f'a{k}', ntwk_b, f'b{l}'),
+                                connect(ntwk_a, f'a{k}', ntwk_b, l),
+                                connect(ntwk_a, k, ntwk_b, f'b{l}')):
+                    self.assertEqual(by_name, by_index)
+                    self.assertEqual(by_name.port_names, by_index.port_names)
+
+        # more than one port at a time, and innerconnect
+        self.assertEqual(connect(ntwk_a, 'a1', ntwk_b, 'b0', num=2),
+                         connect(ntwk_a, 1, ntwk_b, 0, num=2))
+        self.assertEqual(innerconnect(ntwk_a, 'a0', 'a3').port_names, ['a1', 'a2'])
+
+        with self.assertRaises(ValueError):  # unknown name
+            connect(ntwk_a, 'nope', ntwk_b, 0)
+        with self.assertRaises(ValueError):  # network without port names
+            connect(rf.Network(frequency=freq, s=self.rng.random((1, 2, 2))), 'x', ntwk_b, 0)
+        ambiguous = nport(3, 'c')
+        ambiguous.port_names = ['p', 'p', 'r']
+        with self.assertRaises(ValueError):  # the same name twice
+            connect(ambiguous, 'p', ntwk_b, 0)
+
+    def test_parallelconnect_by_port_name(self):
+        """parallelconnect takes port names too, and keeps the port names."""
+        freq = rf.Frequency(1, 1, 1, unit='GHz')
+
+        def nport(nports, prefix, named=True):
+            ntwk = rf.Network(frequency=freq, name=prefix, z0=50,
+                              s=self.rng.random((1, nports, nports)))
+            if named:
+                ntwk.port_names = [f'{prefix}{i}' for i in range(nports)]
+            return ntwk
+
+        ntwk_a, ntwk_b, ntwk_c = nport(2, 'a'), nport(2, 'b'), nport(4, 'c')
+
+        by_index = parallelconnect([ntwk_a, ntwk_b, ntwk_c], [1, 1, 0])
+        by_name = parallelconnect([ntwk_a, ntwk_b, ntwk_c], ['a1', 'b1', 'c0'])
+        self.assertEqual(by_name, by_index)
+        # the remaining ports keep their names, in the order of the inputs
+        self.assertEqual(by_index.port_names, ['a0', 'b0', 'c1', 'c2', 'c3'])
+        self.assertEqual(by_name.port_names, by_index.port_names)
+
+        # a sequence of ports of a single network, ie. an innerconnect
+        self.assertEqual(parallelconnect(ntwk_c, [['c1', 'c3']]).port_names, ['c0', 'c2'])
+
+        # names are created for networks which don't have any
+        self.assertEqual(parallelconnect([ntwk_a, nport(2, 'b', named=False)],
+                                         ['a1', 0]).port_names, ['a0', '1'])
+        self.assertIsNone(parallelconnect([nport(2, 'a', named=False),
+                                           nport(2, 'b', named=False)], [1, 0]).port_names)
+
+        with self.assertRaises(ValueError):
+            parallelconnect([ntwk_a, ntwk_b], ['nope', 0])
 
     def test_connect_no_frequency(self):
         """ Connecting 2 networks defined without frequency returns Error


### PR DESCRIPTION
* Accept port name in `connect`, `parallelconnect`, `renumber`, and `subnetwork`. If there are duplicate port names exception is raised when trying to connect those ports.
* `Network.delay` keeps the port name.
* Added a section about port names in Networks tutorial.

This should be all of the port name related fixes for now, but there are so many places that do weird things with networks that I suspect there are still some broken places somewhere with less used functions.

`nonreciprocity` uses one based indexing instead of zero based indexing used elsewhere. This was there before, but I added a note about it in the docstring. Passing zero as port number there doesn't raise an error and instead indexes the last port. This should be probably fixed in `__getattr__`, but I did not include that in this PR.