### PR TITLE
Fix MDIF parser for AWR MWO tab-continuation lines

### DIFF
--- a/skrf/io/mdif.py
+++ b/skrf/io/mdif.py
@@ -298,6 +298,25 @@ class Mdif:
 
         return ntwk
 
+    @staticmethod
+    def _merge_continuation_lines(lines):
+        """
+        Merge MWO-style continuation lines.
+
+        MDIF files exported by AWR Microwave Office (and other GMDIF/MDF
+        variants) wrap long ``%``-header and data rows onto multiple
+        physical lines by starting each continuation with a tab character.
+        Fold those back into the previous line so the rest of the parser
+        sees each row as a single logical line.
+        """
+        merged = []
+        for line in lines:
+            if line.startswith('\t') and merged:
+                merged[-1] = merged[-1].rstrip('\r\n') + ' ' + line.lstrip('\t')
+            else:
+                merged.append(line)
+        return merged
+
     def _parse_mdif(self, fid) -> list:
         """
         MDIF parser.
@@ -311,6 +330,7 @@ class Mdif:
         list: list of Networks
         """
         fid.seek(0)
+        lines = self._merge_continuation_lines(fid.readlines())
 
         block_data = []
         ntwks = []
@@ -319,7 +339,7 @@ class Mdif:
         in_data_block = False
         in_noise_block = False
 
-        for line in fid:
+        for line in lines:
 
             # parse parameters:
             #

--- a/skrf/io/tests/test_mdif.py
+++ b/skrf/io/tests/test_mdif.py
@@ -95,6 +95,45 @@ class MdifTestCase(unittest.TestCase):
         # to Networkset Init
         ns = NetworkSet.from_mdif(file)
 
+    def test_awr_tab_continuation_lines(self):
+        """
+        Regression test for #1249: MDIF files exported by AWR Microwave Office
+        wrap long %-header and data rows onto continuation lines that start
+        with a tab. These must be folded back into their previous line before
+        the parser sees them, or parsing fails with ValueError on the wrapped
+        header tokens (e.g. 'N22X').
+        """
+        content = (
+            "! AWR Design Environment (17603) Fri Mar  7 16:50:01 2025\n"
+            "! nPorts: 3, nXvals: 6\n"
+            "\n"
+            "VAR x1 = 20\n"
+            "VAR x2 = 30\n"
+            "BEGIN ACDATA\n"
+            "# GHz S DB R 50\n"
+            "% F N11X N11Y N12X N12Y N13X N13Y N21X N21Y \n"
+            "\tN22X N22Y N23X N23Y N31X N31Y N32X N32Y \n"
+            "\tN33X N33Y \n"
+            "0.1 -9.5574863 179.87028 -3.5265759 -0.08911217 -3.524635 -0.042428161 -3.5265759 -0.08911217 \n"
+            "\t-9.5573313 179.84258 -3.5245584 -0.05627355 -3.524635 -0.042428161 -3.5245584 -0.05627355 \n"
+            "\t-9.5534535 179.93604 \n"
+            "1.1 -9.5640098 178.64805 -3.5296304 -0.95062039 -3.5257785 -0.45939033 -3.5296304 -0.95062039 \n"
+            "\t-9.5651793 178.36214 -3.5264164 -0.60217335 -3.5257785 -0.45939033 -3.5264164 -0.60217335 \n"
+            "\t-9.5582923 179.34614 \n"
+            "END\n"
+        )
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.mdf', delete=False) as tf:
+            tf.write(content)
+            path = tf.name
+        try:
+            ns = NetworkSet.from_mdif(path)
+            self.assertEqual(len(ns), 1)
+            self.assertEqual(ns[0].nports, 3)
+            self.assertEqual(len(ns[0].frequency), 2)
+            self.assertEqual(ns[0].params, {'x1': 20.0, 'x2': 30.0})
+        finally:
+            os.unlink(path)
+
     def test_read_and_write_back_noise(self):
         net = rf.Network("skrf/io/tests/ts/ex_18.s2p")
         nset1 = NetworkSet([net.copy() for _i in range(4)])


### PR DESCRIPTION
Fixes #1249.

## Bug
MDIF files exported by AWR Microwave Office wrap long ``%``-header and data rows onto multiple physical lines that start with a tab. The parser was treating each continuation as its own line, so on any 3+ port MDIF from MWO ``_parse_data`` blew up:

```
ValueError: could not convert string to float: 'N22X'
```

on the header continuation (or on the wrapped data itself).

## Fix
Fold tab-continuation lines back into their previous line in ``_parse_mdif`` before the main parsing loop. A small ``_merge_continuation_lines`` staticmethod does the folding:

```python
if line.startswith('\t') and merged:
    merged[-1] = merged[-1].rstrip('\r\n') + ' ' + line.lstrip('\t')
else:
    merged.append(line)
```

This matches the workaround already discovered by the issue commenter (append tab-lines to the previous line before parsing).

## Test
Added ``test_awr_tab_continuation_lines`` built from the reproducer in the issue: a 3-port MWO MDIF with wrapped ``%`` header and wrapped data rows. Verifies parsing succeeds and the NetworkSet has the correct ``nports=3``, ``nfreqs=2``, and VAR params.

All 8 MDIF tests pass (7 existing + 1 new). Ruff clean.

## Scope
Only ``skrf/io/mdif.py`` and ``skrf/io/tests/test_mdif.py`` change. The preprocessing runs before any tokenization, so behavior on non-MWO MDIF/GMDIF files (which don't use tab continuation) is unchanged — the existing 7 tests confirm this.