### PR TITLE
Fix auto-gate ignoring its own unit in time_gate

### DIFF
--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -257,6 +257,68 @@ class NetworkTestCase(unittest.TestCase):
         gated = ntwk.s11.time_gate()
         self.assertTrue(len(gated)== len(ntwk))
 
+    def test_autogate_ignores_t_unit(self):
+        """In auto-gate mode `t_unit` has nothing to label, so it must not change the result.
+
+        `t_unit` states the unit of `start`, `stop`, `center` and `span`. When all four are
+        None the gate is determined by the data alone: the centre is the tallest time-domain
+        peak and the span is the distance to the second tallest. Passing a different unit for
+        arguments that were not passed cannot move the gate.
+
+        The gate edges land on the same integer sample indices whatever the unit, so all three
+        networks come out of identical FFT operations and the comparison is exact.
+
+        The second assertion pins the gate against a reference built here, without calling
+        `time_gate()`: two reflections are placed by hand at -8 and +20 samples from t = 0, so
+        the documented auto-gate rule (centre on the tallest peak, span equal to the distance
+        between the two tallest) puts a boxcar over the closed sample interval [20-14, 20+14].
+
+        The third assertion covers the mixed case, where one of centre and span is given and
+        the other is detected. The given one is expressed in `t_unit` and the detected one is
+        not, so the gate must land on the same samples for every unit there too.
+        """
+        npoints = 128
+        freq = Frequency(1, npoints, npoints, unit='GHz')
+        dt = 1 / (npoints * freq.step)
+        center_idx = npoints // 2  # index of t = 0 on the fftshift-ed time axis
+
+        # a 1e-9 floor keeps s_time_db finite for the peak finder; it is 180 dB below the
+        # reflections and cannot move them
+        t_domain = np.full(npoints, 1e-9, dtype=complex)
+        t_domain[center_idx - 8] = 0.4
+        t_domain[center_idx + 20] = 1.0
+        ntwk = rf.Network(frequency=freq, s=np.fft.fft(np.fft.ifftshift(t_domain)))
+
+        # a boxcar gate and no frequency-domain window keep the covered samples untouched,
+        # so the result is pinned without depending on the shape of any window
+        gated = {unit: ntwk.time_gate(window='boxcar', fft_window=None, t_unit=unit)
+                 for unit in ('s', 'ns', 'ps')}
+
+        for unit in ('s', 'ps'):
+            np.testing.assert_array_equal(
+                gated[unit].s, gated['ns'].s,
+                err_msg=f"auto-gate result differs between t_unit='{unit}' and t_unit='ns'")
+
+        s_td = np.fft.fftshift(np.fft.ifft(ntwk.s[:, 0, 0]))
+        lo, hi = center_idx + 20 - 14, center_idx + 20 + 14
+        reference_td = np.zeros(npoints, dtype=complex)
+        reference_td[lo:hi + 1] = s_td[lo:hi + 1]
+        reference = np.fft.fft(np.fft.ifftshift(reference_td))
+
+        for unit in ('s', 'ns', 'ps'):
+            np.testing.assert_array_equal(
+                gated[unit].s[:, 0, 0], reference,
+                err_msg=f"auto-gate with t_unit='{unit}' does not match the hand-built gate")
+
+        # mixed case: one bound comes from the caller in t_unit, the other is detected
+        per_second = {'s': 1.0, 'ns': 1e9, 'ps': 1e12}
+        for unit, factor in per_second.items():
+            for given in ({'center': 20 * dt * factor}, {'span': 28 * dt * factor}):
+                mixed = ntwk.time_gate(window='boxcar', fft_window=None, t_unit=unit, **given)
+                np.testing.assert_array_equal(
+                    mixed.s[:, 0, 0], reference,
+                    err_msg=f"t_unit='{unit}' with {given} does not match the hand-built gate")
+
     def test_lpi(self):
         """Test low pass impulse response against data generated with METAS VNA Tools."""
 

--- a/skrf/time.py
+++ b/skrf/time.py
@@ -378,16 +378,23 @@ def time_gate(ntwk: Network, start: float = None, stop: float = None, center: fl
         center = (stop+start)/2.
 
     else:
+        # `t_unit` states the unit of the arguments the caller passed, so `t_mult` may only
+        # be applied to those. The values detected below are read in ns and are converted
+        # with the ns multiplier instead.
+        ns_mult = time_lookup_dict["ns"]
+
         if center is None:
             # they didn't provide center, so find the peak
             n = ntwk.s_time_mag.argmax()
-            center = ntwk.frequency.t_ns[n]
+            center = ntwk.frequency.t_ns[n] * ns_mult
+        else:
+            center *= t_mult
 
         if span is None:
-            span = detect_span(ntwk, t_unit='ns')
+            span = detect_span(ntwk, t_unit='ns') * ns_mult
+        else:
+            span *= t_mult
 
-        center *= t_mult
-        span *= t_mult
         start = center - span / 2.
         stop = center + span / 2.
 


### PR DESCRIPTION
## `t_unit` cannot change an auto-gate

`t_unit` declares the unit of `start`, `stop`, `center` and `span`. When all four are `None`, `time_gate()` auto-gates: centre on the tallest time-domain peak, span equal to the distance to the second tallest, both read from the data. No caller value takes part, so `t_unit` has nothing left to label and the result must not depend on it. On master it does.

## The three lines

```python
384:            center = ntwk.frequency.t_ns[n]        # nanoseconds
387:            span = detect_span(ntwk, t_unit='ns')  # nanoseconds
389:        center *= t_mult                           # t_mult is the caller's unit
390:        span *= t_mult
```

Line 384 is from 2017 (`e5356138`) and has always produced nanoseconds. Lines 389-390 arrived in 2022 (`7fa82f7f`) with `t_unit`, and scale the whole branch, including the two detected values that never came from the caller. The result is right only for `t_unit='ns'`; with the default `t_unit='s'` the gate edges land far outside the time window and the gate collapses to a single sample. The mixed case, one bound given and the other detected, fails the same way.

## Oracle

The test builds its expected value without calling `time_gate()`: two reflections placed by hand at -8 and +20 samples from t = 0, so the documented rule puts a boxcar over samples [+6, +34]; the reference is `fft(ifftshift(mask * ifft(s)))`.

```
max|s(t_unit='ns') - hand reference| = 0.000000e+00
max|s(t_unit='s')  - hand reference| = 1.000000e+00
```

Gate edges are integer sample indices, so the units then go through identical FFT operations; all three assertions are exact equality, no tolerance.

Nothing caught it: the Time Domain tutorial exercises this path but notebook CI runs `--nbval-lax`, which ignores outputs, and `test_autogate` only asserts a length.

## Behaviour change

Auto-gate results change for callers who used the default `t_unit`. Their gate was one sample wide, so the output was not usable, but it did change. `t_unit='ns'` is bit-identical, and callers passing `start`/`stop` or both `center` and `span` never reach this branch.

## Not verified

Windows 11, Python 3.12.10, numpy 2.5.2, scipy 1.18.0 only; the CI covers ubuntu-latest and Python 3.10-3.14, none run locally. Notebooks not executed here (no `nbval`), so the effect on the tutorial is read from the code, not observed.

## Spotted, not fixed

`skrf/frequency.py:637-639`: in low-pass mode the time vector spreads `n` points over `n * dt`, so for even `n` the step becomes `n * dt / (n - 1)` and the `t = 0` sample disappears, while the band-pass branch just above handles even `n` explicitly. `test_time_transform_v2` misses it: `np.isclose` on a ~5e-11 step against a default `atol` of 1e-8. Happy to send that separately.
