### PR TITLE
Fix Coaxial.C shape when material parameters are scalar

### DIFF
--- a/skrf/media/coaxial.py
+++ b/skrf/media/coaxial.py
@@ -520,7 +520,10 @@ class Coaxial(DistributedCircuit, Media):
             distributed capacitance, in F/m
 
         """
-        return 2.*np.pi*self.epsilon_prime/np.log(self.b/self.a)
+        return np.broadcast_to(
+            2.*np.pi*self.epsilon_prime/np.log(self.b/self.a),
+            self.frequency.w.shape,
+        )
 
     @property
     def G(self) -> NumberLike:

--- a/skrf/media/coaxial.py
+++ b/skrf/media/coaxial.py
@@ -522,7 +522,7 @@ class Coaxial(DistributedCircuit, Media):
         """
         return np.broadcast_to(
             2.*np.pi*self.epsilon_prime/np.log(self.b/self.a),
-            self.frequency.w.shape,
+            self.frequency.npoints,
         )
 
     @property

--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -135,6 +135,17 @@ class MediaTestCase(unittest.TestCase):
             )
         assert_array_almost_equal(coax.L*coax.C, mu_0*coax.epsilon_prime)
 
+    def test_RLCG_shapes_consistent(self):
+        """R, L, C and G broadcast to the frequency shape (regression for #1423)."""
+        freq = rf.Frequency(1, 10, npoints=21, unit='GHz')
+        coax = Coaxial(freq, Dint=0.5e-3, Dout=1.68e-3, epsilon_r=2.1)
+        for name, val in (('R', coax.R), ('L', coax.L), ('C', coax.C), ('G', coax.G)):
+            self.assertEqual(val.shape, freq.w.shape,
+                             msg=f'{name} shape {val.shape} != frequency shape {freq.w.shape}')
+        # per-frequency indexing must not raise on any of them
+        _ = coax.C[0]
+        _ = coax.C[-1]
+
     def test_material_dicts_match_scalar_parameters(self):
         """The material dicts reproduce epsilon_r, tan_delta and sigma."""
         freq = rf.Frequency(1, 40, 21, unit='GHz')

--- a/skrf/media/tests/test_coaxial.py
+++ b/skrf/media/tests/test_coaxial.py
@@ -138,13 +138,17 @@ class MediaTestCase(unittest.TestCase):
     def test_RLCG_shapes_consistent(self):
         """R, L, C and G broadcast to the frequency shape (regression for #1423)."""
         freq = rf.Frequency(1, 10, npoints=21, unit='GHz')
-        coax = Coaxial(freq, Dint=0.5e-3, Dout=1.68e-3, epsilon_r=2.1)
-        for name, val in (('R', coax.R), ('L', coax.L), ('C', coax.C), ('G', coax.G)):
-            self.assertEqual(val.shape, freq.w.shape,
-                             msg=f'{name} shape {val.shape} != frequency shape {freq.w.shape}')
-        # per-frequency indexing must not raise on any of them
-        _ = coax.C[0]
-        _ = coax.C[-1]
+        # constant or frequency-dependant permittivity
+        eps_rs = [2.1, np.linspace(2.1, 2.2, freq.npoints)]
+        for eps_r in eps_rs:
+            coax = Coaxial(freq, Dint=0.5e-3, Dout=1.68e-3, epsilon_r=eps_r)
+
+            for name, val in (('R', coax.R), ('L', coax.L), ('C', coax.C), ('G', coax.G)):
+                self.assertEqual(val.shape, freq.w.shape,
+                                 msg=f'{name} shape {val.shape} != frequency shape {freq.w.shape}')
+            # per-frequency indexing must not raise any issue
+            _ = coax.C[0]
+            _ = coax.C[-1]
 
     def test_material_dicts_match_scalar_parameters(self):
         """The material dicts reproduce epsilon_r, tan_delta and sigma."""


### PR DESCRIPTION
Fixes the smaller observation reported at the end of #1423.

## Bug

``Coaxial.R``, ``.L`` and ``.G`` all return arrays of ``frequency.npoints`` (R/L scale with ``self._Zc``, G scales with ``frequency.w``). But ``.C`` computes as

```python
2 * np.pi * self.epsilon_prime / np.log(self.b / self.a)
```

which is a bare scalar when ``epsilon_prime`` and geometry are scalar, so ``coax.C`` ends up as a 0-d ``ndarray``. Network generation still works via broadcasting, but any per-frequency access blows up:

```python
>>> freq = rf.Frequency(1, 10, 21, 'ghz')
>>> coax = rf.media.Coaxial(freq, Dint=0.5e-3, Dout=1.68e-3, epsilon_r=2.1)
>>> coax.R.shape, coax.L.shape, coax.C.shape, coax.G.shape
((21,), (21,), (), (21,))
>>> coax.C[0]
IndexError: invalid index to scalar variable.
```

## Fix

Broadcast the scalar result to ``self.frequency.w.shape`` so the four line parameters are shape-consistent. Arrays already broadcast through unchanged, so the per-frequency ``epsilon_r`` path is untouched.

```python
return np.broadcast_to(
    2. * np.pi * self.epsilon_prime / np.log(self.b / self.a),
    self.frequency.w.shape,
)
```

## Test

New ``test_RLCG_shapes_consistent`` asserts all four of R/L/C/G match ``freq.w.shape`` and verifies indexing ``coax.C[0]`` / ``coax.C[-1]`` no longer raises. Full ``skrf/media/tests/`` suite (192 tests) passes. Ruff clean.

## Scope

Only ``skrf/media/coaxial.py`` and its test file change. Does not address the main passivity issue from #1423 (``surface_impedance()`` negative real part in the overlap regime) — that's a separate, larger discussion around the CDF-graded roughness model.