### PR TITLE
Add plot_s_error method for plotting s-parameter error vs frequency

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -5308,6 +5308,12 @@ class Network:
     def plot_reciprocity2(self, db=False, *args, **kwargs):
         return rfplt.plot_reciprocity2(self, db, *args, **kwargs)
 
+    @copy_doc(rfplt.plot_s_error)
+    def plot_s_error(self, other: Network,
+                     error_function: ErrorFunctionsT = "average_l2_norm",
+                     db: bool = False, *args, **kwargs):
+        return rfplt.plot_s_error(self, other, error_function, db, *args, **kwargs)
+
     @copy_doc(rfplt.plot_s_db_time)
     def plot_s_db_time(self, center_to_dc=None, *args, **kwargs):
         return rfplt.plot_s_db_time(self, *args, center_to_dc=center_to_dc, **kwargs)

--- a/skrf/plotting.py
+++ b/skrf/plotting.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 
-    from .constants import NumberLike, PrimaryPropertiesT
+    from .constants import ErrorFunctionsT, NumberLike, PrimaryPropertiesT
     from .frequency import Frequency
     from .network import Network
     from .networkSet import NetworkSet
@@ -1084,6 +1084,52 @@ def plot_reciprocity2(netw: Network, db=False, *args, **kwargs):
                     y = mf.complex_2_db(y)
                 netw.frequency.plot(y, *args, **kwargs)
 
+    plt.legend()
+    if plt.isinteractive():
+        plt.draw()
+
+
+def plot_s_error(netw: Network, other: Network,
+                 error_function: ErrorFunctionsT = "average_l2_norm",
+                 db: bool = False, *args, **kwargs):
+    r"""
+    Plot the s-parameter error between two networks vs frequency.
+
+    Parameters
+    ----------
+    netw : :class:`~skrf.network.Network`
+        The reference network.
+    other : :class:`~skrf.network.Network`
+        The network to compare against ``netw``.
+    error_function : str
+        Error function name passed to :func:`~skrf.network.s_error`.
+        One of ``average_l1_norm``, ``average_l2_norm``, ``maximum_l1_norm``,
+        or ``average_normalized_l1_norm``. Default is ``average_l2_norm``.
+    db : bool
+        If True, plot :math:`20\log_{10}(\delta)`. Default is False.
+    \*args, \*\*kwargs :
+        Passed to :meth:`~skrf.frequency.Frequency.plot`.
+
+    See Also
+    --------
+    skrf.network.s_error
+    skrf.network.Network.s_error
+    """
+    import matplotlib.pyplot as plt
+
+    error = netw.s_error(other, error_function=error_function)
+    if db:
+        with np.errstate(divide='ignore'):
+            error = 20 * np.log10(error)
+
+    name_a = '' if netw.name is None else netw.name
+    name_b = '' if other.name is None else other.name
+    if 'label' not in kwargs:
+        kwargs['label'] = f"{name_a} vs {name_b} ({error_function})"
+
+    netw.frequency.plot(error, *args, **kwargs)
+
+    plt.ylabel(f"{'dB ' if db else ''}s-parameter error ({error_function})")
     plt.legend()
     if plt.isinteractive():
         plt.draw()

--- a/skrf/tests/test_plotting.py
+++ b/skrf/tests/test_plotting.py
@@ -48,6 +48,12 @@ def test_plot_s_db_time(ntwk1_dc: rf.Network, ):
     ntwk1_dc.plot_s_db_time()
     ntwk1_dc.plot_s_db_time(m=0, n=0)
 
+def test_plot_s_error(ntwk1_dc: rf.Network):
+    ntwk1_dc.plot_s_error(ntwk1_dc)
+    ntwk1_dc.plot_s_error(ntwk1_dc, error_function='average_l1_norm')
+    ntwk1_dc.plot_s_error(ntwk1_dc, db=True)
+    rf.plotting.plot_s_error(ntwk1_dc, ntwk1_dc, error_function='maximum_l1_norm')
+
 def test_plot_s_smith(ntwk1_dc: rf.Network, ):
     ntwk1_dc.plot_s_smith()
 


### PR DESCRIPTION
Fixes #1266.

Adds `Network.plot_s_error(other)` and the module-level `skrf.plotting.plot_s_error` for plotting the per-frequency s-parameter error between two networks.

## What it does

```python
ntwkA.plot_s_error(ntwkB)                                         # default (average_l2_norm)
ntwkA.plot_s_error(ntwkB, error_function='average_l1_norm')       # pick error function
ntwkA.plot_s_error(ntwkB, db=True)                                # 20*log10(error)
```

The x-axis uses `netw.frequency.plot(...)`, so the resulting plot is `error` vs frequency with correct units — the same UX users get with the existing `plot_passivity` / `plot_reciprocity` family.

## Approach

Following the [discussion on the issue](https://github.com/scikit-rf/scikit-rf/issues/1266#issuecomment), this PR does **not** change the return type of `Network.s_error()` — keeping parity with other Network quantities (`s`, `z`, etc.) that all return `numpy.ndarray`. Instead, a dedicated plotting method is added alongside `plot_passivity` / `plot_reciprocity` / etc.

## Files changed
- `skrf/plotting.py` — new `plot_s_error(netw, other, error_function=..., db=..., ...)` function, placed between `plot_reciprocity2` and `plot_s_db_time`. `ErrorFunctionsT` added to the `TYPE_CHECKING` import.
- `skrf/network.py` — new `Network.plot_s_error(other, ...)` method, following the existing `@copy_doc` wrapper pattern.
- `skrf/tests/test_plotting.py` — `test_plot_s_error` covering both call styles and the `db=True` path.

## Test
Full `test_plotting.py` and `test_network.py::test_s_error` pass locally (273 tests). Ruff clean.