### PR TITLE
Check port indices in Network.__getattr__

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -992,6 +992,13 @@ class Network:
         if m:
             t0 = int(m.group(1)) - 1
             t1 = int(m.group(2)) - 1
+            # the indices are one-based. 0 is not a valid port, and would
+            # otherwise silently wrap around to the last one
+            if not (0 <= t0 < self.nports and 0 <= t1 < self.nports):
+                raise AttributeError(
+                    f"Object does not have attribute {name}. "
+                    f"Indices are one-based and this network has "
+                    f"{self.nports} port(s)")
             ntwk = self.copy()
             # setting s drops the port names, the result is a one-port
             ntwk.s = self.s[:, t0, t1]
@@ -4124,12 +4131,26 @@ class Network:
         ntwk : :class:`Network` object
             Resulting renumbered Network
 
+        Raises
+        ------
+        ValueError
+            If an index is out of range. Being one-based, 0 is not a valid
+            index.
+        KeyError
+            If a port name is unknown.
+
         """
         # the s{m}_{n} attributes are one-based, port indices are not
         if isinstance(m, str):
             m = _port_index(self, m) + 1
         if isinstance(n, str):
             n = _port_index(self, n) + 1
+
+        for index in (m, n):
+            if not 1 <= index <= self.nports:
+                raise ValueError(
+                    f"Port index {index} is out of range. The indices are "
+                    f"one-based and this network has {self.nports} ports")
 
         forward = getattr(self, f"s{m}_{n}")
         reverse = getattr(self, f"s{n}_{m}")

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -994,6 +994,11 @@ class NetworkTestCase(unittest.TestCase):
         # the result is a pair of ports, not any single one of them
         self.assertIsNone(three_port.nonreciprocity('in', 'out').port_names)
 
+        # one-based indices. 0 is not a valid port.
+        for m, n in [(0, 1), (1, 0), (0, 0), (4, 1), (1, 4), (-1, 1)]:
+            with self.assertRaises(ValueError):
+                three_port.nonreciprocity(m, n)
+
         with self.assertRaises(KeyError):
             three_port.nonreciprocity('nope', 'out')
         unnamed = rf.Network(frequency=freq, z0=50, s=self.rng.random((5, 2, 2)))
@@ -2651,6 +2656,27 @@ class NetworkTestCase(unittest.TestCase):
             ntwk.s99.s[:,0,0]
         )
 
+
+    def test_generate_subnetworks_invalid_port(self):
+        """
+        The s{m}_{n} indices are one-based, an out of range index is not an
+        attribute. 0 used to wrap around to the last port.
+        """
+        ntwk = rf.Network(os.path.join(self.test_dir,'ntwk.s32p'))
+
+        for name in ['s0_1', 's1_0', 's0_0', 's00', 's01', 's10',
+                     's33_1', 's1_33', 's99_99']:
+            with self.assertRaises(AttributeError):
+                getattr(ntwk, name)
+            self.assertFalse(hasattr(ntwk, name))
+
+        # a two port has no third port, whichever way it is spelled
+        two_port = rf.Network(frequency=rf.Frequency(1, 3, 5, unit='GHz'),
+                              z0=50, s=self.rng.random((5, 2, 2)))
+        with self.assertRaises(AttributeError):
+            two_port.s31
+        with self.assertRaises(AttributeError):
+            two_port.s3_1
 
     def test_generate_subnetworks_allports(self):
         """


### PR DESCRIPTION
Raise exception on zero index port or port that exceeds the number of ports on `Network.__getattr__`. For example `Network.s00` used to return the last port but after this PR it raises instead. Same with `nonreciprocity` that has 1-based indices, 0 index doesn't wrap around silently anymore.