### PR TITLE
Fix `innerconnect()` returning a Network with the wrong `s_def`

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -6003,6 +6003,8 @@ def innerconnect(ntwkA: Network, k: int | str, l: int | str, num: int = 1) -> Ne
     if (l + num - 1 > ntwkA.nports - 1):
         raise IndexError('Port `l` out of range')
 
+    s_def_original = ntwkA.s_def
+
     # 'power' is not supported, convert to supported definition and back afterwards
     if ntwkA.s_def == 'power':
         ntwkA = ntwkA.copy()
@@ -6011,8 +6013,6 @@ def innerconnect(ntwkA: Network, k: int | str, l: int | str, num: int = 1) -> Ne
     # create output Network, from copy of input
     # Since ntwkC's s-parameters will change later, use shallow_copy for speedup
     ntwkC = ntwkA.copy(shallow_copy=True)
-
-    s_def_original = ntwkC.s_def
 
     z0_equal = (ntwkC.z0[:, k] == ntwkC.z0[:, l]).all()
 

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -1305,6 +1305,58 @@ class NetworkTestCase(unittest.TestCase):
                 self.assertTrue((net.z0 == net[0].z0).all())
                 self.assertTrue(net.s_def != net[0].s_def)
 
+    def test_innerconnect_preserves_s_def(self):
+        """ Test that innerconnect() returns a Network with the same s_def as
+        the one it was given, and that the returned s-parameters are expressed
+        in that definition.
+
+        The network is a 4-port made of two uncoupled 2-port blocks: ports 0
+        and 1 carry block P, ports 2 and 3 carry block Q, and there is no
+        coupling between the blocks. Connecting ports 0 and 1 together cannot
+        change block Q, so the result must be block Q on the same reference
+        impedance, in the same s_def. That reference is built independently of
+        the connection code.
+
+        Both blocks are passive and reciprocal by construction: Z is symmetric
+        and Re(Z) is positive definite.
+        """
+        zp = np.array([[60.0 + 20.0j, 25.0 - 10.0j],
+                       [25.0 - 10.0j, 80.0 + 5.0j]])
+        zq = np.array([[45.0 - 15.0j, 30.0 + 12.0j],
+                       [30.0 + 12.0j, 70.0 + 25.0j]])
+        z0 = 50.0 + 30.0j
+
+        for blk in (zp, zq):
+            self.assertTrue(np.all(np.linalg.eigvalsh(blk.real) > 0))
+
+        z4 = np.zeros((1, 4, 4), dtype=complex)
+        z4[0, 0:2, 0:2] = zp
+        z4[0, 2:4, 2:4] = zq
+
+        ntwk = rf.Network(s=np.zeros((1, 4, 4)), f=1, z0=z0, s_def='power')
+        ntwk.z = z4
+        ref = rf.Network(s=np.zeros((1, 2, 2)), f=1, z0=z0, s_def='power')
+        ref.z = zq.reshape(1, 2, 2)
+
+        # Tolerance, fixed before the run from the data type and the operation
+        # count, and not adjusted afterwards. complex128 unit roundoff is
+        # u = 2**-53. The reference and the result are separated by k = 14
+        # elementary n x n matrix operations: z2s on each side (2 each), the
+        # power->pseudo and pseudo->power renormalizations inside innerconnect
+        # (4 each), and the connection itself (2). Each carries a relative
+        # error of order n*u amplified by the condition number of the operand
+        # that is inverted, and a factor 10 covers the LU growth factor:
+        #     atol = 10 * k * n * kappa * u
+        u = 2.0 ** -53
+        kappa = float(np.linalg.cond(z4[0] + z0 * np.eye(4)))
+        self.assertLess(kappa, 5.0)
+        atol = 10 * 14 * 4 * kappa * u
+
+        result = rf.network.innerconnect(ntwk, 0, 1)
+
+        np.testing.assert_allclose(result.s, ref.s, rtol=0, atol=atol)
+        self.assertEqual(result.s_def, 'power')
+
     def test_parallelconnect(self):
         # Create 2 network with 2 ports
         ntwka = rf.Network(s=self.rng.random((1, 2, 2)), f=1, name='ntwka')


### PR DESCRIPTION
## The dead line

`innerconnect()` ends with

```python
if ntwkC.s_def != s_def_original:
    ntwkC.renormalize(ntwkC.z0, s_def_original)
```

That branch is never taken. `s_def_original` is captured at line 6015, which is
after the `power` to `pseudo` conversion at lines 6006-6009, so it always
already holds `'pseudo'` and the condition is never true. Coverage confirms it:
line 6049 is not executed by any test in the suite.

`connect()` does the same thing in the opposite order, and is correct:

```python
s_def_original = ntwkA.s_def            # line 5569, BEFORE
if ntwkA.s_def == 'power' and have_complex_ports:   # line 5570
    ...
```

## Where the order changed

The conversion block used to sit below the capture, so `s_def_original` held
`'power'` and the restore ran. Commit `3c4c3e29d`, *"Using shallow_copy in
connect()/innerconnect() method."*, moved it above, as part of reworking both
functions to use `Network.copy(shallow_copy=True)`. The refactor itself is
sound and does what its message says. The interaction with the capture two
lines below is not visible in the diff, and there was no test on that line to
catch it. First release containing the change: v1.4.0.

Checked by running the same case either side of it:

| revision | returned `s_def` | relative error on `.s` |
| --- | --- | --- |
| `2c55eaaf` (parent) | `power` | 3.7e-16 |
| `3c4c3e29d` | `pseudo` | see below |

## What it does

A 4-port on `z0 = 50 + 30j` built with `s_def='power'`, made of two uncoupled
2-port blocks. Ports 0 and 1 carry one block, ports 2 and 3 the other, with no
coupling between them. Connecting ports 0 and 1 cannot change the second block,
so the result must be that block, unchanged, in the definition it was given.

```
input                       nports=4, z0=50+30j, s_def='power'
innerconnect(ntwk, 0, 1)    nports=2, s_def='pseudo'    <-- not 'power'

max|returned - reference|                  0.67874031
max|reference|                             0.41268090
relative                                   164.5 %
tolerance (see below)                      1.21e-13

max|returned - reference in pseudo waves|  0.0
```

That last line is the whole of it: the values returned are the pseudo-wave
S-matrix, bit for bit. They are self-consistent with the `'pseudo'` label they
carry, but they are not the matrix the caller's network was expressed in, and
for a complex reference impedance the two differ. `Network`'s own docstring
notes that the definitions agree only for real-valued characteristic
impedances.

The control, on the same object: `connect()` returns `s_def='power'`.

For a real reference impedance the numbers are unaffected, since all three
definitions coincide there; only the returned label is wrong.

## The change

Two lines: move the capture above the conversion, which is where it was before.

## The test

`test_innerconnect_preserves_s_def`, next to `test_interconnect_complex_ports`.
Both blocks are passive and reciprocal by construction (`Z` symmetric, `Re(Z)`
positive definite, asserted in the test), and the reference is built from the
second block alone, without going through the connection code.

The tolerance is derived from the dtype and the operation count before the run,
not adjusted afterwards. `complex128` unit roundoff is `u = 2**-53`. The
reference and the result are separated by `k = 14` elementary `n x n` matrix
operations: `z2s` on each side (2 each), the two renormalizations inside
`innerconnect` (4 each), and the connection itself (2). Each carries a relative
error of order `n*u` amplified by the condition number of the inverted operand,
with a factor 10 for the LU growth factor:

```
atol = 10 * k * n * kappa * u = 10 * 14 * 4 * kappa * 2**-53
```

`kappa` is measured on the input (1.95 here) and asserted below 5, so the
tolerance's premise is checked rather than assumed. The measured gap exceeds it
by a factor of 5.6e12.

## Why this went unnoticed

The path is already exercised by `test_interconnect_complex_ports`, but that
test works on the input object rather than on the returned one: it calls
`rf.network.innerconnect(net, p - 2, 2)` and then appends `net`, so the network
whose `s_def` would show the problem is never inspected. Its comparison is
between `net` and `net[0]`, and `Network.__getitem__` constructs a new Network
carrying the default `s_def`, so the slice reports `'power'` whichever
definition `net` itself holds. A stale `s_def` on the value returned by
`innerconnect()` is not observable from there, which is why line 6049 stayed
uncovered.

The test added here calls `innerconnect()` and asserts on its return value.
With this change applied, line 6049 is executed, checked with `--cov` on the
new test on its own.

## Spotted, not fixed

`Network.is_passive()` returns `False` for every one-port, whatever `|S11|` is.
A matched load, an ideal short and an ideal open all come back non-passive, and
so does an active one-port, so the predicate carries no information there. The
path goes through `passivity()` raising `ValueError('Doesn't exist for one
ports')`, caught at network.py:2169-2170 and turned into `False`. Those two
lines are also uncovered.

It has two consequences in `vectorFitting.py`: the guard at line 396
(`self.network.is_passive() and not fit_proportional`) is false for any
one-port, so the "the fitted network is passive, but the vector fit is not"
warning cannot be reached; and the guard at line 1629
(`self.network.f[0] == 0.0 and not self.network.is_passive()`) is true for any
one-port with a dc point, so the hint "The dc point in the original network
data is already non-passive" is printed for networks whose dc point is passive.
Presenting the same load as an uncoupled two-port gives the correct answer in
both cases.

Happy to send that separately. It is a different function and a different
decision, namely whether `passivity()` should be defined for one-ports at all.

## Not verified

One platform only: Windows 11, Python 3.12.10, numpy 2.5.2, scipy 1.18.0. CI
covers ubuntu-latest on Python 3.10 through 3.14, and none of those were
exercised here. No notebook was run, since `nbval` is not installed in this
environment.

Two tests fail in the full suite on this machine, both before and after the
change, and neither is related to it:

- `test_networkSet.py::test_to_mdif`: `PermissionError` from
  `tempfile.NamedTemporaryFile` staying open on Windows.
- `test_plotting.py::test_primary_plotting[s-polar]`: `_tkinter.TclError`, a
  broken Tk installation on this host. This one is intermittent: it failed in
  two of the three full-suite runs made here.

Counts, same machine, same invocation: upstream unchanged gives 2 failed and
1825 passed; with this change, 2 failed and 1826 passed. The extra pass is the
new test, and the two failures are the same two.
