### PR TITLE
Forward VNA attribute assignments to the active channel

### DIFF
--- a/skrf/vi/vna/__init__.py
+++ b/skrf/vi/vna/__init__.py
@@ -91,6 +91,16 @@ Here, the start frequency is set **per channel** whereas the number of ports is
 related to the instrument itself. Instruments with channel support should create a
 single channel in `__init__()` using `create_channel`
 
+Channel properties can also be read and set through the instrument, using the
+currently active channel. For example, these assignments are equivalent:
+
+.. code-block:: python
+
+    instr.freq_start = 1e9
+    instr.active_channel.freq_start = 1e9
+
+Properties defined on the instrument itself take precedence over channel properties.
+
 Property Creator
 ----------------
 

--- a/skrf/vi/vna/keysight/tests/test_pna.py
+++ b/skrf/vi/vna/keysight/tests/test_pna.py
@@ -82,6 +82,15 @@ def test_frequency_write(mocker, mocked_ff):
     ]
     mocked_ff.write.assert_has_calls(calls)
 
+
+def test_active_channel_parameter_write(mocked_ff):
+    mocked_ff.query.return_value = "1"
+
+    mocked_ff.freq_start = "100 MHz"
+
+    mocked_ff.write.assert_called_once_with("SENS1:FREQ:STAR 100000000")
+    assert "freq_start" not in vars(mocked_ff)
+
 # def test_create_channel(mocker, mocked_ff):
     # mocked_ff.create_channel(2, 'Channel 2')
     # assert hasattr(mocked_ff, 'ch2')

--- a/skrf/vi/vna/vna.py
+++ b/skrf/vi/vna/vna.py
@@ -124,10 +124,17 @@ class VNA:
                 raise AttributeError(f"{type(self).__name__} has no attribute {k}")
             return getattr(self.active_channel, k)
 
+        def __setattr__(self, k, v):
+            if not hasattr(type(self), k) and hasattr(self.Channel, k):
+                setattr(self.active_channel, k, v)
+            else:
+                super().__setattr__(k, v)
+
         cls.create_channel = create_channel
         cls.delete_channel = delete_channel
         cls.channels = property(_channels)
         cls.__getattr__ = __getattr__
+        cls.__setattr__ = __setattr__
 
     def _setup_scpi(self) -> None:
         self.__class__.wait_for_complete = lambda self: self.query("*OPC?")


### PR DESCRIPTION
Channel properties can already be read through a VNA, but assigning them currently creates a local Python attribute. This leaves the instrument setting unchanged and shadows subsequent reads. I found this behavior really nonintuitive. 

I ran into this in `Cobalt.trigger_single()` while working on the Copper Mountain driver (#1309). With channel 1 active, the original code did this:

```python
self.trigger_cont = True
```

Reading `self.trigger_cont` then returned `True`, even though the channel setting had not changed. The CMT driver needed an explicit `self.active_channel.trigger_cont = True` to send the command.

This PR forwards assignments to the active channel's setter, matching the existing read behavior:

```python
# now calls the channel setter and sends INIT1:CONT 1.
self.trigger_cont = True
```

Properties defined on the instrument itself retain priority. Added some regression tests. 
