### PR TITLE
support passivity assessment for one-port networks

### DIFF
--- a/skrf/network.py
+++ b/skrf/network.py
@@ -2170,10 +2170,7 @@ class Network:
         bool : boolean
 
         """
-        try:
-            M = np.square(self.passivity)
-        except ValueError:
-            return False
+        M = np.square(self.passivity)
 
         I = np.identity(M.shape[-1])
         for f_idx in range(len(M)):

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1814,16 +1814,22 @@ class Network:
     @property
     def passivity(self) -> ndarray:
         r"""
-        Passivity metric for a multi-port network.
+        Passivity metric for a one-port or multi-port network.
 
-        This returns a matrix who's diagonals are equal to the total
+        This returns a matrix whose diagonals are equal to the total
         power received at all ports, normalized to the power at a single
         excitement port.
 
         Mathematically, this is a test for unitary-ness of the
         s-parameter matrix [#]_.
 
-        For two port this is
+        For a one-port network this is
+
+        .. math::
+
+                |S_{11}|
+
+        For a two-port network this is
 
         .. math::
 
@@ -1833,7 +1839,7 @@ class Network:
 
         .. math::
 
-                S^H \cdot S
+                \sqrt( S^H \cdot S)
 
         where :math:`H` is conjugate transpose of S, and :math:`\cdot`
         is dot product.
@@ -8411,18 +8417,24 @@ def s2g(s: np.ndarray, z0: NumberLike = 50) -> np.ndarray:
 ## these methods are used in the secondary properties
 def passivity(s: np.ndarray) -> np.ndarray:
     r"""
-    Passivity metric for a multi-port network.
+    Passivity metric for a one-port or multi-port network.
 
     A metric which is proportional to the amount of power lost in a
-    multiport network, depending on the excitation port. Specifically,
-    this returns a matrix who's diagonals are equal to the total
+    network, depending on the excitation port. Specifically,
+    this returns a matrix whose diagonals are equal to the total
     power received at all ports, normalized to the power at a single
     excitement port.
 
-    mathematically, this is a test for unitary-ness of the
+    Mathematically, this is a test for unitary-ness of the
     s-parameter matrix [#]_.
 
-    for two port this is
+    For a one-port network this is
+
+    .. math::
+
+            |S_{11}|
+
+    For a two-port network this is
 
     .. math::
 
@@ -8445,6 +8457,10 @@ def passivity(s: np.ndarray) -> np.ndarray:
     cascaded with a mismatch, the power dissipated will not be equivalent
     to the attenuator value, nor equal for each excitation port.
 
+    Parameters
+    ----------
+    s : :class:`numpy.ndarray` of shape `fxnxn`
+        s-parameter matrix
 
     Returns
     -------
@@ -8454,9 +8470,6 @@ def passivity(s: np.ndarray) -> np.ndarray:
     ------------
     .. [#] http://en.wikipedia.org/wiki/Scattering_parameters#Lossless_networks
     """
-    if s.shape[-1] == 1:
-        raise (ValueError('Doesn\'t exist for one ports'))
-
     pas_mat = s.copy()
     for f in range(len(s)):
         pas_mat[f, :, :] = np.sqrt(np.dot(s[f, :, :].conj().T, s[f, :, :]))

--- a/skrf/network.py
+++ b/skrf/network.py
@@ -1814,7 +1814,7 @@ class Network:
     @property
     def passivity(self) -> ndarray:
         r"""
-        Passivity metric for a one-port or multi-port network.
+        Passivity metric for a network.
 
         This returns a matrix whose diagonals are equal to the total
         power received at all ports, normalized to the power at a single
@@ -8414,7 +8414,7 @@ def s2g(s: np.ndarray, z0: NumberLike = 50) -> np.ndarray:
 ## these methods are used in the secondary properties
 def passivity(s: np.ndarray) -> np.ndarray:
     r"""
-    Passivity metric for a one-port or multi-port network.
+    Passivity metric for a network.
 
     A metric which is proportional to the amount of power lost in a
     network, depending on the excitation port. Specifically,

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -2365,6 +2365,29 @@ class NetworkTestCase(unittest.TestCase):
         self.assertFalse(y.is_symmetric(n=4))
         return
 
+    def test_passivity(self):
+        # 1-port with complex reflection coefficients across multiple frequencies
+        s = np.array([[[0.3 + 0.4j]], [[-0.6 + 0.8j]], [[0.0]]])
+        ntwk = rf.Network(f=[1, 2, 3], s=s, z0=50)
+        p = ntwk.passivity
+
+        # returns |S11| with shape (nfreqs, 1, 1)
+        self.assertEqual(p.shape, (3, 1, 1))
+        np.testing.assert_allclose(p.real, [[[0.5]], [[1.0]], [[0.0]]])
+        np.testing.assert_allclose(p.imag, 0.0)
+
+        # verify helper function directly
+        np.testing.assert_allclose(rf.network.passivity(s), p)
+
+        # multi-port calculation and return shape remain unchanged
+        s_2port = np.array([[[0.0, 0.5], [0.5, 0.0]]])
+        ntwk_2port = rf.Network(f=[1], s=s_2port, z0=50)
+        p_2port = ntwk_2port.passivity
+        self.assertEqual(p_2port.shape, (1, 2, 2))
+        np.testing.assert_allclose(p_2port.real, [[[0.5, 0.0], [0.0, 0.5]]])
+        np.testing.assert_allclose(p_2port.imag, 0.0)
+        return
+
     def test_is_passive(self):
         a = rf.Network(f=[1],
                        s=[[0, 0.5, 0.5],

--- a/skrf/tests/test_network.py
+++ b/skrf/tests/test_network.py
@@ -2400,6 +2400,32 @@ class NetworkTestCase(unittest.TestCase):
                           [10, 0]],
                        z0=50)
         self.assertFalse(b.is_passive(), 'A unilateral amplifier is not passive.')
+
+        # matched load (S11 = 0)
+        matched = rf.Network(f=[1], s=[[[0.0]]], z0=50)
+        self.assertTrue(matched.is_passive(), 'A matched load is passive.')
+
+        # ideal open and short circuits (|S11| = 1)
+        open_c = rf.Network(f=[1], s=[[[1.0]]], z0=50)
+        short_c = rf.Network(f=[1], s=[[[-1.0]]], z0=50)
+        self.assertTrue(open_c.is_passive(), 'An ideal open circuit is passive.')
+        self.assertTrue(short_c.is_passive(), 'An ideal short circuit is passive.')
+
+        # one-port with gain (|S11| > 1)
+        gain = rf.Network(f=[1], s=[[[1.1]]], z0=50)
+        self.assertFalse(gain.is_passive(), 'A one-port with gain is not passive.')
+
+        # multi-frequency one-port
+        multi_freq_pass = rf.Network(f=[1, 2, 3], s=[[[0.5]], [[0.9]], [[1.0]]], z0=50)
+        self.assertTrue(multi_freq_pass.is_passive(), 'A multi-frequency passive one-port is passive.')
+        multi_freq_fail = rf.Network(f=[1, 2, 3], s=[[[0.5]], [[1.2]], [[0.8]]], z0=50)
+        self.assertFalse(multi_freq_fail.is_passive(), 'A multi-frequency one-port with violation is not passive.')
+
+        # boundary violation with explicit tolerance
+        s_viol = 1.0 + 1e-4
+        ntwk_viol = rf.Network(f=[1], s=[[[s_viol]]], z0=50)
+        self.assertTrue(ntwk_viol.is_passive(tol=1e-3), 'Boundary violation within tolerance is accepted.')
+        self.assertFalse(ntwk_viol.is_passive(tol=1e-5), 'Boundary violation outside tolerance is rejected.')
         return
 
     def test_is_lossless(self):


### PR DESCRIPTION
fixes https://github.com/scikit-rf/scikit-rf/issues/1432

currently, `Network.is_passive()` always returns `False` for any one-port network because `passivity()` raises `ValueError` for one-port networks which `is_passive()` then catches and converts to `False`.  we can address this by updating `passivity()` to support one-port networks (passivity metric $S^\mathrm{H}S$ reduces to $\lvert S_{11} \rvert$ and simplifying `Network.is_passive()` to evaluate one and multi-port networks through the same test.

changes:

`skrf/network.py`
- update `passivity()` to accept one-port S-parameter arrays which yields metric `(nfreqs, 1, 1)` with entry $\lvert S_{11} \rvert$
- remove `try` / `except` `ValueError` fallback from `Network.is_passive()` so one-ports go through same path as multi-port
- update docstrings accordingly

`skrf/tests/test_network.py`:
- add `test_passivity()` to verify that `Network.passivity` and `rf.network.passivity` return $\lvert S_{11} \rvert$ with shape `(nfreqs, 1, 1)` and that multi-port behavior is unchanged
- extend `test_is_passive` with one-port test cases